### PR TITLE
Fix feed name from `BTC-USDT` adapter

### DIFF
--- a/core/adapter/btc-usdt.adapter.json
+++ b/core/adapter/btc-usdt.adapter.json
@@ -4,7 +4,7 @@
   "decimals": 8,
   "feeds": [
     {
-      "name": "Bybit-ticker-BTC-USDT",
+      "name": "Bybit-BTC-USDT",
       "definition": {
         "url": "https://api.bybit.com/derivatives/v3/public/tickers?symbol=BTCUSDT",
         "headers": {


### PR DESCRIPTION
# Description

This PR is for fix naming in `BTC-USDT` adapter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] I have performed a self-review of my code.
