### PR TITLE
Increase `reqCount` test

### DIFF
--- a/contracts/test/v0.1/VRFCoordinator.test.cjs
+++ b/contracts/test/v0.1/VRFCoordinator.test.cjs
@@ -724,4 +724,5 @@ describe('VRF contract', function () {
 
   // TODO send more $KLAY for direct payment
   // TODO getters
+  // TODO pending request exist
 })


### PR DESCRIPTION
# Description

This PR implements tests to confirm that `reqCount` increases after fulfilling the request. The increase of `reqCount` happens indirectly inside of `chargeFee` through calls between multiple contracts (EOA off-chain oracle -> Coordinator -> Prepayment -> Account).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.