### PR TITLE
Remove compilation warning from `Median` library

### DIFF
--- a/contracts/src/v0.1/libraries/Median.sol
+++ b/contracts/src/v0.1/libraries/Median.sol
@@ -282,6 +282,7 @@ library Median {
                 return hi;
             }
         }
+        revert();
     }
 
     /**


### PR DESCRIPTION
# Description

Solidity compiler is not able to understand that infinity loop never finishes, therefore it assumes that there is a chance that return variable might not be initialized and warns about that during compilation step. It recommends to name the variable which we cannot do in our case because we are reusing the same input parameter as return value as well.

According to https://github.com/ethereum/solidity/issues/13746, we can simply add a `revert()` statement that notifies compiler with a zero cost that loop will never break, therefore we do not need to add an additional return statement after an infinite loop.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.