### PR TITLE
Don't run actions after merging to master

### DIFF
--- a/.github/workflows/api.test+build.yaml
+++ b/.github/workflows/api.test+build.yaml
@@ -1,8 +1,12 @@
 name: "api: test+build"
+
 on:
   push:
+    branches-ignore:
+      - "master"
     paths:
       - "api/**"
+
 jobs:
   core-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli.build+publish.yaml
+++ b/.github/workflows/cli.build+publish.yaml
@@ -1,8 +1,12 @@
 name: "cli: build+publish"
+
 on:
   push:
+    branches-ignore:
+      - "master"
     paths:
       - "core/src/cli/orakl-cli/**"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts.publish.yaml
+++ b/.github/workflows/contracts.publish.yaml
@@ -1,7 +1,9 @@
 name: "contracts: test & build & publish"
+
 on:
   release:
     types: [published]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts.test.yaml
+++ b/.github/workflows/contracts.test.yaml
@@ -1,8 +1,12 @@
 name: "contracts: test"
+
 on:
   push:
+    branches-ignore:
+      - "master"
     paths:
       - "contracts/**"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/core.test+build.yaml
+++ b/.github/workflows/core.test+build.yaml
@@ -1,8 +1,12 @@
 name: "core: test+build"
+
 on:
   push:
+    branches-ignore:
+      - "master"
     paths:
       - "core/**"
+
 jobs:
   core-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/request-response.integration.test.yaml
+++ b/.github/workflows/request-response.integration.test.yaml
@@ -3,6 +3,7 @@ name: "request-response: integration-test"
 on:
   issue_comment:
     types: [created, edited, deleted]
+
 jobs:
   build:
     if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/integration')


### PR DESCRIPTION
# Description

This PR blocks the execution of GitHub actions pipeline after merging to master. Previously, certain actions have unnecessarily been executed. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
