### PR TITLE
fix git actions deprecated warning

### DIFF
--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -60,7 +60,7 @@ jobs:
         run:  docker-compose -f api/docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.ROLE_ARN }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -9,6 +9,10 @@ on:
     types:
       - closed
 
+  push:
+    branches:
+      - i-496/fix-git-actions-for-version
+
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
 

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "::set-output name=version::$(node -p -e "require('./api/package.json').version")"
+          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
           
   build:
     name: Build
@@ -60,7 +60,7 @@ jobs:
         run:  docker-compose -f api/docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.ROLE_ARN }}

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -9,10 +9,6 @@ on:
     types:
       - closed
 
-  push:
-    branches:
-      - i-496/fix-git-actions-for-version
-
 env:
   ecr_url: public.ecr.aws/u6t6w0e4/orakl-api
 

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "::set-output name=version::$(node -p -e "require('./cli/package.json').version")"
+          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
+          echo "name=version::$(node -p -e "require('./cli/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
+          echo "name=version::$(node -p -e "require('./core/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "::set-output name=version::$(node -p -e "require('./core/package.json').version")"
+          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
+          echo "name=version::$(node -p -e "require('./fetcher/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "::set-output name=version::$(node -p -e "require('./fetcher/package.json').version")"
+          echo "name=version::$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
 
   build:
     name: Build


### PR DESCRIPTION
# Description

There is currently an issue with the aws credentials in Git Actions not being updated after switching from SDK version 2 to 3. Although version 2 is still working, it is in maintenance mode, so it's unclear whether it will continue to work properly. However, the credentials are still being received correctly when pushing to the repository in myside.
It may be helpful for you to try again to see this was temporary or not.

 Additionally, the warning (deprecated) that was raised is unrelated to the credentials issue but fixed with this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
