### PR TITLE
remove reporter uniqueness from `Reporter`

### DIFF
--- a/api/prisma/migrations/20230421082517_remove_reporter_uniqueness/migration.sql
+++ b/api/prisma/migrations/20230421082517_remove_reporter_uniqueness/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "reporters_address_chain_id_key";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -131,6 +131,5 @@ model Reporter {
   service       Service @relation(fields: [serviceId], references: [id])
   serviceId     BigInt  @map("service_id")
 
-  @@unique([address, chainId])
   @@map("reporters")
 }


### PR DESCRIPTION
# Description

This PR is to remove uniqueness from Reporter table. 

We need to remove uniqueness of reporter address to be able to use same data feed, but for two different aggregators.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
