### PR TITLE
Migrate docker-hub to ECR using git-action

### DIFF
--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -38,7 +38,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read    # This is required for actions/checkout
+      contents: read 
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -46,23 +46,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: set JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Run chmod to make gradlew executable
-        run: chmod +x gradlew
-
-      - name: Gradle Build Movie
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@20ce4e5
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-session-name: GitHubActions

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -14,6 +14,7 @@ on:
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
   aws_region: ap-southeast-1
+  role_arn: arn:aws:iam::831311642255:role/orakl_ecr_github_upload
 
 jobs:
   prepare:
@@ -52,7 +53,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ env.aws_region }}
-          role-to-assume: ${{ secrets.ROLE_ARN }}
+          role-session-name: oraklrolesession
+          role-to-assume: ${{ env.role_arn }}
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -36,6 +36,7 @@ jobs:
     needs: prepare
 
     permissions:
+      id-token: write
       contents: read    # This is required for actions/checkout
 
     outputs:

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -1,0 +1,65 @@
+name: Deploy to Amazon ECR
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+  push:
+    branches:
+      - i-424/docker-hub-is-slow
+
+env:
+  ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
+
+jobs:
+  prepare:
+    name: Prepare Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get time TAG
+        id: tag
+        run: |
+          echo "date=$(date +'%Y%m%d.%H%M')" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    permissions:
+      contents: read    # This is required for actions/checkout
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker build orakl-api
+        run: docker build -t orakl-api src/
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHubActions
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Publish Image to ECR(orakl)
+        run: |
+          docker tag orakl-api:latest ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -47,8 +47,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Docker build orakl-api
-        run: |
-          docker-compose -f api/docker-compose.build.yaml build
+        run:  docker-compose -f api/docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -8,12 +8,6 @@ on:
       - "api/**"
     types:
       - closed
-## remove after test 
-  push:
-    branches:
-      - i-424/docker-hub-is-slow
-    paths:
-      - "api/**"      
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Docker build orakl-api
-        run: docker build -t orakl-api src/
+        run: docker build -t orakl-api api/src/
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -46,9 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Docker build orakl-api
-        run: docker-compose -f api/docker-compose.build.yaml build
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -59,6 +56,9 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker build orakl-api
+        run: docker-compose -f api/docker-compose.build.yaml build
 
       - name: Publish Image to ECR(orakl)
         run: |

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -37,7 +37,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: write 
+      contents: read 
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
-  aws_region: ap-northeast-2
+  aws_region: us-east-2
 
 jobs:
   prepare:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v20
         with:
           aws-region: ${{ env.aws_region }}
           role-session-name: GitHubActions

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -44,8 +44,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Docker build orakl-api
-        run: docker-compose -f api/docker-compose.build.yaml build
-        IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet service_name)
+        run: |
+          docker-compose -f api/docker-compose.build.yaml build
+          IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet service_name)
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -10,12 +10,6 @@ on:
     branches:
       - i-424/docker-hub-is-slow
 
-
-env:
-  ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
-  aws_region: ap-southeast-1
-  role_arn: arn:aws:iam::831311642255:role/orakl_ecr_github_upload
-
 jobs:
   prepare:
     name: Prepare Build
@@ -49,21 +43,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Docker build orakl-api
+        run: docker-compose -f api/docker-compose.build.yaml build
+        IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet service_name)
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: ${{ env.aws_region }}
+          aws-region: ${{ secrets.aws_region }}
           role-session-name: oraklrolesession
-          role-to-assume: ${{ env.role_arn }}
+          role-to-assume: ${{ secrets.role_arn }}
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Docker build orakl-api
-        run: docker-compose -f api/docker-compose.build.yaml build
-
       - name: Publish Image to ECR(orakl)
         run: |
-          docker tag orakl-api:latest ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag orakl-api:${IMAGE_ID} ${{ secrets.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: us-east-1
           role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - i-424/docker-hub-is-slow
-      
+
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
@@ -46,6 +46,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: set JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Run chmod to make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Gradle Build Movie
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
-  aws_region: us-east-2
+  aws_region: ap-southeast-1
 
 jobs:
   prepare:

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -49,10 +49,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v20
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ env.aws_region }}
-          role-session-name: GitHubActions
           role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Docker build orakl-api
         run: |
           docker-compose -f api/docker-compose.build.yaml build
