### PR TITLE
Increase Orakl Network Fetcher concurrency to 5

### DIFF
--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -3,7 +3,7 @@ import { InjectQueue } from '@nestjs/bullmq'
 import { Queue } from 'bullmq'
 import { extractFeeds } from './job.utils'
 import { loadAggregator, activateAggregator, deactivateAggregator } from './job.api'
-import { FETCHER_QUEUE_NAME } from '../settings'
+import { FETCHER_QUEUE_NAME, FETCH_FREQUENCY } from '../settings'
 
 @Controller({
   version: '1'
@@ -34,7 +34,7 @@ export class JobController {
     // Launch recurrent data collection
     await this.queue.add(aggregatorHash, feeds, {
       repeat: {
-        every: 2_000 // FIXME load env settings
+        every: FETCH_FREQUENCY
       },
       removeOnComplete: true,
       removeOnFail: true

--- a/fetcher/src/job/job.processor.ts
+++ b/fetcher/src/job/job.processor.ts
@@ -4,8 +4,9 @@ import { Job } from 'bullmq'
 import { FetcherError, FetcherErrorCode } from './job.errors'
 import { fetchData, aggregateData } from './job.utils'
 import { insertMultipleData, insertAggregateData } from './job.api'
+import { WORKER_OPTS } from '../settings'
 
-@Processor('orakl-fetcher-queue')
+@Processor('orakl-fetcher-queue', WORKER_OPTS)
 export class JobProcessor extends WorkerHost {
   private readonly logger = new Logger(JobProcessor.name)
 

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -1,1 +1,5 @@
 export const FETCHER_QUEUE_NAME = 'orakl-fetcher-queue'
+
+export const WORKER_OPTS = { concurrency: 5 }
+
+export const FETCH_FREQUENCY = 2_000


### PR DESCRIPTION
# Description

Repeatable job of Orakl Network fetcher seems to be limited by sequential processing of jobs from queue. This PR increases the concurrency of job processing to 5. We expect to see increased processing speed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.