### PR TITLE
An easy access to oracle addresses

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -2,7 +2,9 @@
   "extends": "solhint:recommended",
   "plugins": ["prettier"],
   "rules": {
-    "avoid-throw": false,
+    "avoid-throw": "off",
+    "avoid-low-level-calls": "off",
+    "func-visibility": ["warn",{"ignoreConstructors": true}],
     "avoid-suicide": "error",
     "avoid-sha3": "warn",
     "compiler-version": ["error", "^0.8.16"]

--- a/contracts/deploy/VRF/VRFCoordinator.ts
+++ b/contracts/deploy/VRF/VRFCoordinator.ts
@@ -80,7 +80,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           await vrfCoordinator.registerOracle(oracle.address, oracle.publicProvingKey)
         ).wait()
         console.log(
-          `Registered oracle address=${tx.events[0].args.oracle} with keyHash=${tx.events[0].args.keyHash}`
+          `Oracle registered with address=${tx.events[0].args.oracle} and keyHash=${tx.events[0].args.keyHash}`
         )
       }
     }
@@ -96,7 +96,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       for (const oracle of deregisterOracleConfig) {
         const tx = await (await vrfCoordinator.deregisterOracle(oracle.address)).wait()
         console.log(
-          `Deregistered oracle address=${tx.events[0].args.oracle} with keyHash=${tx.events[0].args.keyHash}`
+          `Oracle deregistered with address=${tx.events[0].args.oracle} and keyHash=${tx.events[0].args.keyHash}`
         )
       }
     }

--- a/contracts/deploy/VRF/VRFCoordinator.ts
+++ b/contracts/deploy/VRF/VRFCoordinator.ts
@@ -9,8 +9,8 @@ import {
   validateDirectPaymentConfig,
   validateMinBalanceConfig,
   validateSetConfig,
-  validateVrfDeregisterProvingKey,
-  validateVrfRegisterProvingKey
+  validateVrfDeregisterOracle,
+  validateVrfRegisterOracle
 } from '../../scripts/v0.1/utils'
 import { IVrfCoordinatorConfig } from '../../scripts/v0.1/types'
 
@@ -67,36 +67,36 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       ? vrfCoordinator
       : await ethers.getContractAt('VRFCoordinator', config.vrfCoordinatorAddress)
 
