### PR TITLE
Emit event when connecting prepayment with `VRFCoordinator` || `RequestResponseCoordinator`

### DIFF
--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -106,6 +106,7 @@ contract RequestResponseCoordinator is
     event OracleRegistered(address oracle);
     event OracleDeregistered(address oracle);
     event MinBalanceSet(uint256 minBalance);
+    event RequestResponseCoordinatorPrepayment(address prepayment);
 
     modifier nonReentrant() {
         if (s_config.reentrancyLock) {
@@ -116,6 +117,7 @@ contract RequestResponseCoordinator is
 
     constructor(address prepayment) {
         s_prepayment = PrepaymentInterface(prepayment);
+        emit RequestResponseCoordinatorConnected(prepayment);
     }
 
     /**

--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -106,7 +106,7 @@ contract RequestResponseCoordinator is
     event OracleRegistered(address oracle);
     event OracleDeregistered(address oracle);
     event MinBalanceSet(uint256 minBalance);
-    event RequestResponseCoordinatorConnected(address prepayment);
+    event PrepaymentSet(address prepayment);
 
     modifier nonReentrant() {
         if (s_config.reentrancyLock) {
@@ -117,7 +117,7 @@ contract RequestResponseCoordinator is
 
     constructor(address prepayment) {
         s_prepayment = PrepaymentInterface(prepayment);
-        emit RequestResponseCoordinatorConnected(prepayment);
+        emit PrepaymentSet(prepayment);
     }
 
     /**

--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -106,7 +106,7 @@ contract RequestResponseCoordinator is
     event OracleRegistered(address oracle);
     event OracleDeregistered(address oracle);
     event MinBalanceSet(uint256 minBalance);
-    event RequestResponseCoordinatorPrepayment(address prepayment);
+    event RequestResponseCoordinatorConnected(address prepayment);
 
     modifier nonReentrant() {
         if (s_config.reentrancyLock) {

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -112,7 +112,7 @@ contract VRFCoordinator is
     event ConfigSet(uint32 maxGasLimit, uint32 gasAfterPaymentCalculation, FeeConfig feeConfig);
     event DirectPaymentConfigSet(uint256 fulfillmentFee, uint256 baseFee);
     event MinBalanceSet(uint256 minBalance);
-    event VRFCoordinatorConnected(address prepayment);
+    event PrepaymentSet(address prepayment);
 
     modifier nonReentrant() {
         if (s_config.reentrancyLock) {
@@ -130,7 +130,7 @@ contract VRFCoordinator is
 
     constructor(address prepayment) {
         s_prepayment = PrepaymentInterface(prepayment);
-        emit VRFCoordinatorConnected(prepayment);
+        emit PrepaymentSet(prepayment);
     }
 
     /**

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -10,6 +10,7 @@ import "./interfaces/VRFCoordinatorInterface.sol";
 import "./libraries/VRF.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./VRFConsumerBase.sol";
+import "hardhat/console.sol";
 
 contract VRFCoordinator is
     CoordinatorBaseInterface,
@@ -112,6 +113,7 @@ contract VRFCoordinator is
     event ConfigSet(uint32 maxGasLimit, uint32 gasAfterPaymentCalculation, FeeConfig feeConfig);
     event DirectPaymentConfigSet(uint256 fulfillmentFee, uint256 baseFee);
     event MinBalanceSet(uint256 minBalance);
+    event VRFCoordinatorConnected(address prepayment);
 
     modifier nonReentrant() {
         if (s_config.reentrancyLock) {
@@ -129,6 +131,7 @@ contract VRFCoordinator is
 
     constructor(address prepayment) {
         s_prepayment = PrepaymentInterface(prepayment);
+        emit VRFCoordinatorConnected(prepayment);
     }
 
     /**

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -10,7 +10,6 @@ import "./interfaces/VRFCoordinatorInterface.sol";
 import "./libraries/VRF.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./VRFConsumerBase.sol";
-import "hardhat/console.sol";
 
 contract VRFCoordinator is
     CoordinatorBaseInterface,


### PR DESCRIPTION
# Description

Add new event to the constructor of `VRFCoordinator ` && `RequestResponseCoordinator `

Deployed to `Baobab` to test if the events working from constructor creation. Here is the [tx link](https://baobab.scope.klaytn.com/tx/0xfbaa17d3bd77be145cfcc340c0e295fa6afba23f14d644e7671cf0e6936fe68e?tabId=eventLog). 

-  As you can see from the event logs, `prepayment address` set to `016FB0D0D75997DB1EBc4422567F6dBab3Cb540D`
- https://baobab.scope.klaytn.com/tx/0x5b71c9e78c8c250b56f966c4f4c81372c09437535cc26880304f24600af30a19?tabId=eventLog
- https://baobab.scope.klaytn.com/tx/0xfbaa17d3bd77be145cfcc340c0e295fa6afba23f14d644e7671cf0e6936fe68e?tabId=eventLog

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
