### PR TITLE
Check on data staleness to prevent submitting outdated data

### DIFF
--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -31,6 +31,9 @@ export const DATA_FEED_SERVICE_NAME = 'Aggregator'
 export const VRF_SERVICE_NAME = 'VRF'
 export const REQUEST_RESPONSE_SERVICE_NAME = 'RequestResponse'
 
+// Data Feed
+export const MAX_DATA_STALENESS = 5_000
+
 // BullMQ
 export const REMOVE_ON_COMPLETE = 500
 export const REMOVE_ON_FAIL = 1_000

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -284,7 +284,7 @@ export interface IAggregator {
 
 export interface IAggregate {
   id: bigint
-  timestamp: string | Date
+  timestamp: string
   value: bigint
   aggregatorId: bigint
 }

--- a/core/src/worker/api.ts
+++ b/core/src/worker/api.ts
@@ -15,7 +15,7 @@ export const AGGREGATOR_ENDPOINT = buildUrl(ORAKL_NETWORK_API_URL, 'aggregator')
  *
  * @param {string} aggregator hash
  * @param {Logger} logger
- * @return {number} the latest aggregated value
+ * @return {IAggregate} metadata about the latest aggregate
  * @exception {FailedToGetAggregate}
  */
 export async function fetchDataFeed({
@@ -27,8 +27,7 @@ export async function fetchDataFeed({
 }): Promise<IAggregate> {
   try {
     const url = buildUrl(AGGREGATE_ENDPOINT, `${aggregatorHash}/latest`)
-    const response = (await axios.get(url))?.data
-    return response
+    return (await axios.get(url))?.data
   } catch (e) {
     logger.error(e)
     throw new OraklError(OraklErrorCode.FailedToGetAggregate)

--- a/core/src/worker/data-feed.ts
+++ b/core/src/worker/data-feed.ts
@@ -173,7 +173,7 @@ function aggregatorJob(submitHeartbeatQueue: Queue, reporterQueue: Queue, _logge
       })
 
       const { timestamp, value: submission } = await fetchDataFeed({ aggregatorHash, logger })
-      logger.debug({ aggregatorHash, timestamp, submission }, 'Latest data aggregate')
+      logger.debug({ aggregatorHash, fetchedAt: timestamp, submission }, 'Latest data aggregate')
 
       // Submit heartbeat
       const outDataSubmitHeartbeat: IAggregatorSubmitHeartbeatWorker = {


### PR DESCRIPTION
# Description

This PR adds a check on data staleness to a Data Feed worker. If aggregated data are older than `MAX_DATA_STALENESS` (currently set to 5 seconds), then worker does not submit a job to reporter. The submission to heartbeat queue proceeds as usual.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Deployment

- [x] Should publish Docker image
