### PR TITLE
Graceful shutdown for all services

### DIFF
--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -53,7 +53,6 @@ export async function buildListener(
 
   const watchmanServer = await watchman({ listenFn, state, logger })
 
-  // Graceful shutdown
   async function handleExit() {
     logger.info('Exiting. Wait for graceful shutdown.')
 

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -63,8 +63,6 @@ export async function buildListener(
   }
   process.on('SIGINT', handleExit)
   process.on('SIGTERM', handleExit)
-
-  logger.debug('Listener launched')
 }
 
 async function processEvent(iface: ethers.utils.Interface, queue: Queue, _logger: Logger) {

--- a/core/src/listener/main.ts
+++ b/core/src/listener/main.ts
@@ -43,6 +43,8 @@ async function main() {
   await redisClient.connect()
 
   LISTENERS[service](listenersConfig[service], redisClient, LOGGER)
+
+  LOGGER.info('Listener launched')
 }
 
 function loadArgs(): string {

--- a/core/src/listener/request-response.ts
+++ b/core/src/listener/request-response.ts
@@ -58,8 +58,6 @@ export async function buildListener(
   }
   process.on('SIGINT', handleExit)
   process.on('SIGTERM', handleExit)
-
-  logger.debug('Listener launched')
 }
 
 async function processEvent(iface: ethers.utils.Interface, queue: Queue, _logger: Logger) {

--- a/core/src/listener/request-response.ts
+++ b/core/src/listener/request-response.ts
@@ -48,7 +48,6 @@ export async function buildListener(
 
   const watchmanServer = await watchman({ listenFn, state, logger })
 
-  // Graceful shutdown
   async function handleExit() {
     logger.info('Exiting. Wait for graceful shutdown.')
 

--- a/core/src/worker/data-feed.ts
+++ b/core/src/worker/data-feed.ts
@@ -123,7 +123,6 @@ export async function worker(redisClient: RedisClientType, _logger: Logger) {
 
   const watchmanServer = await watchman({ state, logger })
 
-  // Graceful shutdown
   async function handleExit() {
     logger.info('Exiting. Wait for graceful shutdown.')
 
@@ -136,8 +135,6 @@ export async function worker(redisClient: RedisClientType, _logger: Logger) {
   }
   process.on('SIGINT', handleExit)
   process.on('SIGTERM', handleExit)
-
-  logger.debug('Worker launched')
 }
 
 /**

--- a/core/src/worker/main.ts
+++ b/core/src/worker/main.ts
@@ -27,6 +27,8 @@ async function main() {
 
   WORKERS[worker](redisClient, LOGGER)
 
+  LOGGER.info('Worker launched')
+
   // TODO later replace with watchman after it becomes utilized in every service
   launchHealthCheck()
 }

--- a/core/src/worker/vrf.ts
+++ b/core/src/worker/vrf.ts
@@ -16,12 +16,21 @@ import { remove0x } from '../utils'
 const FILE_NAME = import.meta.url
 
 export async function worker(redisClient: RedisClientType, _logger: Logger) {
-  _logger.debug({ name: 'worker', file: FILE_NAME })
-  new Worker(
+  const logger = _logger.child({ name: 'worker', file: FILE_NAME })
+  const worker = new Worker(
     WORKER_VRF_QUEUE_NAME,
     await vrfJob(REPORTER_VRF_QUEUE_NAME, _logger),
     BULLMQ_CONNECTION
   )
+
+  async function handleExit() {
+    logger.info('Exiting. Wait for graceful shutdown.')
+
+    await redisClient.quit()
+    await worker.close()
+  }
+  process.on('SIGINT', handleExit)
+  process.on('SIGTERM', handleExit)
 }
 
 async function vrfJob(queueName: string, _logger: Logger) {


### PR DESCRIPTION
# Description

This PR adds a graceful shutdown for VRF and Request-Response worker and listener. Reporter is going to be updated soon to more general version #483  therefore it is not necessary to define it for VRF and Request-Response.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Deployment

- [x] Should publish Docker image
