### PR TITLE
Don't allow to submit to Request-Response coordinator twice for the same request

### DIFF
--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -19,6 +19,15 @@ contract RequestResponseCoordinator is
 
     using Orakl for Orakl.Request;
 
+    struct Submission {
+        address[] oracles; // oracles that submitted response
+        mapping(address => bool) submitted;
+    }
+
+    /* request ID */
+    /* submission details */
+    mapping(uint256 => Submission) sSubmission;
+
     /* oracle */
     /* registration status */
     mapping(address => bool) private sIsOracleRegistered;
@@ -26,10 +35,6 @@ contract RequestResponseCoordinator is
     /* jobId */
     /* ability to request for the job */
     mapping(bytes32 => bool) private sJobId;
-
-    /* request ID */
-    /* oracle submission participants */
-    mapping(uint256 => address[]) private sRequestToOracles;
 
     mapping(uint256 => int256[]) private sRequestToSubmissionInt256;
     mapping(uint256 => uint256[]) private sRequestToSubmissionUint256;
@@ -39,6 +44,7 @@ contract RequestResponseCoordinator is
     error UnregisteredOracleFulfillment(address oracle);
     error InvalidJobId();
     error InvalidNumSubmission();
+    error OracleAlreadySubmitted();
 
     event OracleRegistered(address oracle);
     event OracleDeregistered(address oracle);
@@ -217,8 +223,10 @@ contract RequestResponseCoordinator is
         validateDataResponse(rc, requestId);
 
         uint256[] storage arrRes = sRequestToSubmissionUint256[requestId];
-        address[] storage oracles = sRequestToOracles[requestId];
         arrRes.push(response);
+
+        sSubmission[requestId].submitted[msg.sender] = true;
+        address[] storage oracles = sSubmission[requestId].oracles;
         oracles.push(msg.sender);
 
         if (arrRes.length < rc.numSubmission) {
@@ -252,9 +260,11 @@ contract RequestResponseCoordinator is
         uint256 startGas = gasleft();
         validateDataResponse(rc, requestId);
 
+        sSubmission[requestId].submitted[msg.sender] = true;
         int256[] storage arrRes = sRequestToSubmissionInt256[requestId];
-        address[] storage oracles = sRequestToOracles[requestId];
         arrRes.push(response);
+
+        address[] storage oracles = sSubmission[requestId].oracles;
         oracles.push(msg.sender);
 
         if (arrRes.length < rc.numSubmission) {
@@ -287,9 +297,11 @@ contract RequestResponseCoordinator is
         uint256 startGas = gasleft();
         validateDataResponse(rc, requestId);
 
+        sSubmission[requestId].submitted[msg.sender] = true;
         bool[] storage arrRes = sRequestToSubmissionBool[requestId];
-        address[] storage oracles = sRequestToOracles[requestId];
         arrRes.push(response);
+
+        address[] storage oracles = sSubmission[requestId].oracles;
         oracles.push(msg.sender);
 
         if (arrRes.length < rc.numSubmission) {
@@ -321,15 +333,16 @@ contract RequestResponseCoordinator is
         uint256 startGas = gasleft();
         validateDataResponse(rc, requestId);
 
+        sSubmission[requestId].submitted[msg.sender] = true;
+        address[] storage oracles = sSubmission[requestId].oracles;
+        oracles.push(msg.sender);
+
         bytes memory resp = abi.encodeWithSelector(
             RequestResponseConsumerFulfillString.rawFulfillDataRequest.selector,
             requestId,
             response
         );
         bool success = fulfill(resp, rc);
-
-        address[] storage oracles = sRequestToOracles[requestId];
-        oracles.push(msg.sender);
         uint256 payment = pay(rc, isDirectPayment, startGas, oracles);
 
         cleanupAfterFulfillment(requestId);
@@ -346,15 +359,16 @@ contract RequestResponseCoordinator is
         uint256 startGas = gasleft();
         validateDataResponse(rc, requestId);
 
+        sSubmission[requestId].submitted[msg.sender] = true;
+        address[] storage oracles = sSubmission[requestId].oracles;
+        oracles.push(msg.sender);
+
         bytes memory resp = abi.encodeWithSelector(
             RequestResponseConsumerFulfillBytes32.rawFulfillDataRequest.selector,
             requestId,
             response
         );
         bool success = fulfill(resp, rc);
-
-        address[] storage oracles = sRequestToOracles[requestId];
-        oracles.push(msg.sender);
         uint256 payment = pay(rc, isDirectPayment, startGas, oracles);
 
         cleanupAfterFulfillment(requestId);
@@ -371,15 +385,16 @@ contract RequestResponseCoordinator is
         uint256 startGas = gasleft();
         validateDataResponse(rc, requestId);
 
+        sSubmission[requestId].submitted[msg.sender] = true;
+        address[] storage oracles = sSubmission[requestId].oracles;
+        oracles.push(msg.sender);
+
         bytes memory resp = abi.encodeWithSelector(
             RequestResponseConsumerFulfillBytes.rawFulfillDataRequest.selector,
             requestId,
             response
         );
         bool success = fulfill(resp, rc);
-
-        address[] storage oracles = sRequestToOracles[requestId];
-        oracles.push(msg.sender);
         uint256 payment = pay(rc, isDirectPayment, startGas, oracles);
 
         cleanupAfterFulfillment(requestId);
@@ -486,6 +501,10 @@ contract RequestResponseCoordinator is
             revert UnregisteredOracleFulfillment(msg.sender);
         }
 
+        if (sSubmission[requestId].submitted[msg.sender]) {
+            revert OracleAlreadySubmitted();
+        }
+
         bytes32 commitment = sRequestIdToCommitment[requestId];
         if (commitment == 0) {
             revert NoCorrespondingRequest();
@@ -572,7 +591,13 @@ contract RequestResponseCoordinator is
     }
 
     function cleanupAfterFulfillment(uint256 requestId) private {
-        delete sRequestToOracles[requestId];
+        address[] memory oracles = sSubmission[requestId].oracles;
+
+        for (uint8 i = 0; i < oracles.length; ++i) {
+            delete sSubmission[requestId].submitted[oracles[i]];
+        }
+
+        delete sSubmission[requestId];
         delete sRequestIdToCommitment[requestId];
         delete sRequestOwner[requestId];
     }

--- a/contracts/test/v0.1/RequestResponseConsumerContract.test.cjs
+++ b/contracts/test/v0.1/RequestResponseConsumerContract.test.cjs
@@ -286,6 +286,12 @@ async function requestAndFulfill(
     fulfillReceipt = await (
       await fulfillFn[i](_requestId, fulfillValue[i], requestCommitment, isDirectPayment)
     ).wait()
+
+    if (numSubmission > 1 && i < numSubmission - 1) {
+      await expect(
+        fulfillFn[i](_requestId, fulfillValue[i], requestCommitment, isDirectPayment)
+      ).to.be.revertedWithCustomError(state.coordinatorContract, 'OracleAlreadySubmitted')
+    }
   }
 
   const responseValue = aggregateSubmissions(fulfillValue, dataType)
@@ -577,9 +583,7 @@ describe('Request-Response user contract', function () {
     expect(requestId).to.be.equal(cRequestId)
   })
 
-  // TODO deregister oracle
   // TODO getters
-  // TODO set direct payment config
   // TODO pending request exist
   // TODO invalid consumer
   // TODO gas limit too big


### PR DESCRIPTION
# Description

Recent changes to Request-Response that implemented submission by multiple oracles did not include a constraints on a single submission per oracle to a single request. This PR implements those constraints together with tests.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.