### PR TITLE
Add `timeout-minutes: 3` for every github actions pipeline

### DIFF
--- a/.github/workflows/api.test+build.yaml
+++ b/.github/workflows/api.test+build.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   core-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
 
     services:
       postgres:

--- a/.github/workflows/cli.build+publish.yaml
+++ b/.github/workflows/cli.build+publish.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/contracts.publish.yaml
+++ b/.github/workflows/contracts.publish.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/contracts.test.yaml
+++ b/.github/workflows/contracts.test.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/core.test+build.yaml
+++ b/.github/workflows/core.test+build.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   core-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/delegator.test+build.yaml
+++ b/.github/workflows/delegator.test+build.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   core-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
 
     services:
       postgres:

--- a/.github/workflows/request-response.integration.test.yaml
+++ b/.github/workflows/request-response.integration.test.yaml
@@ -8,6 +8,8 @@ jobs:
   build:
     if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/integration')
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/vrf.build+publish.yaml
+++ b/.github/workflows/vrf.build+publish.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/vrf.integration.test.yaml
+++ b/.github/workflows/vrf.integration.test.yaml
@@ -8,6 +8,8 @@ jobs:
   build:
     if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/integration')
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
# Description

Some tests have a hanging issues and keep running unreasonably long. This PR limits all GitHub actions to 3 minute timout.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
