### PR TITLE
Aggregator related updates

### DIFF
--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -593,6 +593,17 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
 
     function timedOut(uint32 _roundId) private view returns (bool) {
         uint64 startedAt = rounds[_roundId].startedAt;
+        // `details` mapping for a specific round is supposed to be
+        // deleted after aggregator collects at least `maxSubmissions`
+        // answers for that specific round. If it does not collect
+        // such number of answers within the round, `details` mapping
+        // will be deleted during the initialization of the next
+        // round.  Depending on the validity of `_roundId` key,
+        // `roundTimeout` variable can be used to distinguish between
+        // successfully acomplished round and unsuccesful
+        // one. Assuming that `roundId` has been active (startedAt >
+        // 0), and a `roundTimeout` is over, a non-negative value of
+        // `roundTimeout` represents unsuccessfully finished round.
         uint32 roundTimeout = details[_roundId].timeout;
         return startedAt > 0 && roundTimeout > 0 && startedAt + roundTimeout < block.timestamp;
     }

--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -57,7 +57,7 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
     uint8 public override decimals;
     string public override description;
 
-    uint256 private constant MAX_ORACLE_COUNT = 77;
+    uint256 public constant MAX_ORACLE_COUNT = 77;
     uint32 private constant ROUND_MAX = 2 ** 32 - 1;
     uint256 private constant VALIDATOR_GAS_LIMIT = 100000;
 

--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -381,6 +381,11 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
         }
     }
 
+    function currentRoundStartedAt() external view returns (uint256) {
+        Round storage round = rounds[reportingRoundId];
+        return round.startedAt;
+    }
+
     /**
      * @notice method to update the address which does external data validation.
      * @param _newValidator designates the address of the new validation contract.

--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -642,6 +642,16 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
         return oracles[_oracle].endingRound == ROUND_MAX;
     }
 
+    /**
+     * @dev `maxSubmissions` struct property is initialized within
+     * `initializeNewRound` function with uint32 storage variable
+     * `maxSubmissionsCount`. After Aggregator collects at least
+     * `maxSubmissions` submissions, `details` struct is deleted
+     * (`deleteRoundDetails`), making `maxSubmissions` effectively
+     * 0. This sequence of events is depended on in this
+     * `acceptingSubmissions` to find out whether aggregator still
+     * accepts submissions for `_roundId`.
+     */
     function acceptingSubmissions(uint32 _roundId) private view returns (bool) {
         return details[_roundId].maxSubmissions != 0;
     }

--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -395,7 +395,6 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
 
         if (previous != _newValidator) {
             validator = IAggregatorValidator(_newValidator);
-
             emit ValidatorUpdated(previous, _newValidator);
         }
     }

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -443,4 +443,13 @@ describe('Aggregator', function () {
       aggregator.contract.changeOracles([], [], minSubmissionCount, maxSubmissionCount, 0)
     ).to.be.revertedWithCustomError(aggregator.contract, 'MinSubmissionGtMaxSubmission')
   })
+
+  it('MaxSubmissionGtOracleNum', async function () {
+    const { aggregator, consumer } = await loadFixture(deploy)
+    const minSubmissionCount = 0
+    const maxSubmissionCount = 1
+    await expect(
+      aggregator.contract.changeOracles([], [], minSubmissionCount, maxSubmissionCount, 0)
+    ).to.be.revertedWithCustomError(aggregator.contract, 'MaxSubmissionGtOracleNum')
+  })
 })

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -2,24 +2,29 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers')
 const { aggregatorConfig } = require('./Aggregator.config.cjs')
