### PR TITLE
Create automatically orakl settings directory

### DIFF
--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -6,6 +6,7 @@ import { IListenerConfig, IVrfConfig } from './types'
 import { aggregatorMapping } from './aggregator'
 import { listHandler } from './cli/operator/kv'
 import { IcnError, IcnErrorCode } from './errors'
+import { mkdir } from './utils'
 import * as dotenv from 'dotenv'
 dotenv.config()
 
@@ -75,6 +76,8 @@ export const BULLMQ_CONNECTION = {
 }
 
 async function openDb() {
+  mkdir(path.dirname(SETTINGS_DB_FILE))
+
   const db = await open({
     filename: SETTINGS_DB_FILE,
     driver: sqlite.Database


### PR DESCRIPTION
This PR creates `ORAKL_DIR` (directory which stores `settings.sqlite`) if it does not already exist. Previously, execution failed when running migration for the first time.