### PR TITLE
Remove `WITHDRAWER_ROLE`

### DIFF
--- a/contracts/src/v0.1/Prepayment.sol
+++ b/contracts/src/v0.1/Prepayment.sol
@@ -16,7 +16,6 @@ contract Prepayment is
     TypeAndVersionInterface
 {
     uint16 public constant MAX_CONSUMERS = 100;
-    bytes32 public constant WITHDRAWER_ROLE = keccak256("WITHDRAWER_ROLE");
     bytes32 public constant COORDINATOR_ROLE = keccak256("COORDINATOR_ROLE");
 
     uint256 private s_totalBalance;
@@ -260,7 +259,7 @@ contract Prepayment is
     /**
      * @inheritdoc PrepaymentInterface
      */
-    function nodeWithdraw(uint256 amount) external onlyRole(WITHDRAWER_ROLE) {
+    function nodeWithdraw(uint256 amount) external {
         if (amount == 0) {
             revert ZeroAmount();
         }


### PR DESCRIPTION
This PR removes `WITHDRAWER_ROLE` from `Prepayment` contract. Node operators can use function `nodeWithdraw` to withdraw their collected fees. Previously, all fees were collected at one place and this function was guarding from malicious attackers.

## Side note

We do not need to set auxiliary functions to set `WITHDRAWER_ROLE` and `COORDINATOR_ROLE`. `WITHDRAWER_ROLE` is remove after merging this PR and `COORDINATOR_ROLE` is set/unset using `_grantRole`/`_revokeRole` in `addCoordinator`/`removeCoordinator`.