### PR TITLE
Use `typeAndVersion` for Aggregator

### DIFF
--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.16;
 // https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.6/FluxAggregator.sol
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "./interfaces/ITypeAndVersion.sol";
 import "./interfaces/IAggregator.sol";
 import "./interfaces/IAggregatorValidator.sol";
 import "./libraries/Median.sol";
@@ -16,7 +17,7 @@ import "./libraries/Median.sol";
  * single answer. The latest aggregated answer is exposed as well as historical
  * answers and their updated at timestamp.
  */
-contract Aggregator is IAggregator, Ownable {
+contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
     struct Round {
         int256 answer;
         uint64 startedAt;
@@ -55,8 +56,6 @@ contract Aggregator is IAggregator, Ownable {
     uint32 public timeout;
     uint8 public override decimals;
     string public override description;
-
-    uint256 public constant override version = 1;
 
     uint256 private constant MAX_ORACLE_COUNT = 77;
     uint32 private constant ROUND_MAX = 2 ** 32 - 1;
@@ -374,6 +373,14 @@ contract Aggregator is IAggregator, Ownable {
 
             emit ValidatorUpdated(previous, _newValidator);
         }
+    }
+
+    /**
+     * @notice The type and version of this contract
+     * @return Type and version string
+     */
+    function typeAndVersion() external pure virtual override returns (string memory) {
+        return "Aggregator v0.1";
     }
 
     /**

--- a/contracts/src/v0.1/AggregatorProxy.sol
+++ b/contracts/src/v0.1/AggregatorProxy.sol
@@ -12,7 +12,7 @@ import "./interfaces/IAggregatorProxy.sol";
  * CurrentAnswerInterface but delegates where it reads from to the owner, who is
  * trusted to update it.
  */
-contract AggregatorProxy is IAggregatorProxy, Ownable {
+contract AggregatorProxy is Ownable, IAggregatorProxy {
     struct Phase {
         uint16 id;
         IAggregatorProxy aggregator;
@@ -210,11 +210,10 @@ contract AggregatorProxy is IAggregatorProxy, Ownable {
     }
 
     /**
-     * @notice the version number representing the type of aggregator the proxy
-     * points to.
+     * @inheritdoc IAggregatorProxy
      */
-    function version() external view override returns (uint256) {
-        return sCurrentPhase.aggregator.version();
+    function typeAndVersion() external view returns (string memory) {
+        return sCurrentPhase.aggregator.typeAndVersion();
     }
 
     /**

--- a/contracts/src/v0.1/interfaces/IAggregator.sol
+++ b/contracts/src/v0.1/interfaces/IAggregator.sol
@@ -9,8 +9,6 @@ interface IAggregator {
 
     function description() external view returns (string memory);
 
-    function version() external view returns (uint256);
-
     function getRoundData(
         uint80 _roundId
     )

--- a/contracts/src/v0.1/interfaces/IAggregatorProxy.sol
+++ b/contracts/src/v0.1/interfaces/IAggregatorProxy.sol
@@ -37,4 +37,10 @@ interface IAggregatorProxy is IAggregator {
         );
 
     function aggregator() external view returns (address);
+
+    /**
+     * @notice the type and version of aggregator to which proxy
+     * points to.
+     */
+    function typeAndVersion() external view returns (string memory);
 }

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -64,7 +64,7 @@ async function deploy() {
   await aggregatorProxy.deployed()
 
   // Read configuration of Aggregator & AggregatorProxy
-  expect(await aggregatorProxy.version()).to.be.equal(1)
+  expect(await aggregatorProxy.typeAndVersion()).to.be.equal('Aggregator v0.1')
   expect(await aggregatorProxy.description()).to.be.equal(description)
 
   // DataFeedConsumerMock ///////////////////////////////////////////////////////


### PR DESCRIPTION
# Description

This PR includes an integration of `typeAndVersion` function to `Aggregator` contract and allow to access it through `AggregatorProxy` as well. Test were appropriately updated.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.