-const { deployAggregator, parseSetRequesterPermissionsTx } = require('./Aggregator.utils.cjs')
+const {
+  deployAggregatorProxy,
+  deployAggregator,
+  parseSetRequesterPermissionsTx,
+  deployDataFeedConsumerMock
+} = require('./Aggregator.utils.cjs')
 
 async function createSigners() {
   let { deployer, consumer, aggregatorOracle0, aggregatorOracle1, aggregatorOracle2 } =
     await hre.getNamedAccounts()
 
-  deployer = await ethers.getSigner(deployer)
-  consumer = await ethers.getSigner(consumer)
-  aggregatorOracle0 = await ethers.getSigner(aggregatorOracle0)
-  aggregatorOracle1 = await ethers.getSigner(aggregatorOracle1)
-  aggregatorOracle2 = await ethers.getSigner(aggregatorOracle2)
+  const account0 = await ethers.getSigner(deployer)
+  const account1 = await ethers.getSigner(consumer)
+  const account2 = await ethers.getSigner(aggregatorOracle0)
+  const account3 = await ethers.getSigner(aggregatorOracle1)
+  const account4 = await ethers.getSigner(aggregatorOracle2)
 
   return {
-    deployer,
-    consumer,
-    aggregatorOracle0,
-    aggregatorOracle1,
-    aggregatorOracle2
+    account0,
+    account1,
+    account2,
+    account3,
+    account4
   }
 }
 