-    // Register proving key /////////////////////////////////////////////////////
-    if (config.registerProvingKey) {
-      console.log('registerProvingKey')
-      const registerProvingKeyConfig = config.registerProvingKey
-      if (!validateVrfRegisterProvingKey(registerProvingKeyConfig)) {
-        throw new Error('Invalid VRF registerProvingKey config')
+    // Register oracle //////////////////////////////////////////////////////////
+    if (config.registerOracle) {
+      console.log('registerOracle')
+      const registerOracleConfig = config.registerOracle
+      if (!validateVrfRegisterOracle(registerOracleConfig)) {
+        throw new Error('Invalid VRF registerOracle config')
       }
 
-      for (const oracle of registerProvingKeyConfig) {
+      for (const oracle of registerOracleConfig) {
         const tx = await (
-          await vrfCoordinator.registerProvingKey(oracle.address, oracle.publicProvingKey)
+          await vrfCoordinator.registerOracle(oracle.address, oracle.publicProvingKey)
         ).wait()
         console.log(
-          `Registered proving key with keyHash=${tx.events[0].args.keyHash} for address=${tx.events[0].args.oracle}`
+          `Registered oracle address=${tx.events[0].args.oracle} with keyHash=${tx.events[0].args.keyHash}`
         )
       }
     }
 
-    // Deregister proving key ///////////////////////////////////////////////////
-    if (config.deregisterProvingKey) {
-      console.log('deregisterProvingKey')
-      const deregisterProvingKeyConfig = config.deregisterProvingKey
-      if (!validateVrfDeregisterProvingKey(deregisterProvingKeyConfig)) {
-        throw new Error('Invalid VRF deregisterProvingKey config')
+    // Deregister oracle ////////////////////////////////////////////////////////
+    if (config.deregisterOracle) {
+      console.log('deregisterOracle')
+      const deregisterOracleConfig = config.deregisterOracle
+      if (!validateVrfDeregisterOracle(deregisterOracleConfig)) {
+        throw new Error('Invalid VRF deregisterOracle config')
       }
 
-      for (const oracle of deregisterProvingKeyConfig) {
-        const tx = await (await vrfCoordinator.deregisterProvingKey(oracle.publicProvingKey)).wait()
+      for (const oracle of deregisterOracleConfig) {
+        const tx = await (await vrfCoordinator.deregisterOracle(oracle.address)).wait()
         console.log(
-          `Deregistered proving key with keyHash=${tx.events[0].args.keyHash} for address=${tx.events[0].args.oracle}`
+          `Deregistered oracle address=${tx.events[0].args.oracle} with keyHash=${tx.events[0].args.keyHash}`
         )
       }
     }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/orakl-contracts",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "The Orakl Network Smart Contracts",
   "files": [
     "./dist",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bisonai/orakl-contracts",
   "version": "0.4.4",
-  "description": "",
+  "description": "The Orakl Network Smart Contracts",
   "files": [
     "./dist",
     "./src"
@@ -11,7 +11,10 @@
       "Orakl",
       "Orakl Network",
       "Blockchain",
-      "Web3"
+      "Web3",
+      "VRF",
+      "Request-Response",
+      "Data Feed"
   ],
   "engines": {
     "node": ">=18.12"

--- a/contracts/scripts/v0.1/request-response/integration/read-data.ts
+++ b/contracts/scripts/v0.1/request-response/integration/read-data.ts
@@ -5,7 +5,7 @@ async function main() {
   const userContract = await ethers.getContract('RequestResponseConsumerMock')
   console.log('RequestResponseConsumerMock', userContract.address)
 
-  const response = await userContract.s_response()
+  const response = await userContract.sResponse()
   console.log(`Response ${response}`)
   expect(response.toString()).to.not.equal('0')
 }

--- a/contracts/scripts/v0.1/request-response/read-data.ts
+++ b/contracts/scripts/v0.1/request-response/read-data.ts
@@ -4,7 +4,7 @@ async function main() {
   const userContract = await ethers.getContract('RequestResponseConsumerMock')
   console.log('RequestResponseConsumerMock', userContract.address)
 
-  const response = await userContract.s_response()
+  const response = await userContract.sResponse()
   console.log(`Response ${response}`)
 }
 

--- a/contracts/scripts/v0.1/types.ts
+++ b/contracts/scripts/v0.1/types.ts
@@ -78,20 +78,20 @@ export interface IRequestResponseCoordinatorConfig {
 }
 
 // VRFCoordinator
-export interface IRegisterProvingKey {
+export interface IRegisterOracle {
   address: string
   publicProvingKey: [string, string]
 }
 
-export interface IDeregisterProvingKey {
-  publicProvingKey: [string, string]
+export interface IDeregisterOracle {
+  address: string
 }
 
 export interface IVrfCoordinatorConfig {
   vrfCoordinatorAddress?: string
   deploy?: ICoordinatorDeploy
-  registerProvingKey?: IRegisterProvingKey[]
-  deregisterProvingKey?: IDeregisterProvingKey[]
+  registerOracle?: IRegisterOracle[]
+  deregisterOracle?: IDeregisterOracle[]
   setConfig?: ICoordinatorConfig
   setDirectPaymentConfig?: ICoordinatorDirectPaymentConfig
   setMinBalance?: ICoordinatorMinBalance

--- a/contracts/scripts/v0.1/utils.ts
+++ b/contracts/scripts/v0.1/utils.ts
@@ -5,8 +5,8 @@ import {
   ICoordinatorDeploy,
   IAggregatorDeployConfig,
   IAggregatorChangeOraclesConfig,
-  IRegisterProvingKey,
-  IDeregisterProvingKey,
+  IRegisterOracle,
+  IDeregisterOracle,
   ICoordinatorConfig,
   ICoordinatorDirectPaymentConfig
 } from './types'
@@ -173,7 +173,7 @@ export function validateDirectPaymentConfig(config: ICoordinatorDirectPaymentCon
   return true
 }
 
-export function validateVrfRegisterProvingKey(config: IRegisterProvingKey[]): boolean {
+export function validateVrfRegisterOracle(config: IRegisterOracle[]): boolean {
   const requiredProperties = ['address', 'publicProvingKey']
 
   for (const c of config) {
@@ -185,8 +185,8 @@ export function validateVrfRegisterProvingKey(config: IRegisterProvingKey[]): bo
   return true
 }
 
-export function validateVrfDeregisterProvingKey(config: IDeregisterProvingKey[]): boolean {
-  const requiredProperties = ['publicProvingKey']
+export function validateVrfDeregisterOracle(config: IDeregisterOracle[]): boolean {
+  const requiredProperties = ['address']
 
   for (const c of config) {
     if (!validateProperties(c, requiredProperties)) {

--- a/contracts/scripts/v0.1/vrf/read-vrf.ts
+++ b/contracts/scripts/v0.1/vrf/read-vrf.ts
@@ -4,7 +4,7 @@ async function main() {
   const userContract = await ethers.getContract('VRFConsumerMock')
   console.log('VRFConsumerMock', userContract.address)
 
-  const randomWord = await userContract.s_randomWord()
+  const randomWord = await userContract.sRandomWord()
   console.log(`randomWord ${randomWord.toString()}`)
 }
 

--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -34,7 +34,7 @@ contract RequestResponseCoordinator is
 
     uint256 public sMinBalance;
 
-    PrepaymentInterface sPrepayment;
+    PrepaymentInterface private sPrepayment;
 
     struct Config {
         uint32 maxGasLimit;
@@ -66,7 +66,7 @@ contract RequestResponseCoordinator is
         uint256 baseFee;
     }
 
-    DirectPaymentConfig sDirectPaymentConfig;
+    DirectPaymentConfig private sDirectPaymentConfig;
 
     error InvalidConsumer(uint64 accId, address consumer);
     error InvalidAccount();

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -465,7 +465,8 @@ contract VRFCoordinator is
         uint64 accId,
         uint64 nonce
     ) public view returns (bool) {
-        for (uint256 i = 0; i < sKeyHashes.length; i++) {
+        uint256 keyHashesLength = sKeyHashes.length;
+        for (uint256 i; i < keyHashesLength; ++i) {
             (uint256 reqId, ) = computeRequestId(sKeyHashes[i], consumer, accId, nonce);
             if (sRequestIdToCommitment[reqId] != 0) {
                 return true;

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -29,9 +29,9 @@ contract VRFCoordinator is
 
     /* requestID */
     /* commitment */
-    mapping(uint256 => bytes32) private s_requestCommitments;
+    mapping(uint256 => bytes32) private sRequestCommitments;
 
-    uint256 public s_minBalance;
+    uint256 public sMinBalance;
 
     // RequestCommitment holds information sent from off-chain oracle
     // describing details of request.
@@ -51,7 +51,7 @@ contract VRFCoordinator is
         // We make it configurable in case those operations are repriced.
         uint32 gasAfterPaymentCalculation;
     }
-    Config private s_config;
+    Config private sConfig;
 
     struct FeeConfig {
         // Flat fee charged per fulfillment in millionths of KLAY
@@ -66,16 +66,16 @@ contract VRFCoordinator is
         uint24 reqsForTier4;
         uint24 reqsForTier5;
     }
-    FeeConfig private s_feeConfig;
+    FeeConfig private sFeeConfig;
 
-    PrepaymentInterface s_prepayment;
+    PrepaymentInterface sPrepayment;
 
     struct DirectPaymentConfig {
         uint256 fulfillmentFee;
         uint256 baseFee;
     }
 
-    DirectPaymentConfig s_directPaymentConfig;
+    DirectPaymentConfig sDirectPaymentConfig;
 
     error InvalidKeyHash(bytes32 keyHash);
     error InvalidConsumer(uint64 accId, address consumer);
@@ -115,7 +115,7 @@ contract VRFCoordinator is
     event PrepaymentSet(address prepayment);
 
     modifier nonReentrant() {
-        if (s_config.reentrancyLock) {
+        if (sConfig.reentrancyLock) {
             revert Reentrant();
         }
         _;
@@ -129,7 +129,7 @@ contract VRFCoordinator is
     }
 
     constructor(address prepayment) {
-        s_prepayment = PrepaymentInterface(prepayment);
+        sPrepayment = PrepaymentInterface(prepayment);
         emit PrepaymentSet(prepayment);
     }
 
@@ -197,13 +197,13 @@ contract VRFCoordinator is
         uint32 gasAfterPaymentCalculation,
         FeeConfig memory feeConfig
     ) external onlyOwner {
-        s_config = Config({
+        sConfig = Config({
             maxGasLimit: maxGasLimit,
             gasAfterPaymentCalculation: gasAfterPaymentCalculation,
             reentrancyLock: false
         });
-        s_feeConfig = feeConfig;
-        emit ConfigSet(maxGasLimit, gasAfterPaymentCalculation, s_feeConfig);
+        sFeeConfig = feeConfig;
+        emit ConfigSet(maxGasLimit, gasAfterPaymentCalculation, sFeeConfig);
     }
 
     function getConfig()
@@ -211,7 +211,7 @@ contract VRFCoordinator is
         view
         returns (uint32 maxGasLimit, uint32 gasAfterPaymentCalculation)
     {
-        return (s_config.maxGasLimit, s_config.gasAfterPaymentCalculation);
+        return (sConfig.maxGasLimit, sConfig.gasAfterPaymentCalculation);
     }
 
     function getFeeConfig()
@@ -230,15 +230,15 @@ contract VRFCoordinator is
         )
     {
         return (
-            s_feeConfig.fulfillmentFlatFeeKlayPPMTier1,
-            s_feeConfig.fulfillmentFlatFeeKlayPPMTier2,
-            s_feeConfig.fulfillmentFlatFeeKlayPPMTier3,
-            s_feeConfig.fulfillmentFlatFeeKlayPPMTier4,
-            s_feeConfig.fulfillmentFlatFeeKlayPPMTier5,
-            s_feeConfig.reqsForTier2,
-            s_feeConfig.reqsForTier3,
-            s_feeConfig.reqsForTier4,
-            s_feeConfig.reqsForTier5
+            sFeeConfig.fulfillmentFlatFeeKlayPPMTier1,
+            sFeeConfig.fulfillmentFlatFeeKlayPPMTier2,
+            sFeeConfig.fulfillmentFlatFeeKlayPPMTier3,
+            sFeeConfig.fulfillmentFlatFeeKlayPPMTier4,
+            sFeeConfig.fulfillmentFlatFeeKlayPPMTier5,
+            sFeeConfig.reqsForTier2,
+            sFeeConfig.reqsForTier3,
+            sFeeConfig.reqsForTier4,
+            sFeeConfig.reqsForTier5
         );
     }
 
@@ -246,13 +246,13 @@ contract VRFCoordinator is
      * @inheritdoc VRFCoordinatorInterface
      */
     function getRequestConfig() external view returns (uint32, bytes32[] memory) {
-        return (s_config.maxGasLimit, sKeyHashes);
+        return (sConfig.maxGasLimit, sKeyHashes);
     }
 
     function setDirectPaymentConfig(
         DirectPaymentConfig memory directPaymentConfig
     ) public onlyOwner {
-        s_directPaymentConfig = directPaymentConfig;
+        sDirectPaymentConfig = directPaymentConfig;
         emit DirectPaymentConfigSet(
             directPaymentConfig.fulfillmentFee,
             directPaymentConfig.baseFee
@@ -260,15 +260,15 @@ contract VRFCoordinator is
     }
 
     function getDirectPaymentConfig() external view returns (uint256, uint256) {
-        return (s_directPaymentConfig.fulfillmentFee, s_directPaymentConfig.baseFee);
+        return (sDirectPaymentConfig.fulfillmentFee, sDirectPaymentConfig.baseFee);
     }
 
     function estimateDirectPaymentFee() public view returns (uint256) {
-        return s_directPaymentConfig.fulfillmentFee + s_directPaymentConfig.baseFee;
+        return sDirectPaymentConfig.fulfillmentFee + sDirectPaymentConfig.baseFee;
     }
 
     function getPrepaymentAddress() public view returns (address) {
-        return address(s_prepayment);
+        return address(sPrepayment);
     }
 
     /**
@@ -277,11 +277,11 @@ contract VRFCoordinator is
      * @dev used to determine if a request is fulfilled or not
      */
     function getCommitment(uint256 requestId) external view returns (bytes32) {
-        return s_requestCommitments[requestId];
+        return sRequestCommitments[requestId];
     }
 
     function setMinBalance(uint256 minBalance) public onlyOwner {
-        s_minBalance = minBalance;
+        sMinBalance = minBalance;
         emit MinBalanceSet(minBalance);
     }
 
@@ -308,7 +308,7 @@ contract VRFCoordinator is
             randomWords[i] = uint256(keccak256(abi.encode(randomness, i)));
         }
 
-        delete s_requestCommitments[requestId];
+        delete sRequestCommitments[requestId];
         VRFConsumerBase v;
         bytes memory resp = abi.encodeWithSelector(
             v.rawFulfillRandomWords.selector,
@@ -322,17 +322,17 @@ contract VRFCoordinator is
         // during the consumers callback code via reentrancyLock.
         // Note that callWithExactGas will revert if we do not have sufficient gas
         // to give the callee their requested amount.
-        s_config.reentrancyLock = true;
+        sConfig.reentrancyLock = true;
         bool success = callWithExactGas(rc.callbackGasLimit, rc.sender, resp);
-        s_config.reentrancyLock = false;
+        sConfig.reentrancyLock = false;
 
         // We want to charge users exactly for how much gas they use in their callback.
         // The gasAfterPaymentCalculation is meant to cover these additional operations where we
         // decrement the account balance and increment the oracles withdrawable balance.
         // We also add the flat KLAY fee to the payment amount.
-        // Its specified in millionths of KLAY, if s_config.fulfillmentFlatFeeKlayPPM = 1
+        // Its specified in millionths of KLAY, if sConfig.fulfillmentFlatFeeKlayPPM = 1
         // 1 KLAY / 1e6 = 1e18 pebs / 1e6 = 1e12 pebs.
-        (uint256 balance, uint64 reqCount, , ) = s_prepayment.getAccount(rc.accId);
+        (uint256 balance, uint64 reqCount, , ) = sPrepayment.getAccount(rc.accId);
 
         uint256 payment;
         if (isDirectPayment) {
@@ -340,15 +340,12 @@ contract VRFCoordinator is
         } else {
             payment = calculatePaymentAmount(
                 startGas,
-                s_config.gasAfterPaymentCalculation,
+                sConfig.gasAfterPaymentCalculation,
                 getFeeTier(reqCount)
             );
         }
 
-        s_prepayment.chargeFee(rc.accId, payment, sKeyHashToOracle[keyHash]);
-
-        // FIXME
-        //s_withdrawableTokens[sKeyHashToOracle[rc.keyHash]] += payment;
+        sPrepayment.chargeFee(rc.accId, payment, sKeyHashToOracle[keyHash]);
 
         // Include payment in the event for tracking costs.
         emit RandomWordsFulfilled(requestId, randomness, payment, success);
@@ -369,7 +366,7 @@ contract VRFCoordinator is
      * @return feePPM fee in KLAY PPM
      */
     function getFeeTier(uint64 reqCount) public view returns (uint32) {
-        FeeConfig memory fc = s_feeConfig;
+        FeeConfig memory fc = sFeeConfig;
         if (0 <= reqCount && reqCount <= fc.reqsForTier2) {
             return fc.fulfillmentFlatFeeKlayPPMTier1;
         }
@@ -395,7 +392,7 @@ contract VRFCoordinator is
     ) public view returns (bool) {
         for (uint256 i = 0; i < sKeyHashes.length; i++) {
             (uint256 reqId, ) = computeRequestId(sKeyHashes[i], consumer, accId, nonce);
-            if (s_requestCommitments[reqId] != 0) {
+            if (sRequestCommitments[reqId] != 0) {
                 return true;
             }
         }
@@ -419,7 +416,7 @@ contract VRFCoordinator is
     ) internal returns (uint256) {
         // Input validation using the account storage.
         // call to prepayment contract
-        address owner = s_prepayment.getAccountOwner(accId);
+        address owner = sPrepayment.getAccountOwner(accId);
         if (owner == address(0)) {
             revert InvalidAccount();
         }
@@ -427,7 +424,7 @@ contract VRFCoordinator is
         // Its important to ensure that the consumer is in fact who they say they
         // are, otherwise they could use someone else's account balance.
         // A nonce of 0 indicates consumer is not allocated to the acc.
-        uint64 currentNonce = s_prepayment.getNonce(msg.sender, accId);
+        uint64 currentNonce = sPrepayment.getNonce(msg.sender, accId);
         if (currentNonce == 0) {
             revert InvalidConsumer(accId, msg.sender);
         }
@@ -435,18 +432,18 @@ contract VRFCoordinator is
         // No lower bound on the requested gas limit. A user could request 0
         // and they would simply be billed for the proof verification and wouldn't be
         // able to do anything with the random value.
-        if (callbackGasLimit > s_config.maxGasLimit) {
-            revert GasLimitTooBig(callbackGasLimit, s_config.maxGasLimit);
+        if (callbackGasLimit > sConfig.maxGasLimit) {
+            revert GasLimitTooBig(callbackGasLimit, sConfig.maxGasLimit);
         }
 
         if (numWords > MAX_NUM_WORDS) {
             revert NumWordsTooBig(numWords, MAX_NUM_WORDS);
         }
 
-        uint64 nonce = s_prepayment.increaseNonce(msg.sender, accId);
+        uint64 nonce = sPrepayment.increaseNonce(msg.sender, accId);
         (uint256 requestId, uint256 preSeed) = computeRequestId(keyHash, msg.sender, accId, nonce);
 
-        s_requestCommitments[requestId] = keccak256(
+        sRequestCommitments[requestId] = keccak256(
             abi.encode(requestId, block.number, accId, callbackGasLimit, numWords, msg.sender)
         );
         emit RandomWordsRequested(
@@ -472,10 +469,10 @@ contract VRFCoordinator is
         uint32 callbackGasLimit,
         uint32 numWords
     ) external nonReentrant onlyValidKeyHash(keyHash) returns (uint256 requestId) {
-        (uint256 balance, , , ) = s_prepayment.getAccount(accId);
+        (uint256 balance, , , ) = sPrepayment.getAccount(accId);
 
-        if (balance < s_minBalance) {
-            revert InsufficientPayment(balance, s_minBalance);
+        if (balance < sMinBalance) {
+            revert InsufficientPayment(balance, sMinBalance);
         }
         bool isDirectPayment = false;
 
@@ -501,8 +498,8 @@ contract VRFCoordinator is
             revert InsufficientPayment(msg.value, vrfFee);
         }
 
-        uint64 accId = s_prepayment.createAccount();
-        s_prepayment.addConsumer(accId, msg.sender);
+        uint64 accId = sPrepayment.createAccount();
+        sPrepayment.addConsumer(accId, msg.sender);
         bool isDirectPayment = true;
         uint256 requestId = requestRandomWordsInternal(
             keyHash,
@@ -511,7 +508,7 @@ contract VRFCoordinator is
             numWords,
             isDirectPayment
         );
-        s_prepayment.deposit{value: vrfFee}(accId);
+        sPrepayment.deposit{value: vrfFee}(accId);
 
         uint256 remaining = msg.value - vrfFee;
         if (remaining > 0) {
@@ -593,7 +590,7 @@ contract VRFCoordinator is
             revert NoSuchProvingKey(keyHash);
         }
         requestId = uint256(keccak256(abi.encode(keyHash, proof.seed)));
-        bytes32 commitment = s_requestCommitments[requestId];
+        bytes32 commitment = sRequestCommitments[requestId];
         if (commitment == 0) {
             revert NoCorrespondingRequest();
         }

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -80,6 +80,7 @@ contract VRFCoordinator is
     error GasLimitTooBig(uint32 have, uint32 want);
     error NumWordsTooBig(uint32 have, uint32 want);
     error OracleAlreadyRegistered(address oracle);
+    error ProvingKeyAlreadyRegistered(bytes32 keyHash);
     error NoSuchOracle(address oracle);
     error NoSuchProvingKey(bytes32 keyHash);
     error NoCorrespondingRequest();
@@ -144,6 +145,10 @@ contract VRFCoordinator is
         }
 
         bytes32 kh = hashOfKey(publicProvingKey);
+        if (sKeyHashToOracle[kh] != address(0)) {
+            revert ProvingKeyAlreadyRegistered(kh);
+        }
+
         sOracles.push(oracle);
         sKeyHashes.push(kh);
         sOracleToKeyHash[oracle] = kh;

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -419,6 +419,22 @@ contract VRFCoordinator is
         return "VRFCoordinator v0.1";
     }
 
+    /**
+     * @notice Find key hash associated with given oracle address.
+     * @return keyhash
+     */
+    function oracleToKeyHash(address oracle) external view returns (bytes32) {
+        return sOracleToKeyHash[oracle];
+    }
+
+    /**
+     * @notice Find key oracle associated with given key hash.
+     * @return oracle address
+     */
+    function keyHashToOracle(bytes32 keyHash) external view returns (address) {
+        return sKeyHashToOracle[keyHash];
+    }
+
     /*
      * @notice Compute fee based on the request count
      * @param reqCount number of requests

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -65,14 +65,14 @@ contract VRFCoordinator is
     }
     FeeConfig private sFeeConfig;
 
-    PrepaymentInterface sPrepayment;
+    PrepaymentInterface private sPrepayment;
 
     struct DirectPaymentConfig {
         uint256 fulfillmentFee;
         uint256 baseFee;
     }
 
-    DirectPaymentConfig sDirectPaymentConfig;
+    DirectPaymentConfig private sDirectPaymentConfig;
 
     error InvalidKeyHash(bytes32 keyHash);
     error InvalidConsumer(uint64 accId, address consumer);

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -163,7 +163,7 @@ contract VRFCoordinator is
      */
     function deregisterOracle(address oracle) external onlyOwner {
         bytes32 kh = sOracleToKeyHash[oracle];
-        if (kh == bytes32(0)) {
+        if (kh == bytes32(0) || sKeyHashToOracle[kh] == address(0)) {
             revert NoSuchOracle(oracle);
         }
         delete sOracleToKeyHash[oracle];

--- a/contracts/src/v0.1/mocks/RequestResponseConsumerMock.sol
+++ b/contracts/src/v0.1/mocks/RequestResponseConsumerMock.sol
@@ -6,20 +6,20 @@ import "../interfaces/RequestResponseCoordinatorInterface.sol";
 
 contract RequestResponseConsumerMock is RequestResponseConsumerBase {
     using Orakl for Orakl.Request;
-    uint256 public s_response;
-    address private s_owner;
+    uint256 public sResponse;
+    address private sOwner;
 
     error OnlyOwner(address notOwner);
 
     modifier onlyOwner() {
-        if (msg.sender != s_owner) {
+        if (msg.sender != sOwner) {
             revert OnlyOwner(msg.sender);
         }
         _;
     }
 
     constructor(address coordinator) RequestResponseConsumerBase(coordinator) {
-        s_owner = msg.sender;
+        sOwner = msg.sender;
     }
 
     // Receive remaining payment from requestDataPayment
@@ -59,6 +59,6 @@ contract RequestResponseConsumerMock is RequestResponseConsumerBase {
     }
 
     function fulfillDataRequest(uint256 /*requestId*/, uint256 response) internal override {
-        s_response = response;
+        sResponse = response;
     }
 }

--- a/contracts/src/v0.1/mocks/VRFConsumerMock.sol
+++ b/contracts/src/v0.1/mocks/VRFConsumerMock.sol
@@ -5,22 +5,22 @@ import "../VRFConsumerBase.sol";
 import "../interfaces/VRFCoordinatorInterface.sol";
 
 contract VRFConsumerMock is VRFConsumerBase {
-    uint256 public s_randomWord;
-    address private s_owner;
+    uint256 public sRandomWord;
+    address private sOwner;
 
     VRFCoordinatorInterface COORDINATOR;
 
     error OnlyOwner(address notOwner);
 
     modifier onlyOwner() {
-        if (msg.sender != s_owner) {
+        if (msg.sender != sOwner) {
             revert OnlyOwner(msg.sender);
         }
         _;
     }
 
     constructor(address coordinator) VRFConsumerBase(coordinator) {
-        s_owner = msg.sender;
+        sOwner = msg.sender;
         COORDINATOR = VRFCoordinatorInterface(coordinator);
     }
 
@@ -54,6 +54,6 @@ contract VRFConsumerMock is VRFConsumerBase {
     ) internal override {
         // requestId should be checked if it matches the expected request
         // Generate random value between 1 and 50.
-        s_randomWord = (randomWords[0] % 50) + 1;
+        sRandomWord = (randomWords[0] % 50) + 1;
     }
 }

--- a/contracts/test/v0.1/Prepayment.test.ts
+++ b/contracts/test/v0.1/Prepayment.test.ts
@@ -152,7 +152,7 @@ describe('Prepayment contract', function () {
       feeConfig
     } = vrfConfig()
 
-    await coordinatorContract.registerProvingKey(oracle, publicProvingKey)
+    await coordinatorContract.registerOracle(oracle, publicProvingKey)
 
     await coordinatorContract.setConfig(
       maxGasLimit,
@@ -190,7 +190,7 @@ describe('Prepayment contract', function () {
       feeConfig
     } = vrfConfig()
 
-    await coordinatorContract.registerProvingKey(oracle, publicProvingKey)
+    await coordinatorContract.registerOracle(oracle, publicProvingKey)
 
     await coordinatorContract.setConfig(
       maxGasLimit,

--- a/contracts/test/v0.1/RequestResponseConsumerContract.test.ts
+++ b/contracts/test/v0.1/RequestResponseConsumerContract.test.ts
@@ -148,7 +148,7 @@ describe('Request-Response user contract', function () {
     const fulfillEvent = coordinatorContract.interface.parseLog(fulfillReceipt.events[1])
     expect(fulfillEvent.name).to.be.equal('DataRequestFulfilled')
     expect(fulfillEvent.args.requestId).to.be.equal(requestId)
-    expect(Number(await consumerContract.s_response())).to.be.equal(response)
+    expect(Number(await consumerContract.sResponse())).to.be.equal(response)
   })
   it('requestData should revert with InsufficientPayment error', async function () {
     const { accId, maxGasLimit, consumerContract, coordinatorContract } = await loadFixture(

--- a/contracts/test/v0.1/RequestResponseCoordinator.test.ts
+++ b/contracts/test/v0.1/RequestResponseCoordinator.test.ts
@@ -53,4 +53,29 @@ describe('RequestResponseCoordinator', function () {
       'OracleAlreadyRegistered'
     )
   })
+
+  it('should allow to deregister registered oracle', async function () {
+    const { coordinatorContract } = await loadFixture(deployFixture)
+    const { address: oracle } = ethers.Wallet.createRandom()
+
+    // Cannot deregister underegistered oracle
+    await expect(coordinatorContract.deregisterOracle(oracle)).to.be.revertedWithCustomError(
+      coordinatorContract,
+      'NoSuchOracle'
+    )
+
+    // Registration
+    const txRegisterReceipt = await (await coordinatorContract.registerOracle(oracle)).wait()
+    expect(txRegisterReceipt.events.length).to.be.equal(1)
+    const registerEvent = coordinatorContract.interface.parseLog(txRegisterReceipt.events[0])
+    expect(registerEvent.name).to.be.equal('OracleRegistered')
+    expect(registerEvent.args['oracle']).to.be.equal(oracle)
+
+    // Deregistration
+    const txDeregisterReceipt = await (await coordinatorContract.deregisterOracle(oracle)).wait()
+    expect(txDeregisterReceipt.events.length).to.be.equal(1)
+    const deregisterEvent = coordinatorContract.interface.parseLog(txDeregisterReceipt.events[0])
+    expect(deregisterEvent.name).to.be.equal('OracleDeregistered')
+    expect(deregisterEvent.args['oracle']).to.be.equal(oracle)
+  })
 })

--- a/contracts/test/v0.1/RequestResponseCoordinator.test.ts
+++ b/contracts/test/v0.1/RequestResponseCoordinator.test.ts
@@ -31,6 +31,7 @@ describe('RequestResponseCoordinator', function () {
     const { coordinatorContract } = await loadFixture(deployFixture)
     const { address: oracle1 } = ethers.Wallet.createRandom()
     const { address: oracle2 } = ethers.Wallet.createRandom()
+    expect(oracle1).to.not.be.equal(oracle2)
 
     // Register oracle 1
     const txReceipt = await (await coordinatorContract.registerOracle(oracle1)).wait()

--- a/contracts/test/v0.1/RequestResponseCoordinator.test.ts
+++ b/contracts/test/v0.1/RequestResponseCoordinator.test.ts
@@ -1,0 +1,56 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+import { ethers } from 'hardhat'
+
+describe('RequestResponseCoordinator', function () {
+  async function deployFixture() {
+    const { deployer, consumer, rrOracle0 } = await hre.getNamedAccounts()
+
+    // PREPAYMENT
+    let prepaymentContract = await ethers.getContractFactory('Prepayment', {
+      signer: deployer
+    })
+    prepaymentContract = await prepaymentContract.deploy()
+    await prepaymentContract.deployed()
+
+    // COORDINATOR
+    let coordinatorContract = await ethers.getContractFactory('RequestResponseCoordinator', {
+      signer: deployer
+    })
+    coordinatorContract = await coordinatorContract.deploy(prepaymentContract.address)
+    await coordinatorContract.deployed()
+
+    return {
+      deployer,
+      coordinatorContract
+    }
+  }
+
+  it('should register oracle', async function () {
+    const { coordinatorContract } = await loadFixture(deployFixture)
+    const { address: oracle1 } = ethers.Wallet.createRandom()
+    const { address: oracle2 } = ethers.Wallet.createRandom()
+
+    // Register oracle 1
+    const txReceipt = await (await coordinatorContract.registerOracle(oracle1)).wait()
+    expect(txReceipt.events.length).to.be.equal(1)
+    const registerEvent = coordinatorContract.interface.parseLog(txReceipt.events[0])
+    expect(registerEvent.name).to.be.equal('OracleRegistered')
+    expect(registerEvent.args['oracle']).to.be.equal(oracle1)
+
+    // Register oracle 2
+    await (await coordinatorContract.registerOracle(oracle2)).wait()
+  })
+
+  it('should not allow to register the same oracle twice', async function () {
+    const { coordinatorContract } = await loadFixture(deployFixture)
+    const { address: oracle } = ethers.Wallet.createRandom()
+
+    await (await coordinatorContract.registerOracle(oracle)).wait()
+    await expect(coordinatorContract.registerOracle(oracle)).to.be.revertedWithCustomError(
+      coordinatorContract,
+      'OracleAlreadyRegistered'
+    )
+  })
+})

--- a/contracts/test/v0.1/VRF.test.ts
+++ b/contracts/test/v0.1/VRF.test.ts
@@ -87,6 +87,8 @@ describe('VRF contract', function () {
     const { address: oracle2 } = ethers.Wallet.createRandom()
     const publicProvingKey1 = [generateDummyPublicProvingKey(), generateDummyPublicProvingKey()]
     const publicProvingKey2 = [generateDummyPublicProvingKey(), generateDummyPublicProvingKey()]
+    expect(oracle1).to.not.be.equal(oracle2)
+    expect(publicProvingKey1).to.not.be.equal(publicProvingKey2)
 
     // Registration
     await (await coordinatorContract.registerOracle(oracle1, publicProvingKey1)).wait()

--- a/contracts/test/v0.1/VRF.test.ts
+++ b/contracts/test/v0.1/VRF.test.ts
@@ -132,9 +132,8 @@ describe('VRF contract', function () {
     expect(txDeregisterReceipt.events.length).to.be.equal(1)
     const deregisterEvent = coordinatorContract.interface.parseLog(txDeregisterReceipt.events[0])
     expect(deregisterEvent.name).to.be.equal('OracleDeregistered')
-
-    expect(registerEvent.args['oracle']).to.be.equal(oracle)
-    expect(registerEvent.args['keyHash']).to.be.equal(kh)
+    expect(deregisterEvent.args['oracle']).to.be.equal(oracle)
+    expect(deregisterEvent.args['keyHash']).to.be.equal(kh)
   })
 
   it('requestRandomWords should revert on InvalidKeyHash', async function () {

--- a/contracts/test/v0.1/VRF.test.ts
+++ b/contracts/test/v0.1/VRF.test.ts
@@ -95,7 +95,7 @@ describe('VRF contract', function () {
       feeConfig
     } = vrfConfig()
 
-    await coordinatorContract.registerProvingKey(oracle, publicProvingKey)
+    await coordinatorContract.registerOracle(oracle, publicProvingKey)
 
     await coordinatorContract.setConfig(
       maxGasLimit,


### PR DESCRIPTION
# Description

This PR changes the way how Coordinator registers and deregisters oracles. This change will give more direct access to registered metadata. The interface changes, therefore the version of `@bisonai/orakl-contracts` is bumped to 0.5.0.

## `VRFCoordinator` access points

* `sOracles()` -> `address[]`
* `oracleToKeyHash(address oracle)` -> `bytes32`
* `sKeyHashes()` -> `bytes32[]`
* `keyHashToOracle(bytes32 keyHash)` -> `address`

## `RequestResponseCoordinator`

* `sOracles()` -> `address[]`
* `isOracleRegistered` -> `bool`

## Others

* Change order of functions within `*Coordinator` files based on Solidity guidelines for visibility
* Remove `s_` prefix pattern from `*Coordinator` files
* Updated VRF migration script for registration and deregistration of oracle

## Subgraph

The VRF events below has to be updated in https://github.com/bisonai/orakl-subgraph through https://github.com/Bisonai/orakl/issues/478

* `event ProvingKeyRegistered(bytes32 keyHash, address indexed oracle)` -> `event OracleRegistered(address indexed oracle, bytes32 keyHash)`
* `event ProvingKeyDeregistered(bytes32 keyHash, address indexed oracle)` -> `event OracleDeregistered(address indexed oracle, bytes32 keyHash)`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [x] Should publish npm package
- [x] Should publish Docker image
