### PR TITLE
Wake up single-node Data Feed reporters

### DIFF
--- a/core/src/reporter/aggregator.ts
+++ b/core/src/reporter/aggregator.ts
@@ -55,7 +55,7 @@ function job(wallet, _logger: Logger) {
         aggregatorAddress
       }
       await heartbeatQueue.add('fixed-heartbeat', outData, {
-        delay: 15_000, // FIXME
+        delay: inData.delay,
         removeOnComplete: true,
         removeOnFail: true,
         jobId: aggregatorAddress

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -248,6 +248,7 @@ export interface IAggregatorWorkerReporter {
   roundId: number
   submission: number
   workerSource: string
+  delay: number
 }
 
 // VRF

--- a/core/src/worker/aggregator.ts
+++ b/core/src/worker/aggregator.ts
@@ -344,8 +344,8 @@ async function getSynchronizedDelay(
 ): Promise<number> {
   // FIXME modify aggregator to use single contract call
 
-  let startedAt: number = 0
-  let { _startedAt, _roundId } = await oracleRoundStateCall({
+  const startedAt = 0
+  const { _startedAt, _roundId } = await oracleRoundStateCall({
     aggregatorAddress,
     operatorAddress: OPERATOR_ADDRESS
   })

--- a/core/src/worker/aggregator.ts
+++ b/core/src/worker/aggregator.ts
@@ -344,7 +344,7 @@ async function getSynchronizedDelay(
 ): Promise<number> {
   // FIXME modify aggregator to use single contract call
 
-  const startedAt = 0
+  let startedAt = 0
   const { _startedAt, _roundId } = await oracleRoundStateCall({
     aggregatorAddress,
     operatorAddress: OPERATOR_ADDRESS


### PR DESCRIPTION
# Description

When data feed operated by a single node operator is rebooted, fixed heartbeat is not relaunched and unless the latest data deviates enough from the latest submission (operated by random heartbeat), then the aggregator does not enter the healthy lifecycle.

This PR pushes a fixed heartbeat job to designated queue and restarts the process of collecting and submitting the latest values to aggregator smart contract. 

## Others

* Avoid using magic constant delay set in reporter for fixed delay queue

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Deployment

- [x] Should publish Docker image
