### PR TITLE
Review & Update of docker-compose health check

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai-cic/icn-contracts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "files": [
     "dist"

--- a/core/.env.example
+++ b/core/.env.example
@@ -17,5 +17,4 @@ VRF_PK=
 VRF_PK_X=
 VRF_PK_Y=
 
-#prod || dev
-NODE_ENV=
+HEALTH_CHECK_PORT=

--- a/core/docker-compose.dev.yaml
+++ b/core/docker-compose.dev.yaml
@@ -16,22 +16,22 @@ services:
     restart: always
 
   listener-vrf:
-    image: core_icn
+    image: core-icn
+    container_name: listener_vrf_dev
+    hostname: listener_vrf_dev
+    entrypoint: ["yarn", "start:listener:vrf"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LISTENERS
-      - NODE_ENV
-    container_name: listener_vrf_dev
-    hostname: listener_vrf_dev
-    entrypoint: ["yarn", "start:listener:vrf"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl --fail http://localhost:8888/health-check || exit 1"
+      &common-health-check
+      test: "curl --fail http://localhost:${HEALTH_CHECK_PORT} || exit 1"
       interval: 5s
       timeout: 30s
       retries: 3
@@ -40,56 +40,50 @@ services:
       - redis
 
   listener-any-api:
-    image: core_icn
+    image: core-icn
+    container_name: listener_any_api_dev
+    hostname: listener_any_api_dev
+    entrypoint: ["yarn", "start:listener:any_api"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LISTENERS
-      - NODE_ENV
-    container_name: listener_any_api_dev
-    hostname: listener_any_api_dev
-    entrypoint: ["yarn", "start:listener:any_api"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl --fail http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   listener-aggregator:
-    image: core_icn
+    image: core-icn
+    container_name: listener_aggregator_dev
+    hostname: listener_aggregator_dev
+    entrypoint: ["yarn", "start:listener:aggregator"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LISTENERS
-      - NODE_ENV
-    container_name: listener_aggregator_dev
-    hostname: listener_aggregator_dev
-    entrypoint: ["yarn", "start:listener:aggregator"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl --fail http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   worker-vrf:
-    image: core_icn
+    image: core-icn
+    container_name: worker_vrf_dev
+    hostname: worker_vrf_dev
+    entrypoint: ["yarn", "start:worker:vrf"]
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
@@ -98,173 +92,122 @@ services:
       - VRF_PK
       - VRF_PK_X
       - VRF_PK_Y
-      - NODE_ENV      
-    container_name: worker_vrf_dev
-    hostname: worker_vrf_dev
-    entrypoint: ["yarn", "start:worker:vrf"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   worker-any-api:
-    image: core_icn
+    image: core-icn
+    container_name: worker_any_api_dev
+    hostname: worker_any_api_dev
+    entrypoint: ["yarn", "start:worker:any_api"]
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LOCAL_AGGREGATOR
-      - VRF_SK
-      - VRF_PK
-      - VRF_PK_X
-      - VRF_PK_Y
-      - NODE_ENV      
-    container_name: worker_any_api_dev
-    hostname: worker_any_api_dev
-    entrypoint: ["yarn", "start:worker:any_api"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   worker-aggregator:
-    image: core_icn
+    image: core-icn
+    container_name: worker_aggregator_dev
+    hostname: worker_aggregator_dev
+    entrypoint: ["yarn", "start:worker:aggregator"]
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LOCAL_AGGREGATOR
-      - VRF_SK
-      - VRF_PK
-      - VRF_PK_X
-      - VRF_PK_Y
-      - NODE_ENV      
-    container_name: worker_aggregator_dev
-    hostname: worker_aggregator_dev
-    entrypoint: ["yarn", "start:worker:aggregator"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   worker-predefined-feed:
-    image: core_icn
+    image: core-icn
+    container_name: worker_predefined_feed_dev
+    hostname: worker_predefined_feed_dev
+    entrypoint: ["yarn", "start:worker:predefined_feed"]
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - LOCAL_AGGREGATOR
-      - VRF_SK
-      - VRF_PK
-      - VRF_PK_X
-      - VRF_PK_Y
-      - NODE_ENV      
-    container_name: worker_predefined_feed_dev
-    hostname: worker_predefined_feed_dev
-    entrypoint: ["yarn", "start:worker:predefined_feed"]
-    expose:
-      - 8888
+      - NODE_ENV=production
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   reporter-vrf:
-    image: core_icn
+    image: core-icn
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    container_name: reporter_vrf_dev
+    hostname: reporter_vrf_dev
+    entrypoint: ["yarn", "start:reporter:vrf"]
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - MNEMONIC
       - PUBLIC_KEY
       - PRIVATE_KEY
-      - NODE_ENV       
-    container_name: reporter_vrf_dev
-    hostname: reporter_vrf_dev
-    entrypoint: ["yarn", "start:reporter:vrf"]
-    expose:
-      - 8888
+      - NODE_ENV="production"
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   reporter-any-api:
-    image: core_icn
+    image: core-icn
+    container_name: reporter_any_api_dev
+    hostname: reporter_any_api_dev
+    entrypoint: ["yarn", "start:reporter:any_api"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - MNEMONIC
       - PUBLIC_KEY
       - PRIVATE_KEY
-      - NODE_ENV       
-    container_name: reporter_any_api_dev
-    hostname: reporter_any_api_dev
-    entrypoint: ["yarn", "start:reporter:any_api"]
-    expose:
-      - 8888
+      - NODE_ENV="production"
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
       - redis
 
   reporter-aggregator:
-    image: core_icn
+    image: core-icn
+    container_name: reporter_aggregator_dev
+    hostname: reporter_aggregator_dev
+    entrypoint: ["yarn", "start:reporter:aggregator"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      - HEALTH_CHECK_PORT
       - PROVIDER
       - REDIS_HOST
       - REDIS_PORT
       - MNEMONIC
       - PUBLIC_KEY
       - PRIVATE_KEY
-      - NODE_ENV       
-    container_name: reporter_aggregator_dev
-    hostname: reporter_aggregator_dev
-    entrypoint: ["yarn", "start:reporter:aggregator"]
-    expose:
-      - 8888
+      - NODE_ENV="production"
     healthcheck:
-      test: "curl -f  http://localhost:8888/health-check || exit 1"
-      interval: 5s
-      timeout: 30s
-      retries: 3
-      start_period: 10s
+      <<: *common-health-check
     depends_on:
-      - redis      
+      - redis

--- a/core/package.json
+++ b/core/package.json
@@ -34,7 +34,7 @@
     "eslint": "DEBUG=eslint:cli-engine npx eslint 'src/**/*.ts' 'src/*.ts' 'test/*.ts'"
   },
   "dependencies": {
-    "@bisonai-cic/icn-contracts": "0.1.0",
+    "@bisonai-cic/icn-contracts": "^0.2.0",
     "bn.js": "^5.2.1",
     "bullmq": "^3.2.2",
     "dotenv": "^16.0.3",

--- a/core/src/Dockerfile.dev
+++ b/core/src/Dockerfile.dev
@@ -22,6 +22,8 @@ COPY config config
 
 COPY adapter adapter
 
+COPY aggregator aggregator
+
 COPY src src
 
 RUN yarn install

--- a/core/src/health-checker.ts
+++ b/core/src/health-checker.ts
@@ -1,12 +1,14 @@
 import * as http from 'http'
+import { NODE_ENV, HEALTH_CHECK_PORT } from './load-parameters'
 
-export function healthChack() {
-  process.env.NODE_ENV !== 'prod' ||
+export function healthCheck() {
+  if (NODE_ENV == 'production') {
     http
       .createServer(function (_, res) {
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.write('ok')
         res.end()
       })
-      .listen(8888)
+      .listen(HEALTH_CHECK_PORT)
+  }
 }

--- a/core/src/listener/main.ts
+++ b/core/src/listener/main.ts
@@ -11,7 +11,7 @@ import {
   WORKER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { LISTENER_CONFIG_FILE } from '../settings'
-import { healthChack } from '../health-checker'
+import { healthCheck } from '../health-checker'
 
 const LISTENERS = {
   AGGREGATOR: {
@@ -49,7 +49,7 @@ async function main() {
   const config = listenersConfig[listener]
   buildListener(queueName, config)
 
-  healthChack()
+  healthCheck()
 }
 
 function loadArgs() {

--- a/core/src/load-parameters.ts
+++ b/core/src/load-parameters.ts
@@ -9,6 +9,8 @@ function cantBeEmptyString(s) {
   }
 }
 
+export const NODE_ENV = process.env.NODE_ENV
+
 export const PROVIDER_URL = process.env.PROVIDER
 
 export const REDIS_HOST = process.env.REDIS_HOST || 'localhost'
@@ -21,3 +23,5 @@ export const PROVIDER = process.env.PROVIDER
 // FIXME allow either private key or mnemonic
 export const MNEMONIC = process.env.MNEMONIC
 export const PRIVATE_KEY = process.env.PRIVATE_KEY
+
+export const HEALTH_CHECK_PORT = process.env.HEALTH_CHECK_PORT

--- a/core/src/reporter/main.ts
+++ b/core/src/reporter/main.ts
@@ -2,7 +2,7 @@ import { parseArgs } from 'node:util'
 import { aggregatorReporter } from './aggregator'
 import { vrfReporter } from './vrf'
 import { anyApiReporter } from './any-api'
-import { healthChack } from '../health-checker'
+import { healthCheck } from '../health-checker'
 
 const REPORTERS = {
   AGGREGATOR: aggregatorReporter,
@@ -13,7 +13,7 @@ const REPORTERS = {
 async function main() {
   const reporter = loadArgs()
   REPORTERS[reporter]()
-  healthChack()
+  healthCheck()
 }
 
 function loadArgs() {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -239,7 +239,3 @@ export interface IListenerConfig {
   eventName: string
   factoryName: string
 }
-
-export interface HealthStatus {
-  status: string
-}

--- a/core/src/worker/main.ts
+++ b/core/src/worker/main.ts
@@ -3,7 +3,7 @@ import { aggregatorWorker } from './aggregator'
 import { vrfWorker } from './vrf'
 import { anyApiWorker } from './any-api'
 import { predefinedFeedWorker } from './predefined-feed'
-import { healthChack } from '../health-checker'
+import { healthCheck } from '../health-checker'
 
 const WORKERS = {
   AGGREGATOR: aggregatorWorker,
@@ -15,7 +15,7 @@ const WORKERS = {
 async function main() {
   const worker = loadArgs()
   WORKERS[worker]()
-  healthChack()
+  healthCheck()
 }
 
 function loadArgs() {

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -305,10 +305,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bisonai-cic/icn-contracts@0.1.0":
-  version "0.1.0"
-  resolved "https://npm.pkg.github.com/download/@bisonai-cic/icn-contracts/0.1.0/bb8f088fd5421cf954e773d1e8a4b3b8ddf58419#bb8f088fd5421cf954e773d1e8a4b3b8ddf58419"
-  integrity sha512-SJW0Y2Z8wjSyTLSvzzSW1n+KYZwVo0Mj7z873OZRXsYUsODXG4y8MIu6IanT2I586YHT0iH6Fbh9oKxxSQNEAQ==
+"@bisonai-cic/icn-contracts@^0.2.0":
+  version "0.2.0"
+  resolved "https://npm.pkg.github.com/download/@bisonai-cic/icn-contracts/0.2.0/35d73cd992473eb66145a36b7fad241cf2591834#35d73cd992473eb66145a36b7fad241cf2591834"
+  integrity sha512-MJKPZXWF0pZrecvKBcacfJ5yvoOLRpIVAunMZ1dZDAQICIjsS8VZfhv1ArYdn/TF+1atAwshBwOUfeFQGG21Gw==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
This PR is a review and also update for #104. It is meant to be first merged before #104 and then #104 to master.

* Using anchors to simplify docker-compose (https://medium.com/@anasanjaria/code-reuse-in-docker-compose-using-yaml-anchor-feature-6cb2ff1d0427)
* `healthChack` -> `healthCheck`
* `NODE_ENV` values are commonly used `production` and `development` (https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/)
* Remove `NODE_ENV` from `.env.example` file file and load only within docker-compose file (https://docs.docker.com/compose/environment-variables/)
* Remove unused `HealthStatus` from types
* Define `HEALTH_CHECK_PORT` in `.env.example` and used for both docker-compose and `health-checker.ts` file (loaded through `load-parameters.ts`)
* Remove `expose` (not necessary)
* Remove `/health-check` endpoint from docker compose `healthcheck` (not defined in http server)