### PR TITLE
Get prepayment address from coordinator

### DIFF
--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -222,6 +222,10 @@ contract RequestResponseCoordinator is
         return s_directPaymentConfig.fulfillmentFee + s_directPaymentConfig.baseFee;
     }
 
+    function getPrepaymentAddress() public view returns (address) {
+        return address(s_prepayment);
+    }
+
     function requestData(
         Orakl.Request memory req,
         uint32 callbackGasLimit,

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -284,6 +284,10 @@ contract VRFCoordinator is
         return s_directPaymentConfig.fulfillmentFee + s_directPaymentConfig.baseFee;
     }
 
+    function getPrepaymentAddress() public view returns (address) {
+        return address(s_prepayment);
+    }
+
     /**
      * @notice Get request commitment
      * @param requestId id of request

--- a/contracts/test/v0.1/RequestResponseConsumerContract.test.ts
+++ b/contracts/test/v0.1/RequestResponseConsumerContract.test.ts
@@ -42,7 +42,7 @@ describe('Request-Response user contract', function () {
     await consumerContract.deployed()
 
     const accId = await createAccount(
-      prepaymentContract.address,
+      await coordinatorContract.getPrepaymentAddress(),
       consumerContract.address,
       true,
       true

--- a/contracts/test/v0.1/VRF.test.ts
+++ b/contracts/test/v0.1/VRF.test.ts
@@ -29,7 +29,7 @@ describe('VRF contract', function () {
     await consumerContract.deployed()
 
     const accId = await createAccount(
-      prepaymentContract.address,
+      await coordinatorContract.getPrepaymentAddress(),
       consumerContract.address,
       true,
       true


### PR DESCRIPTION
This PR adds auxiliary `getPrepaymentAddress` function to `VRFCoordinator` and `RequestResponseCoordinator` for an easier access to connected `Prepayment` contract.

## Others

* Rename `Prepayment` interface in VRFCoordinator to `s_prepayment` to unify naming conventions