### PR TITLE
remove `serviceId` from Reporter table

### DIFF
--- a/api/prisma/migrations/20230419030642_reporter_remove_serviceId_from_unique/migration.sql
+++ b/api/prisma/migrations/20230419030642_reporter_remove_serviceId_from_unique/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[address,chain_id]` on the table `reporters` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "reporters_address_chain_id_service_id_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reporters_address_chain_id_key" ON "reporters"("address", "chain_id");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -99,20 +99,20 @@ model Aggregator {
 }
 
 model Data {
-  id           BigInt      @id @default(autoincrement()) @map("data_id")
-  timestamp    DateTime    @db.Timestamptz
+  id           BigInt     @id @default(autoincrement()) @map("data_id")
+  timestamp    DateTime   @db.Timestamptz
   value        BigInt
   aggregator   Aggregator @relation(fields: [aggregatorId], references: [id], onDelete: Cascade)
   aggregatorId BigInt     @map("aggregator_id")
-  feed         Feed        @relation(fields: [feedId], references: [id])
-  feedId       BigInt      @map("feed_id")
+  feed         Feed       @relation(fields: [feedId], references: [id])
+  feedId       BigInt     @map("feed_id")
 
   @@map("data")
 }
 
 model Aggregate {
-  id           BigInt      @id @default(autoincrement()) @map("aggregate_id")
-  timestamp    DateTime    @db.Timestamptz
+  id           BigInt     @id @default(autoincrement()) @map("aggregate_id")
+  timestamp    DateTime   @db.Timestamptz
   value        BigInt
   aggregator   Aggregator @relation(fields: [aggregatorId], references: [id], onDelete: Cascade)
   aggregatorId BigInt     @map("aggregator_id")
@@ -131,6 +131,6 @@ model Reporter {
   service       Service @relation(fields: [serviceId], references: [id])
   serviceId     BigInt  @map("service_id")
 
-  @@unique([address, chainId, serviceId])
+  @@unique([address, chainId])
   @@map("reporters")
 }


### PR DESCRIPTION
# Description

This PR is to change uniqueness of Reporter, which is to force make unique `reporter` in each `chain` for all types of services. Previously, it was allowed to use same reporter for different services.  

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
