### PR TITLE
Check for a validity of a `consumer` under `accId`

### DIFF
--- a/contracts/src/v0.1/Prepayment.sol
+++ b/contracts/src/v0.1/Prepayment.sol
@@ -197,13 +197,11 @@ contract Prepayment is Ownable, IPrepayment, ITypeAndVersion {
     /**
      * @inheritdoc IPrepayment
      */
-    function isValidAccount(uint64 accId) external view returns (bool) {
-        Account account = sAccIdToAccount[accId];
-        if (address(account) != address(0) || sIsTemporaryAccount[accId]) {
-            return true;
-        } else {
-            revert InvalidAccount();
-        }
+    function isValid(uint64 accId, address consumer) external view returns (bool) {
+        bool isValidRegular = sAccIdToAccount[accId].getNonce(consumer) != 0;
+        bool isValidTemporary = sAccIdToTmpAcc[accId].owner == msg.sender;
+
+        return isValidRegular || isValidTemporary;
     }
 
     /**
@@ -255,12 +253,7 @@ contract Prepayment is Ownable, IPrepayment, ITypeAndVersion {
      * @inheritdoc IPrepayment
      */
     function getNonce(uint64 accId, address consumer) external view returns (uint64) {
-        Account account = sAccIdToAccount[accId];
-        if (address(account) != address(0)) {
-            return sAccIdToAccount[accId].getNonce(consumer);
-        } else {
-            return 1;
-        }
+        return sAccIdToAccount[accId].getNonce(consumer);
     }
 
     /**

--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -368,13 +368,7 @@ contract RequestResponseCoordinator is
         uint32 callbackGasLimit,
         bool isDirectPayment
     ) internal returns (uint256) {
-        sPrepayment.isValidAccount(accId);
-
-        // Its important to ensure that the consumer is in fact who they say they
-        // are, otherwise they could use someone else's account balance.
-        // A nonce of 0 indicates consumer is not allocated to the acc.
-        uint64 currentNonce = sPrepayment.getNonce(accId, msg.sender);
-        if (currentNonce == 0) {
+        if (!sPrepayment.isValid(accId, msg.sender)) {
             revert InvalidConsumer(accId, msg.sender);
         }
 

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -482,16 +482,11 @@ contract VRFCoordinator is Ownable, ICoordinatorBase, ITypeAndVersion, IVRFCoord
         uint32 numWords,
         bool isDirectPayment
     ) internal returns (uint256) {
-        sPrepayment.isValidAccount(accId);
-
-        // Its important to ensure that the consumer is in fact who they say they
-        // are, otherwise they could use someone else's account balance.
-        // A nonce of 0 indicates consumer is not allocated to the acc.
-        uint64 currentNonce = sPrepayment.getNonce(accId, msg.sender);
-        if (currentNonce == 0) {
+        if (!sPrepayment.isValid(accId, msg.sender)) {
             revert InvalidConsumer(accId, msg.sender);
         }
 
+        // TODO update comment
         // No lower bound on the requested gas limit. A user could request 0
         // and they would simply be billed for the proof verification and wouldn't be
         // able to do anything with the random value.

--- a/contracts/src/v0.1/interfaces/IPrepayment.sol
+++ b/contracts/src/v0.1/interfaces/IPrepayment.sol
@@ -7,12 +7,13 @@ interface IPrepayment {
     /// READ-ONLY FUNCTIONS /////////////////////////////////////////////////////
 
     /**
-     * @notice Returns `true` when given `accId` is valid, otherwise reverts.
+     * @notice Returns `true` when a `consumer` is registered under
+     * @notice `accId`, otherwise returns `false`.
      * @dev This function can be used for checking validity of both
      * @dev [regular] and [temporary] account.
      * @param accId - ID of the account
      */
-    function isValidAccount(uint64 accId) external view returns (bool);
+    function isValid(uint64 accId, address consumer) external view returns (bool);
 
     /**
      * @notice Returns the balance of given account.
@@ -61,13 +62,11 @@ interface IPrepayment {
 
     /**
      * @notice Get nonce for specified `consumer` in account denoted by `accId`.
-     * @dev This function is meant to be used for both [regular] and
-     * @dev [temporary] account. In case of [regular] account, we keep
-     * @dev track of nonces for every consumer inside of the
-     * @dev account. [temporary] account is expected to be used only
-     * @dev once, therefore we do not keep track of nonce, and always return 1.
-     * @dev We do not check on validity of the `accId`, therefore when
-     * @dev a an invalid `accId` is passed, nonce equal to 1 is returned.
+     * @dev This function is meant to be used only for [regular]
+     * @dev account. [temporary] account does not have a notion of a nonce.
+     * @dev When an invalid `accId` is passed, transaction is
+     * @dev reverted. When an invalid `consumer` is passed, 0 zero
+     * @dev nonce is returned that represents an unregistered consumer.
      * @param accId - ID of the account
      * @param consumer - consumer address
      */


### PR DESCRIPTION
# Description

This PR changes a way how we check for a registered consumer under a specific amount. Previously, we used a clumsy way through nonce which is still used under the hood but now we support validity for both `regular` and `temporary` accounts with a simpler expression.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.