### PR TITLE
Move CODEOWNERS back to .github and remove test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,5 +32,3 @@ worker/request-response.ts              @bayram98
 worker/vrf.ts                           @KelvinThai
 reporter/request-response.ts            @bayram98
 reporter/vrf.ts                         @KelvinThai
-
-/README.md @martinkersner


### PR DESCRIPTION
This PR is continuation of https://github.com/Bisonai-CIC/orakl/pull/231. It moves `CODEOWNERS` undef `.github` directory and remove a test code owner for main README.