### PR TITLE
Majority voting for Boolean

### DIFF
--- a/contracts/src/v0.1/libraries/MajorityVoting.sol
+++ b/contracts/src/v0.1/libraries/MajorityVoting.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.16;
 
 library MajorityVoting {
-    function calculateBool(bool[] memory list) {
+    error EvenLengthList();
+
+    function voting(bool[] memory list) pure internal returns(bool) {
+        if (list.length % 2 == 0) {
+            revert EvenLengthList();
+        }
         uint256 trueCount = 0;
         uint256 falseCount = 0;
 

--- a/contracts/src/v0.1/libraries/MajorityVoting.sol
+++ b/contracts/src/v0.1/libraries/MajorityVoting.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+library MajorityVoting {
+    function calculateBool(bool[] memory list) {
+        uint256 trueCount = 0;
+        uint256 falseCount = 0;
+
+        for (uint256 i; i < list.length; ++i) {
+            if (list[i] == true) {
+                trueCount++;
+            } else {
+                falseCount++;
+            }
+        }
+
+        if (trueCount >= falseCount) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/src/v0.1/libraries/MajorityVoting.sol
+++ b/contracts/src/v0.1/libraries/MajorityVoting.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.16;
 library MajorityVoting {
     error EvenLengthList();
 
-    function voting(bool[] memory list) pure internal returns(bool) {
+    function voting(bool[] memory list) internal pure returns (bool) {
         if (list.length % 2 == 0) {
             revert EvenLengthList();
         }
-        uint256 trueCount = 0;
-        uint256 falseCount = 0;
+        uint256 trueCount;
+        uint256 falseCount;
 
         for (uint256 i; i < list.length; ++i) {
-            if (list[i] == true) {
+            if (list[i]) {
                 trueCount++;
             } else {
                 falseCount++;

--- a/contracts/src/v0.1/mocks/MajorityVotingMock.sol
+++ b/contracts/src/v0.1/mocks/MajorityVotingMock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "../libraries/MajorityVoting.sol";
+
+contract MajorityVotingMock {
+    function voting(bool[] memory arr) external pure returns (bool) {
+        return MajorityVoting.voting(arr);
+    }
+}

--- a/contracts/test/v0.1/MajorityVoting.test.cjs
+++ b/contracts/test/v0.1/MajorityVoting.test.cjs
@@ -1,0 +1,47 @@
+const { expect } = require('chai')
+const { ethers } = require('hardhat')
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers')
+
+async function deploy() {
+  let contract = await ethers.getContractFactory('MajorityVotingMock', {})
+  contract = await contract.deploy()
+  await contract.deployed()
+
+  return { contract }
+}
+
+describe('MajorityVoting', function () {
+  it('Single true value', async function () {
+    const { contract } = await loadFixture(deploy)
+    const arr = [true]
+    const res = true
+    expect(await contract.voting(arr)).to.be.equal(res)
+  })
+
+  it('Single false value', async function () {
+    const { contract } = await loadFixture(deploy)
+    const arr = [false]
+    const res = false
+    expect(await contract.voting(arr)).to.be.equal(res)
+  })
+
+  it('List cannot be of even length', async function () {
+    const { contract } = await loadFixture(deploy)
+    const arr = [true, false]
+    await expect(contract.voting(arr)).to.be.revertedWithCustomError(contract, 'EvenLengthList')
+  })
+
+  it('True majority', async function () {
+    const { contract } = await loadFixture(deploy)
+    const arr = [true, false, true]
+    const res = true
+    expect(await contract.voting(arr)).to.be.equal(res)
+  })
+
+  it('False majority', async function () {
+    const { contract } = await loadFixture(deploy)
+    const arr = [true, false, false]
+    const res = false
+    expect(await contract.voting(arr)).to.be.equal(res)
+  })
+})


### PR DESCRIPTION
# Description

This PR implemented majority voting library for `boolean` data type. Majority voting can be applied only on boolean arrays of even length. If odd length array is passed to the library function, `EvenLenghtArray` error will be thrown.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
