### PR TITLE
Allow to register multiple reporters in VRF to enable better off-chain scaling

### DIFF
--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -17,13 +17,18 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
 
     bytes32[] public sKeyHashes;
 
+    struct Oracle {
+        bool registered;
+        address[] oracles;
+    }
+
+    /* keyHash */
+    /* Oracle */
+    mapping(bytes32 => Oracle) private sKeyHashToOracle;
+
     /* oracle */
     /* keyHash */
     mapping(address => bytes32) private sOracleToKeyHash;
-
-    /* keyHash */
-    /* oracle */
-    mapping(bytes32 => address) private sKeyHashToOracle;
 
     // RequestCommitment holds information sent from off-chain oracle
     // describing details of request.
@@ -37,7 +42,6 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
 
     error InvalidKeyHash(bytes32 keyHash);
     error NumWordsTooBig(uint32 have, uint32 want);
-    error ProvingKeyAlreadyRegistered(bytes32 keyHash);
     error NoSuchProvingKey(bytes32 keyHash);
 
     event OracleRegistered(address indexed oracle, bytes32 keyHash);
@@ -61,7 +65,7 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
     event PrepaymentSet(address prepayment);
 
     modifier onlyValidKeyHash(bytes32 keyHash) {
-        if (sKeyHashToOracle[keyHash] == address(0)) {
+        if (!sKeyHashToOracle[keyHash].registered) {
             revert InvalidKeyHash(keyHash);
         }
         _;
@@ -86,14 +90,13 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
         }
 
         bytes32 kh = hashOfKey(publicProvingKey);
-        if (sKeyHashToOracle[kh] != address(0)) {
-            revert ProvingKeyAlreadyRegistered(kh);
+        if (!sKeyHashToOracle[kh].registered) {
+            sKeyHashToOracle[kh].registered = true;
+            sKeyHashes.push(kh);
         }
 
-        sOracles.push(oracle);
-        sKeyHashes.push(kh);
+        sKeyHashToOracle[kh].oracles.push(oracle);
         sOracleToKeyHash[oracle] = kh;
-        sKeyHashToOracle[kh] = oracle;
 
         emit OracleRegistered(oracle, kh);
     }
@@ -104,24 +107,29 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
      */
     function deregisterOracle(address oracle) external onlyOwner {
         bytes32 kh = sOracleToKeyHash[oracle];
-        if (kh == bytes32(0) || sKeyHashToOracle[kh] == address(0)) {
+        if (kh == bytes32(0) || !sKeyHashToOracle[kh].registered) {
             revert NoSuchOracle(oracle);
         }
         delete sOracleToKeyHash[oracle];
-        delete sKeyHashToOracle[kh];
 
-        uint256 oraclesLength = sOracles.length;
+        address[] storage oracles = sKeyHashToOracle[kh].oracles;
+        uint256 oraclesLength = oracles.length;
         for (uint256 i; i < oraclesLength; ++i) {
-            if (sOracles[i] == oracle) {
+            if (oracles[i] == oracle) {
                 // oracles
-                address lastOracle = sOracles[oraclesLength - 1];
-                sOracles[i] = lastOracle;
-                sOracles.pop();
+                address lastOracle = oracles[oraclesLength - 1];
+                oracles[i] = lastOracle;
+                oracles.pop();
 
                 // key hashes
-                bytes32 lastKeyHash = sKeyHashes[oraclesLength - 1];
-                sKeyHashes[i] = lastKeyHash;
-                sKeyHashes.pop();
+                if (oraclesLength == 1) {
+                    bytes32 lastKeyHash = sKeyHashes[oraclesLength - 1];
+                    sKeyHashes[i] = lastKeyHash;
+                    sKeyHashes.pop();
+
+                    delete sKeyHashToOracle[kh];
+                }
+
                 break;
             }
         }
@@ -214,10 +222,7 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
         bool isDirectPayment
     ) external nonReentrant {
         uint256 startGas = gasleft();
-        (bytes32 keyHash, uint256 requestId, uint256 randomness) = getRandomnessFromProof(
-            proof,
-            rc
-        );
+        (uint256 requestId, uint256 randomness) = getRandomnessFromProof(proof, rc);
 
         uint256[] memory randomWords = new uint256[](rc.numWords);
         for (uint256 i = 0; i < rc.numWords; i++) {
@@ -243,21 +248,20 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
         bool success = callWithExactGas(rc.callbackGasLimit, rc.sender, resp);
         sConfig.reentrancyLock = false;
 
-        uint256 payment = pay(rc, isDirectPayment, startGas, keyHash);
+        uint256 payment = pay(rc, isDirectPayment, startGas);
         emit RandomWordsFulfilled(requestId, randomness, payment, success);
     }
 
     function pay(
         RequestCommitment memory rc,
         bool isDirectPayment,
-        uint256 startGas,
-        bytes32 keyHash
+        uint256 startGas
     ) internal returns (uint256) {
         if (isDirectPayment) {
             // [temporary] account
             (uint256 totalFee, uint256 operatorFee) = sPrepayment.chargeFeeTemporary(rc.accId);
             if (operatorFee > 0) {
-                sPrepayment.chargeOperatorFeeTemporary(operatorFee, sKeyHashToOracle[keyHash]);
+                sPrepayment.chargeOperatorFeeTemporary(operatorFee, msg.sender);
             }
 
             return totalFee;
@@ -269,7 +273,7 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
             uint256 gasFee = calculateGasCost(startGas);
             uint256 fee = operatorFee + gasFee;
             if (fee > 0) {
-                sPrepayment.chargeOperatorFee(rc.accId, fee, sKeyHashToOracle[keyHash]);
+                sPrepayment.chargeOperatorFee(rc.accId, fee, msg.sender);
             }
 
             return serviceFee + gasFee;
@@ -293,11 +297,11 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
     }
 
     /**
-     * @notice Find key oracle associated with given key hash.
-     * @return oracle address
+     * @notice Find oracles associated with given key hash.
+     * @return oracle addresses
      */
-    function keyHashToOracle(bytes32 keyHash) external view returns (address) {
-        return sKeyHashToOracle[keyHash];
+    function keyHashToOracles(bytes32 keyHash) external view returns (address[] memory) {
+        return sKeyHashToOracle[keyHash].oracles;
     }
 
     /**
@@ -403,11 +407,9 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
     function getRandomnessFromProof(
         VRF.Proof memory proof,
         RequestCommitment memory rc
-    ) private view returns (bytes32 keyHash, uint256 requestId, uint256 randomness) {
-        keyHash = hashOfKey(proof.pk);
-        // Only registered proving keys are permitted.
-        address oracle = sKeyHashToOracle[keyHash];
-        if (oracle == address(0)) {
+    ) private view returns (uint256 requestId, uint256 randomness) {
+        bytes32 keyHash = hashOfKey(proof.pk);
+        if (sOracleToKeyHash[msg.sender] != keyHash) {
             revert NoSuchProvingKey(keyHash);
         }
         requestId = uint256(keccak256(abi.encode(keyHash, proof.seed)));

--- a/contracts/test/v0.1/VRFCoordinator.test.cjs
+++ b/contracts/test/v0.1/VRFCoordinator.test.cjs
@@ -9,6 +9,7 @@ const { State } = require('./State.utils.cjs')
 
 const DUMMY_KEY_HASH = '0x00000773ef09e40658e643fe79f8d1a27c0aa6eb7251749b268f829ea49f2024'
 const NUM_WORDS = 1
+const EMPTY_COMMITMENT = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 async function createSigners() {
   let { deployer, consumer, consumer1, vrfOracle0 } = await hre.getNamedAccounts()
@@ -34,6 +35,181 @@ function generateDummyPublicProvingKey() {
       return a % 10
     })
     .reduce((acc, v) => acc + v, '')
+}
+
+function validateRandomWordsRequestedEvent(
+  tx,
+  coordinatorContract,
+  keyHash,
+  accId,
+  maxGasLimit,
+  numWords,
+  sender,
+  isDirectPayment
+) {
+  let eventIndex
+  if (isDirectPayment) {
+    expect(tx.events.length).to.be.equal(3)
+    eventIndex = 1
+  } else {
+    expect(tx.events.length).to.be.equal(1)
+    eventIndex = 0
+  }
+
+  const event = coordinatorContract.interface.parseLog(tx.events[eventIndex])
+  expect(event.name).to.be.equal('RandomWordsRequested')
+  const {
+    keyHash: eKeyHash,
+    requestId,
+    preSeed,
+    accId: eAccId,
+    callbackGasLimit: eCallbackGasLimit,
+    numWords: eNumWords,
+    sender: eSender,
+    isDirectPayment: eIsDirectPayment
+  } = event.args
+  expect(eKeyHash).to.be.equal(keyHash)
+  if (!isDirectPayment) {
+    expect(eAccId).to.be.equal(accId)
+  }
+  expect(eCallbackGasLimit).to.be.equal(maxGasLimit)
+  expect(eNumWords).to.be.equal(numWords)
+  expect(eSender).to.be.equal(sender)
+  expect(eIsDirectPayment).to.be.equal(isDirectPayment)
+
+  return { requestId, preSeed, accId: eAccId }
+}
+
+async function testCommitmentBeforeFulfillment(coordinator, signer, requestId) {
+  // Request has not been fulfilled yet, therewere we expect the
+  // commitment to be non-zero
+  const commitment = await coordinator.connect(signer).getCommitment(requestId)
+  expect(commitment).to.not.be.equal(EMPTY_COMMITMENT)
+}
+
+async function testCommitmentAfterFulfillment(coordinator, signer, requestId) {
+  // Request has been fulfilled, therewere the requested
+  // commitment must be zero
+  const commitment = await coordinator.connect(signer).getCommitment(requestId)
+  expect(commitment).to.be.equal(EMPTY_COMMITMENT)
+}
+
+async function offChainVRF(
+  preSeed,
+  blockHash,
+  blockNumber,
+  accId,
+  callbackGasLimit,
+  numWords,
+  sender
+) {
+  const { sk, pk, pkX, pkY, publicProvingKey, keyHash } = vrfConfig()
+
+  const alpha = remove0x(
+    ethers.utils.solidityKeccak256(['uint256', 'bytes32'], [preSeed, blockHash])
+  )
+
+  // Simulate off-chain proof generation
+  const { processVrfRequest } = await oraklVrf
+  const { proof, uPoint, vComponents } = processVrfRequest(alpha, {
+    sk,
+    pk,
+    pkX,
+    pkY,
+    keyHash
+  })
+
+  const pi = [publicProvingKey, proof, preSeed, uPoint, vComponents]
+  const rc = [blockNumber, accId, callbackGasLimit, NUM_WORDS, sender]
+
+  return { pi, rc }
+}
+
+async function fulfillRandomWords(
+  coordinator,
+  registeredOracleSigner,
+  unregisteredOracleSigner,
+  pi,
+  rc,
+  isDirectPayment
+) {
+  // Random word request cannot be fulfilled by an unregistered oracle
+  await expect(
+    coordinator.connect(unregisteredOracleSigner).fulfillRandomWords(pi, rc, isDirectPayment)
+  ).to.be.revertedWithCustomError(coordinator, 'NoSuchProvingKey')
+
+  // Registered oracle can submit data back to chain
+  const tx = await (
+    await coordinator.connect(registeredOracleSigner).fulfillRandomWords(pi, rc, isDirectPayment)
+  ).wait()
+
+  // However even registered oracle cannot fulfill the request more than once
+  await expect(
+    coordinator.connect(registeredOracleSigner).fulfillRandomWords(pi, rc, isDirectPayment)
+  ).to.be.revertedWithCustomError(coordinator, 'NoCorrespondingRequest')
+
+  return tx
+}
+
+function validateRandomWordsFulfilledEvent(
+  tx,
+  coordinator,
+  prepayment,
+  requestId,
+  accId,
+  isDirectPayment
+) {
+  let burnedFeeEventIdx
+  let randomWordsFulfilledEventIdx
+  if (isDirectPayment) {
+    expect(tx.events.length).to.be.equal(3)
+    burnedFeeEventIdx = 1
+    randomWordsFulfilledEventIdx = 2
+  } else {
+    expect(tx.events.length).to.be.equal(4)
+    burnedFeeEventIdx = 1
+    randomWordsFulfilledEventIdx = 3
+  }
+
+  // Event: AccountBalanceDecreased
+  const accountBalanceDecreasedEvent = prepayment.interface.parseLog(tx.events[0])
+  expect(accountBalanceDecreasedEvent.name).to.be.equal('AccountBalanceDecreased')
+  const {
+    accId: dAccId,
+    oldBalance: dOldBalance,
+    newBalance: dNewBalance
+  } = accountBalanceDecreasedEvent.args
+  expect(dAccId).to.be.equal(accId)
+  expect(dOldBalance).to.be.above(dNewBalance)
+
+  if (isDirectPayment) {
+    expect(dNewBalance).to.be.equal(0)
+  } else {
+    expect(dNewBalance).to.be.above(0)
+  }
+
+  // Event: FeeBurned
+  const burnedFeeEvent = prepayment.interface.parseLog(tx.events[burnedFeeEventIdx])
+  expect(burnedFeeEvent.name).to.be.equal('BurnedFee')
+  const { accId: bAccId, amount: bAmount } = burnedFeeEvent.args
+  expect(bAccId).to.be.equal(accId)
+  expect(bAmount).to.be.above(0)
+
+  // Event: RandomWordsFulfilled
+  const randomWordsFulfilledEvent = coordinator.interface.parseLog(
+    tx.events[randomWordsFulfilledEventIdx]
+  )
+  expect(randomWordsFulfilledEvent.name).to.be.equal('RandomWordsFulfilled')
+  const {
+    requestId: fRequestId,
+    // outputSeed: fOutputSeed,
+    payment: fPayment,
+    success: fSuccess
+  } = randomWordsFulfilledEvent.args
+
+  expect(fRequestId).to.be.equal(requestId)
+  expect(fSuccess).to.be.equal(true)
+  expect(fPayment).to.be.above(0)
 }
 
 async function deployFixture() {
@@ -292,123 +468,51 @@ describe('VRF contract', function () {
     const blockHash = txRequestRandomWords.blockHash
     const blockNumber = txRequestRandomWords.blockNumber
 
-    expect(txRequestRandomWords.events.length).to.be.equal(1)
-    const requestedRandomWordsEvent = coordinatorContract.interface.parseLog(
-      txRequestRandomWords.events[0]
-    )
-    expect(requestedRandomWordsEvent.name).to.be.equal('RandomWordsRequested')
-
-    const {
-      keyHash: eKeyHash,
-      requestId: eRequestId,
-      preSeed: ePreSeed,
-      accId: eAccId,
-      callbackGasLimit: eCallbackGasLimit,
-      numWords: eNumWords,
-      sender: eSender,
-      isDirectPayment: eIsDirectPayment
-    } = requestedRandomWordsEvent.args
-    expect(eKeyHash).to.be.equal(keyHash)
-    expect(eAccId).to.be.equal(accId)
-    expect(eCallbackGasLimit).to.be.equal(maxGasLimit)
-    expect(eNumWords).to.be.equal(NUM_WORDS)
-    expect(eSender).to.be.equal(consumerContract.address)
-    expect(eIsDirectPayment).to.be.equal(false)
-
-    // Request has not been fulfilled yet, therewere we expect the
-    // commitment to be non-zero
-    const commitmentBeforeFulfillment = await coordinatorContract
-      .connect(consumerSigner)
-      .getCommitment(eRequestId)
-    expect(commitmentBeforeFulfillment).to.not.be.equal(
-      '0x0000000000000000000000000000000000000000000000000000000000000000'
-    )
-
-    const alpha = remove0x(
-      ethers.utils.solidityKeccak256(['uint256', 'bytes32'], [ePreSeed, blockHash])
-    )
-
-    // Simulate off-chain proof generation
-    const { processVrfRequest } = await oraklVrf
-    const { proof, uPoint, vComponents } = processVrfRequest(alpha, {
-      sk,
-      pk,
-      pkX,
-      pkY,
-      keyHash
-    })
-
-    const pi = [publicProvingKey, proof, ePreSeed, uPoint, vComponents]
-    const rc = [blockNumber, eAccId, eCallbackGasLimit, NUM_WORDS, eSender]
     const isDirectPayment = false
-
-    // Random word request cannot be fulfilled by an unregistered oracle
-    await expect(
-      coordinatorContract.connect(unregisteredOracle).fulfillRandomWords(pi, rc, isDirectPayment)
-    ).to.be.revertedWithCustomError(coordinatorContract, 'NoSuchProvingKey')
-
-    // Registered oracle can submit data back to chain
-    const txFulfillRandomWords = await (
-      await coordinatorContract
-        .connect(vrfOracle0Signer)
-        .fulfillRandomWords(pi, rc, isDirectPayment)
-    ).wait()
-
-    // However even registered oracle canno fulfill the request more than once
-    await expect(
-      coordinatorContract.connect(vrfOracle0Signer).fulfillRandomWords(pi, rc, isDirectPayment)
-    ).to.be.revertedWithCustomError(coordinatorContract, 'NoCorrespondingRequest')
-
-    // Request has been fulfilled, therewere the requested
-    // commitment must be zero
-    const commitmentAfterFulfillment = await coordinatorContract
-      .connect(consumerSigner)
-      .getCommitment(eRequestId)
-    expect(commitmentAfterFulfillment).to.be.equal(
-      '0x0000000000000000000000000000000000000000000000000000000000000000'
+    const callbackGasLimit = maxGasLimit
+    const numWords = NUM_WORDS
+    const sender = consumerContract.address
+    const { requestId, preSeed } = validateRandomWordsRequestedEvent(
+      txRequestRandomWords,
+      coordinatorContract,
+      keyHash,
+      accId,
+      callbackGasLimit,
+      numWords,
+      sender,
+      isDirectPayment
     )
 
-    // Check the event information //////////////////////////////////////////////
-    expect(txFulfillRandomWords.events.length).to.be.equal(4)
-
-    // Event: AccountBalanceDecreased
-    const accountBalanceDecreasedEvent = prepaymentContract.interface.parseLog(
-      txFulfillRandomWords.events[0]
+    await testCommitmentBeforeFulfillment(coordinatorContract, consumerSigner, requestId)
+    const { pi, rc } = await offChainVRF(
+      preSeed,
+      blockHash,
+      blockNumber,
+      accId,
+      callbackGasLimit,
+      numWords,
+      sender
     )
-    expect(accountBalanceDecreasedEvent.name).to.be.equal('AccountBalanceDecreased')
 
-    const {
-      accId: dAccId,
-      oldBalance: dOldBalance,
-      newBalance: dNewBalance
-    } = accountBalanceDecreasedEvent.args
-    expect(dAccId).to.be.equal(eAccId)
-    expect(dOldBalance).to.be.above(dNewBalance)
-    expect(dNewBalance).to.be.above(0)
-
-    // Event: FeeBurned
-    const burnedFeeEvent = prepaymentContract.interface.parseLog(txFulfillRandomWords.events[1])
-    expect(burnedFeeEvent.name).to.be.equal('BurnedFee')
-    const { accId: bAccId, amount: bAmount } = burnedFeeEvent.args
-    expect(bAccId).to.be.equal(eAccId)
-    expect(bAmount).to.be.above(0)
-
-    // Event: RandomWordsFulfilled
-    const randomWordsFulfilledEvent = coordinatorContract.interface.parseLog(
-      txFulfillRandomWords.events[3]
+    const txFulfillRandomWords = await fulfillRandomWords(
+      coordinatorContract,
+      vrfOracle0Signer,
+      unregisteredOracle,
+      pi,
+      rc,
+      isDirectPayment
     )
-    expect(randomWordsFulfilledEvent.name).to.be.equal('RandomWordsFulfilled')
 
-    const {
-      requestId: fRequestId,
-      // outputSeed: fOutputSeed,
-      payment: fPayment,
-      success: fSuccess
-    } = randomWordsFulfilledEvent.args
+    await testCommitmentAfterFulfillment(coordinatorContract, consumerSigner, requestId)
 
-    expect(fRequestId).to.be.equal(eRequestId)
-    expect(fSuccess).to.be.equal(true)
-    expect(fPayment).to.be.above(0)
+    validateRandomWordsFulfilledEvent(
+      txFulfillRandomWords,
+      coordinatorContract,
+      prepaymentContract,
+      requestId,
+      accId,
+      isDirectPayment
+    )
   })
 
   it('requestRandomWords with [temporary] account', async function () {
@@ -420,6 +524,11 @@ describe('VRF contract', function () {
       prepaymentContract,
       state
     } = await loadFixture(deployFixture)
+    const {
+      consumerSigner,
+      consumer1Signer: unregisteredOracle,
+      vrfOracle0Signer
+    } = await createSigners()
 
     const {
       maxGasLimit,
@@ -444,17 +553,59 @@ describe('VRF contract', function () {
 
     // Request random words through temporary account
     const value = parseKlay('1')
+    const callbackGasLimit = maxGasLimit
     const txRequestRandomWords = await (
-      await consumerContract.requestRandomWordsDirectPayment(keyHash, maxGasLimit, NUM_WORDS, {
+      await consumerContract.requestRandomWordsDirectPayment(keyHash, callbackGasLimit, NUM_WORDS, {
         value
       })
     ).wait()
+    const blockHash = txRequestRandomWords.blockHash
+    const blockNumber = txRequestRandomWords.blockNumber
 
-    expect(txRequestRandomWords.events.length).to.be.equal(3)
-    const requestedRandomWordsEvent = coordinatorContract.interface.parseLog(
-      txRequestRandomWords.events[1]
+    const isDirectPayment = true
+    const numWords = NUM_WORDS
+    const sender = consumerContract.address
+    const { requestId, preSeed, accId } = validateRandomWordsRequestedEvent(
+      txRequestRandomWords,
+      coordinatorContract,
+      keyHash,
+      0,
+      callbackGasLimit,
+      numWords,
+      sender,
+      isDirectPayment
     )
-    expect(requestedRandomWordsEvent.name).to.be.equal('RandomWordsRequested')
+
+    await testCommitmentBeforeFulfillment(coordinatorContract, consumerSigner, requestId)
+    const { pi, rc } = await offChainVRF(
+      preSeed,
+      blockHash,
+      blockNumber,
+      accId,
+      callbackGasLimit,
+      numWords,
+      sender
+    )
+
+    const txFulfillRandomWords = await fulfillRandomWords(
+      coordinatorContract,
+      vrfOracle0Signer,
+      unregisteredOracle,
+      pi,
+      rc,
+      isDirectPayment
+    )
+
+    await testCommitmentAfterFulfillment(coordinatorContract, consumerSigner, requestId)
+
+    validateRandomWordsFulfilledEvent(
+      txFulfillRandomWords,
+      coordinatorContract,
+      prepaymentContract,
+      requestId,
+      accId,
+      isDirectPayment
+    )
   })
 
   it('cancel random words request for [regular] account', async function () {

--- a/contracts/test/v0.1/VRFCoordinator.test.cjs
+++ b/contracts/test/v0.1/VRFCoordinator.test.cjs
@@ -106,7 +106,7 @@ describe('VRF contract', function () {
     expect(registerEvent.args['keyHash']).to.not.be.undefined
   })
 
-  it('Do not allow to register the same oracle or public proving key twice', async function () {
+  it('Single oracle cannot be registered more than once, but keyhash can be registered multiple times', async function () {
     const { coordinatorContract } = await loadFixture(deployFixture)
     const { address: oracle1 } = ethers.Wallet.createRandom()
     const { address: oracle2 } = ethers.Wallet.createRandom()
@@ -127,10 +127,8 @@ describe('VRF contract', function () {
       coordinatorContract.registerOracle(oracle1, publicProvingKey2)
     ).to.be.revertedWithCustomError(coordinatorContract, 'OracleAlreadyRegistered')
 
-    // Public proving key cannot be registered twice
-    await expect(
-      coordinatorContract.registerOracle(oracle2, publicProvingKey1)
-    ).to.be.revertedWithCustomError(coordinatorContract, 'ProvingKeyAlreadyRegistered')
+    // Public proving key can be registered twice
+    await coordinatorContract.registerOracle(oracle2, publicProvingKey1)
   })
 
   it('Deregister registered oracle', async function () {


### PR DESCRIPTION
# Description

This PR changes basic data structures in `VRFCoordinator` in order to allow registration of multiple off-chain oracles under the same keyhash. This will allow to scale off-chain service better without being subject to blockchain transaction limitations.

Additionally this PR includes tests for VRF temporary account fulfillment.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
