### PR TITLE
Remove failed data feeds in Orakl Network Fetcher before inserting to the Orakl Network API

### DIFF
--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -38,7 +38,7 @@ yarn run start:prod
 
 ## Endpoints
 
-- `GET /health`
+- `GET /` (health endpoint)
 - `GET /api`
 - `GET /api/v1/start/{aggregator}`
 - `GET /api/v1/stop/{aggregator}`

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -1,6 +1,6 @@
 # Orakl Network Fetcher
 
-The Orakl Network Fetcher regularly collects data defined through aggregators registered withing the [Orakl Network API](https://github.com/Bisonai/orakl/tree/master/api).
+The Orakl Network Fetcher regularly collects data defined through aggregators registered within the [Orakl Network API](https://github.com/Bisonai/orakl/tree/master/api).
 
 ## Installation
 

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -1,6 +1,6 @@
 # Orakl Network Fetcher
 
-Orakl Network Fetcher collects regularly data defined through aggregators defined within [Orakl Network API](https://github.com/Bisonai/orakl/tree/master/api).
+The Orakl Network Fetcher regularly collects data defined through aggregators registered withing the [Orakl Network API](https://github.com/Bisonai/orakl/tree/master/api).
 
 ## Installation
 
@@ -56,24 +56,12 @@ yarn run test:e2e
 yarn run test:cov
 ```
 
-## Configure Orakl Network Fetcher
+## Documentation
 
-```shell
-yarn cli chain insert --name localhost
-yarn cli adapter insert --source adapter/btc-usdt.adapter.json
+- [Learn about how the Orakl Network Fetcher can be controlled](https://orakl-network.gitbook.io/docs/orakl-network-cli/fetcher) by the [Orakl Network CLI](https://orakl-network.gitbook.io/docs/orakl-network-cli/introduction)
+- [Documentation for the Orakl Network Operators](https://orakl-network.gitbook.io/docs/node-operators-guide/orakl-network-fetcher)
 
-# adapterHash=0xd6fbe30bd6249b3093ee065496115e5736bbe760cadfc85598ef27eb4739a849
-yarn cli aggregator insert --source aggregator/localhost/btc-usdt.aggregator.json --chain localhost
-```
 
-## Start data collection and aggregation
+## License
 
-```shell
-yarn cli fetcher start --id 0xd6fbe30bd6249b3093ee065496115e5736bbe760cadfc85598ef27eb4739a849 --chain localhost
-```
-
-## Stop data collection and aggregation
-
-```shell
-yarn cli fetcher stop --id 0xd6fbe30bd6249b3093ee065496115e5736bbe760cadfc85598ef27eb4739a849 --chain localhost
-```
+[MIT License](LICENSE)

--- a/fetcher/src/job/job.api.ts
+++ b/fetcher/src/job/job.api.ts
@@ -1,16 +1,24 @@
 import axios from 'axios'
-import { HttpStatus, HttpException } from '@nestjs/common'
+import { HttpStatus, HttpException, Logger } from '@nestjs/common'
 import { buildUrl } from './job.utils'
 import { IRawData, IData, IAggregator } from './job.types'
 
-export async function loadAggregator(aggregatorHash: string, chain: string) {
+export async function loadAggregator({
+  aggregatorHash,
+  chain,
+  logger
+}: {
+  aggregatorHash: string
+  chain: string
+  logger: Logger
+}) {
   try {
     const url = buildUrl(process.env.ORAKL_NETWORK_API_URL, `aggregator/${aggregatorHash}/${chain}`)
     const aggregator: IAggregator = (await axios.get(url))?.data
     return aggregator
   } catch (e) {
     const msg = `Loading aggregator with hash ${aggregatorHash} for chain ${chain} failed.`
-    this.logger.error(msg)
+    logger.error(msg)
     throw new HttpException(msg, HttpStatus.BAD_REQUEST)
   }
 }

--- a/fetcher/src/job/job.api.ts
+++ b/fetcher/src/job/job.api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { buildUrl } from './job.utils'
+import { IRawData, IData } from './job.types'
 
 export async function loadAggregator(aggregatorHash: string, chain: string) {
   let response = {}
@@ -20,9 +21,9 @@ export async function insertMultipleData({
 }: {
   aggregatorId: string
   timestamp: string
-  data: any[]
+  data: IRawData[]
 }) {
-  const _data = data.map((d) => {
+  const _data: IData[] = data.map((d) => {
     return {
       aggregatorId: aggregatorId,
       feedId: d.id,
@@ -58,7 +59,7 @@ export async function insertAggregateData({
   }
 }
 
-export async function updateAggregator(aggregatorHash: string, chain: string, active: boolean) {
+async function updateAggregator(aggregatorHash: string, chain: string, active: boolean) {
   const url = buildUrl(process.env.ORAKL_NETWORK_API_URL, `aggregator/${aggregatorHash}`)
   const response = await axios.patch(url, { data: { active, chain } })
   return response?.data

--- a/fetcher/src/job/job.api.ts
+++ b/fetcher/src/job/job.api.ts
@@ -1,16 +1,17 @@
 import axios from 'axios'
+import { HttpStatus, HttpException } from '@nestjs/common'
 import { buildUrl } from './job.utils'
-import { IRawData, IData } from './job.types'
+import { IRawData, IData, IAggregator } from './job.types'
 
 export async function loadAggregator(aggregatorHash: string, chain: string) {
-  let response = {}
   try {
     const url = buildUrl(process.env.ORAKL_NETWORK_API_URL, `aggregator/${aggregatorHash}/${chain}`)
-    response = (await axios.get(url))?.data
+    const aggregator: IAggregator = (await axios.get(url))?.data
+    return aggregator
   } catch (e) {
-    this.logger.error(e)
-  } finally {
-    return response
+    const msg = `Loading aggregator with hash ${aggregatorHash} for chain ${chain} failed.`
+    this.logger.error(msg)
+    throw new HttpException(msg, HttpStatus.BAD_REQUEST)
   }
 }
 

--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -31,8 +31,6 @@ export class JobController {
 
     const feeds = extractFeeds(aggregator.adapter, aggregator.id, aggregator.aggregatorHash)
 
-    // TODO Validate adapter
-
     // Launch recurrent data collection
     await this.queue.add(aggregatorHash, feeds, {
       repeat: {

--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -15,7 +15,7 @@ export class JobController {
 
   @Get('start/:aggregator')
   async start(@Param('aggregator') aggregatorHash: string, @Body('chain') chain) {
-    const aggregator = await loadAggregator(aggregatorHash, chain)
+    const aggregator = await loadAggregator({ aggregatorHash, chain, logger: this.logger })
 
     if (Object.keys(aggregator).length == 0) {
       const msg = `Aggregator [${aggregatorHash}] not found`

--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -23,15 +23,13 @@ export class JobController {
       throw new HttpException(msg, HttpStatus.NOT_FOUND)
     }
 
-    // TODO define aggregator type
-    if (aggregator['active']) {
+    if (aggregator.active) {
       const msg = `Aggregator [${aggregatorHash}] is already active`
       this.logger.error(msg)
       throw new HttpException(msg, HttpStatus.BAD_REQUEST)
     }
 
-    const adapter = aggregator['adapter']
-    const feeds = extractFeeds(adapter, aggregator['id'], aggregator['aggregatorHash']) // FIXME define types
+    const feeds = extractFeeds(aggregator.adapter, aggregator.id, aggregator.aggregatorHash)
 
     // TODO Validate adapter
 

--- a/fetcher/src/job/job.processor.ts
+++ b/fetcher/src/job/job.processor.ts
@@ -20,7 +20,7 @@ export class JobProcessor extends WorkerHost {
       const aggregatorHash = keys[0]
       const aggregatorId = inData[aggregatorHash].aggregatorId
       const feeds = inData[aggregatorHash].feeds
-      const data = await fetchData(feeds)
+      const data = await fetchData(feeds, this.logger)
       const aggregate = aggregateData(data)
 
       try {

--- a/fetcher/src/job/job.processor.ts
+++ b/fetcher/src/job/job.processor.ts
@@ -19,7 +19,6 @@ export class JobProcessor extends WorkerHost {
     } else {
       const aggregatorHash = keys[0]
       const aggregatorId = inData[aggregatorHash].aggregatorId
-      // const name = inData[aggregatorHash].name
       const feeds = inData[aggregatorHash].feeds
       const data = await fetchData(feeds)
       const aggregate = aggregateData(data)

--- a/fetcher/src/job/job.types.ts
+++ b/fetcher/src/job/job.types.ts
@@ -1,11 +1,56 @@
 export interface IRawData {
-  id: string
+  id: bigint
   value: number
 }
 
 export interface IData {
   aggregatorId: string
-  feedId: string
+  feedId: bigint
   timestamp: string
   value: number
+}
+
+interface IHeader {
+  'Content-Type': string
+}
+
+interface IReducer {
+  function: string
+  args: string[]
+}
+
+interface IDefinition {
+  url: string
+  method: string
+  headers: IHeader[]
+  reducers: IReducer[]
+}
+
+interface IFeed {
+  id: bigint
+  name: string
+  definition: IDefinition
+  adapterId: bigint
+}
+
+export interface IAdapter {
+  id: bigint
+  adapterHash: string
+  name: string
+  decimals: number
+  feeds: IFeed[]
+}
+
+export interface IAggregator {
+  id: bigint
+  aggregatorHash: string
+  active: boolean
+  name: string
+  address: string
+  heartbeat: number
+  threshold: number
+  absoluteThreshold: number
+  adapterId: bigint
+  chainId: bigint
+  adapter: IAdapter
 }

--- a/fetcher/src/job/job.types.ts
+++ b/fetcher/src/job/job.types.ts
@@ -54,3 +54,8 @@ export interface IAggregator {
   chainId: bigint
   adapter: IAdapter
 }
+
+export interface IFetchedData {
+  id: string
+  value: number
+}

--- a/fetcher/src/job/job.types.ts
+++ b/fetcher/src/job/job.types.ts
@@ -1,0 +1,11 @@
+export interface IRawData {
+  id: string
+  value: number
+}
+
+export interface IData {
+  aggregatorId: string
+  feedId: string
+  timestamp: string
+  value: number
+}

--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { DATA_FEED_REDUCER_MAPPING } from './job.reducer'
 import { LOCAL_AGGREGATOR_FN } from './job.aggregator'
 import { FetcherError, FetcherErrorCode } from './job.errors'
+import { IAdapter } from './job.types'
 
 export function buildUrl(host: string, path: string) {
   const url = [host, path].join('/')
@@ -73,7 +74,7 @@ function checkDataFormat(data) {
   }
 }
 
-function validateAdapter(adapter) /*: IAdapter*/ {
+function validateAdapter(adapter): IAdapter {
   // TODO extract properties from Interface
   const requiredProperties = ['id', 'active', 'name', 'jobType', 'decimals', 'feeds']
   // TODO show where is the error
@@ -83,13 +84,13 @@ function validateAdapter(adapter) /*: IAdapter*/ {
   const isValid = hasProperty.every((x) => x)
 
   if (isValid) {
-    return adapter /*as IAdapter*/
+    return adapter as IAdapter
   } else {
     throw new FetcherError(FetcherErrorCode.InvalidAdapter)
   }
 }
 
-export function extractFeeds(adapter, aggregatorId: string, aggregatorHash: string) {
+export function extractFeeds(adapter, aggregatorId: bigint, aggregatorHash: string) {
   const adapterHash = adapter.adapterHash
   const feeds = adapter.feeds.map((f) => {
     return {

--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { DATA_FEED_REDUCER_MAPPING } from './job.reducer'
 import { LOCAL_AGGREGATOR_FN } from './job.aggregator'
 import { FetcherError, FetcherErrorCode } from './job.errors'
-import { IAdapter } from './job.types'
+import { IAdapter, IFetchedData } from './job.types'
 
 export function buildUrl(host: string, path: string) {
   const url = [host, path].join('/')
@@ -13,10 +13,11 @@ export function buildUrl(host: string, path: string) {
  * Fetch data from data sources defined in `adapter`.
  *
  * @param {} adapter Single data adapter to define which data to fetch.
+ * @param {} NestJs logger
  * @return {number} aggregatedresults
  */
-export async function fetchData(adapter) {
-  return await Promise.all(
+export async function fetchData(adapter, logger) {
+  const data = await Promise.allSettled(
     adapter.map(async (a) => {
       const options = {
         method: a.method,
@@ -34,17 +35,18 @@ export async function fetchData(adapter) {
         checkDataFormat(datum)
         return { id: a.id, value: datum }
       } catch (e) {
-        console.error(`Error in ${a.name}`)
-        console.error(e)
-        return { id: a.id, value: undefined }
+        logger.error(`Error in ${a.name}`)
+        logger.error(e)
+        throw e
       }
     })
   )
+
+  return data.flatMap((D) => (D.status == 'fulfilled' ? [D.value] : []))
 }
 
-// TODO define data type
-export function aggregateData(data: number[]): number {
-  const aggregate = LOCAL_AGGREGATOR_FN(data.map((d) => d['value']))
+export function aggregateData(data: IFetchedData[]): number {
+  const aggregate = LOCAL_AGGREGATOR_FN(data.map((d) => d.value))
   return aggregate
 }
 


### PR DESCRIPTION
# Description

Previously, when data collection failed for any resource, value of that data feed was set `undefined`. After submitting data with `undefined` value(s) to the Orakl Network API, the `undefined` value was rejected to be inserted and caused an error for all values that were supposed to be submitted at that time as a part of multi record insert transaction.

Additionally, this PR defines several types for safes object property access.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Deployment

- [x] Should publish Docker image