-          IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet service_name)
+          IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet orakl-api)
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          role-session-name: oraklrolesession
+          role-session-name: githubAction
           role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -54,7 +54,6 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          role-session-name: githubAction
           role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Docker build orakl-api
-        run: docker build -t orakl-api api/src/
+        run: docker-compose -f api/docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -63,5 +63,5 @@ jobs:
 
       - name: Publish Image to ECR(orakl)
         run: |
-          docker tag bisonai/orakl-api:latest ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag orakl-api ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -57,8 +57,10 @@ jobs:
           role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR
-        id: login-ecr
+        id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public        
 
       - name: Publish Image to ECR(orakl)
         run: |

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@20ce4e5
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ env.aws_region }}
           role-session-name: GitHubActions

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -46,7 +46,6 @@ jobs:
       - name: Docker build orakl-api
         run: |
           docker-compose -f api/docker-compose.build.yaml build
-          IMAGE_ID=$(docker-compose -f api/docker-compose.build.yaml images --quiet orakl-api)
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -61,5 +60,5 @@ jobs:
 
       - name: Publish Image to ECR(orakl)
         run: |
-          docker tag orakl-api:${IMAGE_ID} ${{ secrets.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag bisonai/orakl-api:latest ${{ secrets.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - i-424/docker-hub-is-slow
+      
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -6,7 +6,7 @@ on:
       - master
     types:
       - closed
-## remove after test remove administrator access   
+## remove after test 
   push:
     branches:
       - i-424/docker-hub-is-slow

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -13,6 +13,7 @@ on:
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
+  aws_region: ap-northeast-2
 
 jobs:
   prepare:
@@ -38,7 +39,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: write 
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -50,7 +51,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@20ce4e5
         with:
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ env.aws_region }}
           role-session-name: GitHubActions
           role-to-assume: ${{ secrets.ROLE_ARN }}
 

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -6,6 +6,7 @@ on:
       - master
     types:
       - closed
+## remove after test      
   push:
     branches:
       - i-424/docker-hub-is-slow

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -10,6 +10,9 @@ on:
     branches:
       - i-424/docker-hub-is-slow
 
+env:
+  ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
+
 jobs:
   prepare:
     name: Prepare Build
@@ -50,9 +53,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: ${{ secrets.aws_region }}
+          aws-region: ${{ secrets.AWS_REGION }}
           role-session-name: oraklrolesession
-          role-to-assume: ${{ secrets.role_arn }}
+          role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -60,5 +63,5 @@ jobs:
 
       - name: Publish Image to ECR(orakl)
         run: |
-          docker tag bisonai/orakl-api:latest ${{ secrets.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag bisonai/orakl-api:latest ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -6,7 +6,7 @@ on:
       - master
     types:
       - closed
-## remove after test      
+## remove after test remove administrator access   
   push:
     branches:
       - i-424/docker-hub-is-slow

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -8,12 +8,6 @@ on:
       - "cli/**"
     types:
       - closed
-## remove after test 
-  push:
-    branches:
-      - i-424/docker-hub-is-slow
-    paths:
-      - "cli/**"      
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-cli

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - "api/**"
+      - "cli/**"
     types:
       - closed
 ## remove after test 
@@ -13,10 +13,10 @@ on:
     branches:
       - i-424/docker-hub-is-slow
     paths:
-      - "api/**"      
+      - "cli/**"      
 
 env:
-  ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
+  ecr_url: public.ecr.aws/u6t6w0e4/orakl-cli
 
 jobs:
   prepare:
@@ -51,8 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Docker build orakl-api
-        run:  docker-compose -f api/docker-compose.build.yaml build
+      - name: Docker build orakl-cli
+        run:  docker-compose -f cli/docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -68,5 +68,5 @@ jobs:
 
       - name: Publish Image to ECR(orakl)
         run: |
-          docker tag orakl-api ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag orakl-cli ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -1,0 +1,72 @@
+name: Deploy to Amazon ECR
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "core/**"
+    types:
+      - closed
+## remove after test 
+  push:
+    branches:
+      - i-424/docker-hub-is-slow
+    paths:
+      - "core/**"      
+
+env:
+  ecr_url: public.ecr.aws/u6t6w0e4/orakl-core
+
+jobs:
+  prepare:
+    name: Prepare Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get time TAG
+        id: tag
+        run: |
+          echo "date=$(date +'%Y%m%d.%H%M')" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    permissions:
+      id-token: write
+      contents: read 
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker build orakl-core
+        run:  docker-compose -f core/docker-compose.build.yaml build
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public        
+
+      - name: Publish Image to ECR(orakl)
+        run: |
+          docker tag orakl-core ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -7,14 +7,8 @@ on:
     paths:
       - "core/**"
     types:
-      - closed
-## remove after test 
-  push:
-    branches:
-      - i-424/docker-hub-is-slow
-    paths:
-      - "core/**"      
-
+      - closed  
+      
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-core
 

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -1,0 +1,72 @@
+name: Deploy to Amazon ECR
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "fetcher/**"
+    types:
+      - closed
+## remove after test 
+  push:
+    branches:
+      - i-424/docker-hub-is-slow
+    paths:
+      - "fetcher/**"      
+
+env:
+  ecr_url: public.ecr.aws/u6t6w0e4/orakl-fetcher
+
+jobs:
+  prepare:
+    name: Prepare Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get time TAG
+        id: tag
+        run: |
+          echo "date=$(date +'%Y%m%d.%H%M')" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    permissions:
+      id-token: write
+      contents: read 
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker build orakl-fetcher
+        run:  docker-compose -f fetcher/docker-compose.build.yaml build
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public        
+
+      - name: Publish Image to ECR(orakl)
+        run: |
+          docker tag orakl-fetcher ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker push ${{ env.ecr_url }}:${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -8,12 +8,6 @@ on:
       - "fetcher/**"
     types:
       - closed
-## remove after test 
-  push:
-    branches:
-      - i-424/docker-hub-is-slow
-    paths:
-      - "fetcher/**"      
 
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-fetcher

--- a/api/docker-compose.build.yaml
+++ b/api/docker-compose.build.yaml
@@ -5,4 +5,4 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: bisonai/orakl-api:v0.0.2
+    image: orakl-api

--- a/api/docker-compose.build.yaml
+++ b/api/docker-compose.build.yaml
@@ -5,4 +5,4 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: bisonai/orakl-api:v0.0.1
+    image: bisonai/orakl-api:v0.0.2

--- a/api/docker-compose.build.yaml
+++ b/api/docker-compose.build.yaml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  orakl-cli:
+  orakl-api:
     build:
       context: .
       dockerfile: src/Dockerfile

--- a/cli/docker-compose.build.yaml
+++ b/cli/docker-compose.build.yaml
@@ -5,4 +5,4 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: bisonai/orakl-cli:v0.0.0-dev-alpha
+    image: orakl-cli

--- a/core/docker-compose.build.yaml
+++ b/core/docker-compose.build.yaml
@@ -5,4 +5,4 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: orakl
+    image: orakl-core

--- a/core/docker-compose.build.yaml
+++ b/core/docker-compose.build.yaml
@@ -1,8 +1,8 @@
 version: '3.7'
 
 services:
-  orakl:
+  orakl-core:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: bisonai/orakl:v0.0.2
+    image: orakl

--- a/fetcher/docker-compose.build.yaml
+++ b/fetcher/docker-compose.build.yaml
@@ -1,8 +1,8 @@
 version: '3.7'
 
 services:
-  orakl-cli:
+  orakl-fetcher:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: bisonai/orakl-fetcher:v0.0.0-dev
+    image: orakl-fetcher


### PR DESCRIPTION
# Description

This pull request (PR) is about migrating the repository from Docker Hub to AWS ECR. The reason for this change is that Docker Hub has a limitation for upload after a certain megabyte or call, which slows down the upload speed significantly. Therefore, I decided to migrate the repository to AWS ECR.

To connect to AWS ECR, I do not store any AWS secrets on Git-Action-Secrets. Instead, I use AWS web-identity to log in to ECR.

I have made the repository in ECR public for now. However, I plan to write a description about the organization later.

This PR is only triggered when you merge into the 'Master' branch containing each service changed. After merging, this will create using docker-compose in 'src/'. These images will then be pushed to ECR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