@@ -44,63 +49,80 @@ async function changeOracles(aggregator, removeOracles, addOracles) {
 }
 
 async function deploy() {
-  const { deployer, consumer, aggregatorOracle0, aggregatorOracle1, aggregatorOracle2 } =
-    await createSigners()
+  const {
+    account0: deployerSigner,
+    account1: consumerSigner,
+    account2,
+    account3,
+    account4
+  } = await createSigners()
 
   // Aggregator /////////////////////////////////////////////////////////////////
-  const aggregator = await deployAggregator(deployer)
+  const aggregatorContract = await deployAggregator(deployerSigner)
+  const aggregator = {
+    contract: aggregatorContract,
+    signer: deployerSigner
+  }
 
   // AggregatorProxy ////////////////////////////////////////////////////////////
-  let aggregatorProxy = await ethers.getContractFactory('AggregatorProxy', {
-    signer: deployer
-  })
-  aggregatorProxy = await aggregatorProxy.deploy(aggregator.address)
-  await aggregatorProxy.deployed()
+  const aggregatorProxyContract = await deployAggregatorProxy(
+    aggregator.contract.address,
+    deployerSigner
+  )
+  const aggregatorProxy = {
+    contract: aggregatorProxyContract,
+    signer: deployerSigner
+  }
 
   // Read configuration of Aggregator & AggregatorProxy
   const { description } = aggregatorConfig()
-  expect(await aggregatorProxy.typeAndVersion()).to.be.equal('Aggregator v0.1')
-  expect(await aggregatorProxy.description()).to.be.equal(description)
+  expect(await aggregatorProxy.contract.typeAndVersion()).to.be.equal('Aggregator v0.1')
+  expect(await aggregatorProxy.contract.description()).to.be.equal(description)
 
   // DataFeedConsumerMock ///////////////////////////////////////////////////////
-  let dataFeedConsumerMock = await ethers.getContractFactory('DataFeedConsumerMock', {
-    signer: consumer
-  })
-  dataFeedConsumerMock = await dataFeedConsumerMock.deploy(aggregatorProxy.address)
-  await dataFeedConsumerMock.deployed()
+  const dataFeedConsumerMockContract = await deployDataFeedConsumerMock(
+    aggregatorProxy.contract.address,
+    consumerSigner
+  )
+  const dataFeedConsumerMock = {
+    contract: dataFeedConsumerMockContract,
+    signer: consumerSigner
+  }
 
   return {
     aggregator,
     aggregatorProxy,
     dataFeedConsumerMock,
-    deployer,
-    consumer,
-    aggregatorOracle0,
-    aggregatorOracle1,
-    aggregatorOracle2
+    account2,
+    account3,
+    account4
   }
 }
 
 describe('Aggregator', function () {
   it('Add & Remove Oracle', async function () {
-    const { aggregator, aggregatorOracle0, aggregatorOracle1, aggregatorOracle2 } =
-      await loadFixture(deploy)
+    const {
+      aggregator,
+      account2: oracle0,
+      account3: oracle1,
+      account4: oracle2
+    } = await loadFixture(deploy)
 
     // Add 2 Oracles ////////////////////////////////////////////////////////////
-    await changeOracles(aggregator, [], [aggregatorOracle0, aggregatorOracle1])
+    await changeOracles(aggregator.contract, [], [oracle0, oracle1])
 
     // Remove Oracle //////////////////////////////////////////////////////////
     // Cannot remove oracle that has not been added
     await expect(
-      aggregator.changeOracles([aggregatorOracle2.address], [], 1, 1, 0)
-    ).to.be.revertedWithCustomError(aggregator, 'OracleNotEnabled')
+      aggregator.contract.changeOracles([oracle2.address], [], 1, 1, 0)
+    ).to.be.revertedWithCustomError(aggregator.contract, 'OracleNotEnabled')
 
     // Remove oracle that has been added before
-    await changeOracles(aggregator, [aggregatorOracle0], [])
+    await changeOracles(aggregator.contract, [oracle0], [])
 
-    const currentOracles = await aggregator.getOracles()
+    const currentOracles = await aggregator.contract.getOracles()
     expect(currentOracles.length).to.be.equal(1)
-    expect(currentOracles[0]).to.be.equal(aggregatorOracle1.address)
+    expect(currentOracles[0]).to.be.equal(oracle1.address)
   })
 
   it('Submit & Read Response', async function () {
@@ -108,49 +130,48 @@ describe('Aggregator', function () {
       aggregator,
       aggregatorProxy,
       dataFeedConsumerMock,
-      consumer,
-      aggregatorOracle0,
-      aggregatorOracle1,
-      aggregatorOracle2
+      account2: oracle0,
+      account3: oracle1,
+      account4: oracle2
     } = await loadFixture(deploy)
 
     // Change oracles /////////////////////////////////////////////////////////////
-    await changeOracles(aggregator, [], [aggregatorOracle0, aggregatorOracle1, aggregatorOracle2])
+    await changeOracles(aggregator.contract, [], [oracle0, oracle1, oracle2])
 
     // First submission
-    const txReceipt0 = await (await aggregator.connect(aggregatorOracle0).submit(1, 10)).wait()
+    const txReceipt0 = await (await aggregator.contract.connect(oracle0).submit(1, 10)).wait()
     expect(txReceipt0.events.length).to.be.equal(2)
     expect(txReceipt0.events[0].event).to.be.equal('NewRound')
     expect(txReceipt0.events[1].event).to.be.equal('SubmissionReceived')
 
     // second submission
-    const txReceipt1 = await (await aggregator.connect(aggregatorOracle1).submit(1, 11)).wait()
+    const txReceipt1 = await (await aggregator.contract.connect(oracle1).submit(1, 11)).wait()
     expect(txReceipt1.events[0].event).to.be.equal('SubmissionReceived')
     expect(txReceipt1.events[1].event).to.be.equal('AnswerUpdated')
     const { current: current1 } = txReceipt1.events[1].args
     expect(current1).to.be.equal(10)
 
     // third submission
-    const txReceipt2 = await (await aggregator.connect(aggregatorOracle2).submit(1, 12)).wait()
+    const txReceipt2 = await (await aggregator.contract.connect(oracle2).submit(1, 12)).wait()
     expect(txReceipt2.events[0].event).to.be.equal('SubmissionReceived')
     expect(txReceipt2.events[1].event).to.be.equal('AnswerUpdated')
     const { current: current2 } = txReceipt2.events[1].args
     expect(current2).to.be.equal(11)
 
-    const { answer } = await aggregatorProxy.latestRoundData()
+    const { answer } = await aggregatorProxy.contract.latestRoundData()
     expect(answer).to.be.equal(11)
 
-    const proposedAggregator = await aggregatorProxy.proposedAggregator()
+    const proposedAggregator = await aggregatorProxy.contract.proposedAggregator()
     expect(proposedAggregator).to.be.equal(ethers.constants.AddressZero)
 
     // Address of current aggregator can be obtained through
     // AggregatorProxy `aggregator` function.
-    expect(await aggregatorProxy.aggregator()).to.be.equal(aggregator.address)
+    expect(await aggregatorProxy.contract.aggregator()).to.be.equal(aggregator.contract.address)
 
     // Read submission from DataFeedConsumerMock ////////////////////////////////
-    await dataFeedConsumerMock.getLatestRoundData()
-    const sId = await dataFeedConsumerMock.sId()
-    const sAnswer = await dataFeedConsumerMock.sAnswer()
+    await dataFeedConsumerMock.contract.getLatestRoundData()
+    const sId = await dataFeedConsumerMock.contract.sId()
+    const sAnswer = await dataFeedConsumerMock.contract.sAnswer()
     expect(sId).to.be.equal('18446744073709551617')
     expect(sAnswer).to.be.equal(11)
 
@@ -161,28 +182,28 @@ describe('Aggregator', function () {
       startedAt: pStartedAt,
       updatedAt: pUpdatedAt,
       answeredInRound: pAnsweredInRound
-    } = await aggregatorProxy.connect(consumer).getRoundData(sId)
+    } = await aggregatorProxy.contract.connect(dataFeedConsumerMock.signer).getRoundData(sId)
     expect(pId).to.be.equal(sId)
     expect(pAnswer).to.be.equal(sAnswer)
-    expect(pStartedAt).to.be.equal(await dataFeedConsumerMock.sStartedAt())
-    expect(pUpdatedAt).to.be.equal(await dataFeedConsumerMock.sUpdatedAt())
-    expect(pAnsweredInRound).to.be.equal(await dataFeedConsumerMock.sAnsweredInRound())
+    expect(pStartedAt).to.be.equal(await dataFeedConsumerMock.contract.sStartedAt())
+    expect(pUpdatedAt).to.be.equal(await dataFeedConsumerMock.contract.sUpdatedAt())
+    expect(pAnsweredInRound).to.be.equal(await dataFeedConsumerMock.contract.sAnsweredInRound())
 
     // Read decimals from DataFeedConsumerMock //////////////////////////////////
     const { decimals } = aggregatorConfig()
-    expect(await dataFeedConsumerMock.decimals()).to.be.equal(decimals)
+    expect(await dataFeedConsumerMock.contract.decimals()).to.be.equal(decimals)
   })
 
   it('addOracle assertions', async function () {
-    const { aggregator, aggregatorOracle0, aggregatorOracle1 } = await loadFixture(deploy)
+    const { aggregator, account2: oracle0, account3: oracle1 } = await loadFixture(deploy)
 
     // Add Oracle ///////////////////////////////////////////////////////////////
-    await changeOracles(aggregator, [], [aggregatorOracle0])
+    await changeOracles(aggregator.contract, [], [oracle0])
 
     // Cannot add the same oracle twice
     await expect(
-      aggregator.changeOracles([], [aggregatorOracle0.address], 1, 2, 0)
-    ).to.be.revertedWithCustomError(aggregator, 'OracleAlreadyEnabled')
+      aggregator.contract.changeOracles([], [oracle0.address], 1, 2, 0)
+    ).to.be.revertedWithCustomError(aggregator.contract, 'OracleAlreadyEnabled')
   })
 
   it('Propose & Confirm Aggregator Through AggregatorProxy', async function () {
@@ -190,47 +211,49 @@ describe('Aggregator', function () {
       aggregator: currentAggregator,
       aggregatorProxy,
       dataFeedConsumerMock,
-      deployer,
-      consumer,
-      aggregatorOracle0,
-      aggregatorOracle1,
-      aggregatorOracle2: invalidAggregator
+      account2: oracle0,
+      account3: oracle1,
+      account4: invalidOracle
     } = await loadFixture(deploy)
 
     // Aggregator /////////////////////////////////////////////////////////////////
-    const aggregator = await deployAggregator(deployer)
+    const aggregator = await deployAggregator(currentAggregator.deployer)
 
     // Change oracles /////////////////////////////////////////////////////////////
-    await changeOracles(aggregator, [], [aggregatorOracle0, aggregatorOracle1])
+    await changeOracles(aggregator, [], [oracle0, oracle1])
 
     // proposeAggregator ////////////////////////////////////////////////////////
     // Aggregator can be proposed only by owner
     await expect(
-      aggregatorProxy.connect(consumer).proposeAggregator(aggregator.address)
+      aggregatorProxy.contract
+        .connect(dataFeedConsumerMock.signer)
+        .proposeAggregator(aggregator.address)
     ).to.be.revertedWith('Ownable: caller is not the owner')
 
     // Propose aggregator with contract owner
     const proposeAggregatorTx = await (
-      await aggregatorProxy.proposeAggregator(aggregator.address)
+      await aggregatorProxy.contract.proposeAggregator(aggregator.address)
     ).wait()
     expect(proposeAggregatorTx.events.length).to.be.equal(1)
-    const proposeAggregatorEvent = aggregatorProxy.interface.parseLog(proposeAggregatorTx.events[0])
+    const proposeAggregatorEvent = aggregatorProxy.contract.interface.parseLog(
+      proposeAggregatorTx.events[0]
+    )
     expect(proposeAggregatorEvent.name).to.be.equal('AggregatorProposed')
     const { current, proposed } = proposeAggregatorEvent.args
-    expect(current).to.be.equal(currentAggregator.address)
+    expect(current).to.be.equal(currentAggregator.contract.address)
     expect(proposed).to.be.equal(aggregator.address)
 
     // proposedLatestRoundData //////////////////////////////////////////////////
     // If no data has been submitted to proposed yet, reading from proxy reverts
     await expect(
-      aggregatorProxy.connect(consumer).proposedLatestRoundData()
+      aggregatorProxy.contract.connect(dataFeedConsumerMock.signer).proposedLatestRoundData()
     ).to.be.revertedWithCustomError(aggregator, 'NoDataPresent')
-    await aggregator.connect(aggregatorOracle0).submit(1, 10)
-    await aggregator.connect(aggregatorOracle1).submit(1, 10)
+    await aggregator.connect(oracle0).submit(1, 10)
+    await aggregator.connect(oracle1).submit(1, 10)
 
     // Read after submitting at least `minSubmissionCount` to proposed aggregator
-    const { id, answer, startedAt, updatedAt, answeredInRound } = await aggregatorProxy
-      .connect(consumer)
+    const { id, answer, startedAt, updatedAt, answeredInRound } = await aggregatorProxy.contract
+      .connect(dataFeedConsumerMock.signer)
       .proposedLatestRoundData()
     expect(id).to.be.equal(1)
     expect(answer).to.be.equal(10)
@@ -242,7 +265,7 @@ describe('Aggregator', function () {
       startedAt: pStartedAt,
       updatedAt: pUpdatedAt,
       answeredInRound: pAnsweredInRound
-    } = await aggregatorProxy.connect(consumer).proposedGetRoundData(id)
+    } = await aggregatorProxy.contract.connect(dataFeedConsumerMock.signer).proposedGetRoundData(id)
     expect(id).to.be.equal(pId)
     expect(answer).to.be.equal(pAnswer)
     expect(startedAt).to.be.equal(pStartedAt)
@@ -252,49 +275,51 @@ describe('Aggregator', function () {
     // confirmAggregator ////////////////////////////////////////////////////////
     // Aggregator can be confirmed only by owner
     expect(
-      aggregatorProxy.connect(consumer).confirmAggregator(aggregator.address)
+      aggregatorProxy.contract
+        .connect(dataFeedConsumerMock.signer)
+        .confirmAggregator(aggregator.address)
     ).to.be.revertedWith('Ownable: caller is not the owner')
 
     // Owner must pass proposed aggregator address, otherwise reverts
     await expect(
-      aggregatorProxy.confirmAggregator(invalidAggregator.address)
-    ).to.be.revertedWithCustomError(aggregatorProxy, 'InvalidProposedAggregator')
+      aggregatorProxy.contract.confirmAggregator(invalidOracle.address)
+    ).to.be.revertedWithCustomError(aggregatorProxy.contract, 'InvalidProposedAggregator')
 
     // The initial `phaseId` is equal to 1
     const currentPhaseId = 1
-    expect(await aggregatorProxy.phaseId()).to.be.equal(currentPhaseId)
+    expect(await aggregatorProxy.contract.phaseId()).to.be.equal(currentPhaseId)
 
     // Confirm aggregator with contract owner
     {
-      const tx = await (await aggregatorProxy.confirmAggregator(aggregator.address)).wait()
+      const tx = await (await aggregatorProxy.contract.confirmAggregator(aggregator.address)).wait()
       expect(tx.events.length).to.be.equal(1)
-      const event = aggregatorProxy.interface.parseLog(tx.events[0])
+      const event = aggregatorProxy.contract.interface.parseLog(tx.events[0])
       expect(event.name).to.be.equal('AggregatorConfirmed')
       const { previous, latest } = event.args
-      expect(previous).to.be.equal(currentAggregator.address)
+      expect(previous).to.be.equal(currentAggregator.contract.address)
       expect(latest).to.be.equal(aggregator.address)
     }
 
     // `phaseId` is increased by 1 after confirming the new aggregator
-    expect(await aggregatorProxy.phaseId()).to.be.equal(currentPhaseId + 1)
+    expect(await aggregatorProxy.contract.phaseId()).to.be.equal(currentPhaseId + 1)
 
     // Every Aggregator address that has been connected with
     // AggregatorProxy is stored in mapping and can be accessed through
     // `phaseAggregators` by specifing the `phaseId`.
-    expect(await aggregatorProxy.phaseAggregators(1)).to.be.equal(current)
-    expect(await aggregatorProxy.phaseAggregators(2)).to.be.equal(proposed)
+    expect(await aggregatorProxy.contract.phaseAggregators(1)).to.be.equal(current)
+    expect(await aggregatorProxy.contract.phaseAggregators(2)).to.be.equal(proposed)
   })
 
   it('oracleRoundState', async function () {
-    const { aggregator, aggregatorOracle0, aggregatorOracle1 } = await loadFixture(deploy)
+    const { aggregator, account2: oracle0, account3: oracle1 } = await loadFixture(deploy)
 
     // Add Oracle ///////////////////////////////////////////////////////////////
-    await changeOracles(aggregator, [], [aggregatorOracle0])
+    await changeOracles(aggregator.contract, [], [oracle0])
 
     {
       // State of oracle before the first submission
       const { _roundId, _latestSubmission, _startedAt, _timeout, _oracleCount } =
-        await aggregator.oracleRoundState(aggregatorOracle0.address, 0)
+        await aggregator.contract.oracleRoundState(oracle0.address, 0)
       expect(_roundId).to.be.equal(1)
       expect(_latestSubmission).to.be.equal(0)
       expect(_startedAt).to.be.equal(0)
@@ -305,14 +330,12 @@ describe('Aggregator', function () {
     // Submit to aggregator
     const roundId = 1
     const submission = 10
-    await aggregator.connect(aggregatorOracle0).submit(roundId, submission)
+    await aggregator.contract.connect(oracle0).submit(roundId, submission)
 
     // State of oracle after the first submission
     {
-      const { _roundId, _latestSubmission, _oracleCount } = await aggregator.oracleRoundState(
-        aggregatorOracle0.address,
-        roundId
-      )
+      const { _roundId, _latestSubmission, _oracleCount } =
+        await aggregator.contract.oracleRoundState(oracle0.address, roundId)
       expect(_roundId).to.be.equal(roundId)
       expect(_latestSubmission).to.be.equal(submission)
       expect(_oracleCount).to.be.equal(1)
@@ -322,21 +345,24 @@ describe('Aggregator', function () {
   it('External Requester', async function () {
     const {
       aggregator,
-      consumer: requesterSigner,
-      aggregatorOracle0: unauthorizedRequester
+      account2: authorizedRequester,
+      account3: unauthorizedRequester
     } = await loadFixture(deploy)
 
-    const requesterAddress = requesterSigner.address
+    const requesterAddress = authorizedRequester.address
 
     // Add a new requester //////////////////////////////////////////////////////
     {
       const _authorized = true
       const _delay = 0
       const tx = await (
-        await aggregator.setRequesterPermissions(requesterAddress, _authorized, _delay)
+        await aggregator.contract.setRequesterPermissions(requesterAddress, _authorized, _delay)
       ).wait()
-      const { requester, authorized, delay } = parseSetRequesterPermissionsTx(aggregator, tx)
-      expect(requester).to.be.equal(requesterSigner.address)
+      const { requester, authorized, delay } = parseSetRequesterPermissionsTx(
+        aggregator.contract,
+        tx
+      )
+      expect(requester).to.be.equal(authorizedRequester.address)
       expect(authorized).to.be.equal(_authorized)
       expect(delay).to.be.equal(_delay)
     }
@@ -346,7 +372,7 @@ describe('Aggregator', function () {
       const _delay = 0
       // Test idempotency for adding a new requester
       const tx = await (
-        await aggregator.setRequesterPermissions(requesterAddress, _authorized, _delay)
+        await aggregator.contract.setRequesterPermissions(requesterAddress, _authorized, _delay)
       ).wait()
       // No new requester added -> no emmited event
       expect(tx.events.length).to.be.equal(0)
@@ -355,19 +381,21 @@ describe('Aggregator', function () {
     // Request NewRound /////////////////////////////////////////////////////////
     // Only authorized requester can request new round, otherwise reverts
     await expect(
-      aggregator.connect(unauthorizedRequester).requestNewRound()
-    ).to.be.revertedWithCustomError(aggregator, 'RequesterNotAuthorized')
+      aggregator.contract.connect(unauthorizedRequester).requestNewRound()
+    ).to.be.revertedWithCustomError(aggregator.contract, 'RequesterNotAuthorized')
 
     // Request with authorized requester
     {
-      const tx = await (await aggregator.connect(requesterSigner).requestNewRound()).wait()
+      const tx = await (
+        await aggregator.contract.connect(authorizedRequester).requestNewRound()
+      ).wait()
       const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber)).timestamp
       expect(tx.events.length).to.be.equal(1)
       expect(tx.events[0].event).to.be.equal('NewRound')
-      const event = aggregator.interface.parseLog(tx.events[0])
+      const event = aggregator.contract.interface.parseLog(tx.events[0])
       const { roundId, startedBy, startedAt } = event.args
       expect(roundId).to.be.equal(1)
-      expect(startedBy).to.be.equal(requesterSigner.address)
+      expect(startedBy).to.be.equal(authorizedRequester.address)
       expect(startedAt).to.be.equal(blockTimestamp)
     }
 
@@ -376,10 +404,17 @@ describe('Aggregator', function () {
       const _authorized = false
       const _delay = 0
       const tx = await (
-        await aggregator.setRequesterPermissions(requesterSigner.address, _authorized, _delay)
+        await aggregator.contract.setRequesterPermissions(
+          authorizedRequester.address,
+          _authorized,
+          _delay
+        )
       ).wait()
-      const { requester, authorized, delay } = parseSetRequesterPermissionsTx(aggregator, tx)
-      expect(requester).to.be.equal(requesterSigner.address)
+      const { requester, authorized, delay } = parseSetRequesterPermissionsTx(
+        aggregator.contract,
+        tx
+      )
+      expect(requester).to.be.equal(authorizedRequester.address)
       expect(authorized).to.be.equal(_authorized)
       expect(delay).to.be.equal(_delay)
     }

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -434,4 +434,13 @@ describe('Aggregator', function () {
       aggregator.contract.changeOracles([], [oracle], i, i, 0)
     ).to.be.revertedWithCustomError(aggregator.contract, 'TooManyOracles')
   })
+
+  it('MinSubmissionGtMaxSubmission', async function () {
+    const { aggregator, consumer } = await loadFixture(deploy)
+    const minSubmissionCount = 1
+    const maxSubmissionCount = 0
+    await expect(
+      aggregator.contract.changeOracles([], [], minSubmissionCount, maxSubmissionCount, 0)
+    ).to.be.revertedWithCustomError(aggregator.contract, 'MinSubmissionGtMaxSubmission')
+  })
 })

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -452,4 +452,21 @@ describe('Aggregator', function () {
       aggregator.contract.changeOracles([], [], minSubmissionCount, maxSubmissionCount, 0)
     ).to.be.revertedWithCustomError(aggregator.contract, 'MaxSubmissionGtOracleNum')
   })
+
+  it('RestartDelayExceedOracleNum', async function () {
+    const { aggregator, consumer } = await loadFixture(deploy)
+    const minSubmissionCount = 0
+    const maxSubmissionCount = 1
+    const restartDelay = 1
+    const { address: oracle } = ethers.Wallet.createRandom()
+    await expect(
+      aggregator.contract.changeOracles(
+        [],
+        [oracle],
+        minSubmissionCount,
+        maxSubmissionCount,
+        restartDelay
+      )
+    ).to.be.revertedWithCustomError(aggregator.contract, 'RestartDelayExceedOracleNum')
+  })
 })

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -469,4 +469,21 @@ describe('Aggregator', function () {
       )
     ).to.be.revertedWithCustomError(aggregator.contract, 'RestartDelayExceedOracleNum')
   })
+
+  it('MinSubmissionZero', async function () {
+    const { aggregator, consumer } = await loadFixture(deploy)
+    const minSubmissionCount = 0
+    const maxSubmissionCount = 1
+    const restartDelay = 0
+    const { address: oracle } = ethers.Wallet.createRandom()
+    await expect(
+      aggregator.contract.changeOracles(
+        [],
+        [oracle],
+        minSubmissionCount,
+        maxSubmissionCount,
+        restartDelay
+      )
+    ).to.be.revertedWithCustomError(aggregator.contract, 'MinSubmissionZero')
+  })
 })

--- a/contracts/test/v0.1/Aggregator.utils.cjs
+++ b/contracts/test/v0.1/Aggregator.utils.cjs
@@ -3,10 +3,28 @@ const { aggregatorConfig } = require('./Aggregator.config.cjs')
 
 async function deployAggregator(signer) {
   const { timeout, validator, decimals, description } = aggregatorConfig()
-  let aggregator = await ethers.getContractFactory('Aggregator', { signer })
-  aggregator = await aggregator.deploy(timeout, validator, decimals, description)
-  await aggregator.deployed()
-  return aggregator
+  let contract = await ethers.getContractFactory('Aggregator', { signer })
+  contract = await contract.deploy(timeout, validator, decimals, description)
+  await contract.deployed()
+  return contract
+}
+
+async function deployAggregatorProxy(aggregatorAddress, signer) {
+  let contract = await ethers.getContractFactory('AggregatorProxy', {
+    signer
+  })
+  contract = await contract.deploy(aggregatorAddress)
+  await contract.deployed()
+  return contract
+}
+
+async function deployDataFeedConsumerMock(aggregatorProxyAddress, signer) {
+  let contract = await ethers.getContractFactory('DataFeedConsumerMock', {
+    signer
+  })
+  contract = await contract.deploy(aggregatorProxyAddress)
+  await contract.deployed()
+  return contract
 }
 
 function parseSetRequesterPermissionsTx(aggregator, tx) {
@@ -20,5 +38,7 @@ function parseSetRequesterPermissionsTx(aggregator, tx) {
 
 module.exports = {
   deployAggregator,
-  parseSetRequesterPermissionsTx
+  parseSetRequesterPermissionsTx,
+  deployAggregatorProxy,
+  deployDataFeedConsumerMock
 }


### PR DESCRIPTION
# Description

This PR slightly changes and improve Aggregator contract code and add more tests.

* Made `MAX_ORACLE_COUNT` public
* Replaced some `require` with `revert`
* Added auxiliary function `currentRoundStartedAt` that will be used by off-chain oracle to compute synchronized delay
* Added comments to not so obvious functions and code statements
* Added more Aggregator tests

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.