### PR TITLE
Optimize gas fee

### DIFF
--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -162,7 +162,7 @@ contract VRFCoordinator is
             revert NoSuchProvingKey(kh);
         }
         delete s_provingKeys[kh];
-uint256 provingKeyHashesLength = s_provingKeyHashes.length;
+        uint256 provingKeyHashesLength = s_provingKeyHashes.length;
         for (uint256 i; i < provingKeyHashesLength; i++) {
             if (s_provingKeyHashes[i] == kh) {
                 bytes32 last = s_provingKeyHashes[provingKeyHashesLength - 1];

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -162,7 +162,8 @@ contract VRFCoordinator is
             revert NoSuchProvingKey(kh);
         }
         delete s_provingKeys[kh];
-        for (uint256 i = 0; i < s_provingKeyHashes.length; i++) {
+		uint256 provingKeyHashesLength = s_provingKeyHashes.length;
+        for (uint256 i; i < provingKeyHashesLength; ) {
             if (s_provingKeyHashes[i] == kh) {
                 bytes32 last = s_provingKeyHashes[s_provingKeyHashes.length - 1];
                 // Copy last element and overwrite kh to be deleted with it
@@ -170,6 +171,9 @@ contract VRFCoordinator is
                 s_provingKeyHashes.pop();
                 break;
             }
+			unchecked {
+				++i;
+			}
         }
         emit ProvingKeyDeregistered(kh, oracle);
     }

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -162,7 +162,7 @@ contract VRFCoordinator is
             revert NoSuchProvingKey(kh);
         }
         delete s_provingKeys[kh];
-		uint256 provingKeyHashesLength = s_provingKeyHashes.length;
+uint256 provingKeyHashesLength = s_provingKeyHashes.length;
         for (uint256 i; i < provingKeyHashesLength; i++) {
             if (s_provingKeyHashes[i] == kh) {
                 bytes32 last = s_provingKeyHashes[provingKeyHashesLength - 1];

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -163,17 +163,14 @@ contract VRFCoordinator is
         }
         delete s_provingKeys[kh];
 		uint256 provingKeyHashesLength = s_provingKeyHashes.length;
-        for (uint256 i; i < provingKeyHashesLength; ) {
+        for (uint256 i; i < provingKeyHashesLength; i++) {
             if (s_provingKeyHashes[i] == kh) {
-                bytes32 last = s_provingKeyHashes[s_provingKeyHashes.length - 1];
+                bytes32 last = s_provingKeyHashes[provingKeyHashesLength - 1];
                 // Copy last element and overwrite kh to be deleted with it
                 s_provingKeyHashes[i] = last;
                 s_provingKeyHashes.pop();
                 break;
             }
-			unchecked {
-				++i;
-			}
         }
         emit ProvingKeyDeregistered(kh, oracle);
     }


### PR DESCRIPTION
# Issue: #399: Optimize gas fee for deregisterProvingKey function in VRFCoordinator contract

## Change description:

- [1] Cache length of s_provingKeyHashes array to memory before running for loop.
- [2] Default value of uint type is 0 so we don't need to assign it value to 0 again. 
- [3] Proving key hashes will be pushed by only contract owner so it can't be overflow 256 bit. So we can add ++i inside unchecked keyword

