### PR TITLE
Allow to withdraw $KLAY from temporary account

### DIFF
--- a/contracts/src/v0.1/RequestResponseCoordinator.sol
+++ b/contracts/src/v0.1/RequestResponseCoordinator.sol
@@ -211,7 +211,7 @@ contract RequestResponseCoordinator is
             revert InsufficientPayment(msg.value, fee);
         }
 
-        uint64 accId = sPrepayment.createTemporaryAccount();
+        uint64 accId = sPrepayment.createTemporaryAccount(msg.sender);
         bool isDirectPayment = true;
         uint256 requestId = requestData(
             req,

--- a/contracts/src/v0.1/VRFCoordinator.sol
+++ b/contracts/src/v0.1/VRFCoordinator.sol
@@ -193,7 +193,7 @@ contract VRFCoordinator is IVRFCoordinatorBase, CoordinatorBase, ITypeAndVersion
             revert InsufficientPayment(msg.value, fee);
         }
 
-        uint64 accId = sPrepayment.createTemporaryAccount();
+        uint64 accId = sPrepayment.createTemporaryAccount(msg.sender);
         bool isDirectPayment = true;
         uint256 requestId = requestRandomWords(
             keyHash,

--- a/contracts/src/v0.1/interfaces/ICoordinatorBase.sol
+++ b/contracts/src/v0.1/interfaces/ICoordinatorBase.sol
@@ -59,4 +59,11 @@ interface ICoordinatorBase {
      * @param requestId - ID of the Oracle Request
      */
     function cancelRequest(uint256 requestId) external;
+
+    /**
+     * @notice Access address for prepayment associated with
+     * @notice coordinator.
+     * @return prepayment address
+     */
+    function getPrepaymentAddress() external returns (address);
 }

--- a/contracts/src/v0.1/interfaces/IPrepayment.sol
+++ b/contracts/src/v0.1/interfaces/IPrepayment.sol
@@ -71,13 +71,28 @@ interface IPrepayment {
     function getNonce(uint64 accId, address consumer) external view returns (uint64);
 
     /*
-     * @notice Check to see if there exists a request commitment consumers
-     * for all consumers and coordinators for a given account.
+     * @notice Check to see if there exists a request commitment
+     * @notice for all consumers and coordinators for a given
+     * @notice [permanent] account.
+     * @dev Use to reject account cancelation while outstanding
+     * @dev request are present.
      * @param accId - ID of the account
      * @return true if there exists at least one unfulfilled request for the account, false
      * otherwise.
      */
     function pendingRequestExists(uint64 accId) external view returns (bool);
+
+    /*
+     * @notice Check to see if there exists a request commitment
+     * @notice for an account owner of [permanent] account across
+     * @notice all coordinators.
+     * @dev Use to reject balance withdrawal while outstanding
+     * @dev request are present.
+     * @param accId - ID of the account
+     * @return true if there exists at least one unfulfilled request for the account, false
+     * otherwise.
+     */
+    function pendingRequestExistsTemporary(uint64 accId) external view returns (bool);
 
     /// STATE-ALTERING FUNCTIONS ////////////////////////////////////////////////
 
@@ -164,14 +179,24 @@ interface IPrepayment {
     /**
      * @notice Withdraw $KLAY from [regular] account.
      * @dev Account owner can withdraw $KLAY only when there are no
-     * @dev pending requests on any of associated consumers. If one
-     * @dev tries to withdraw $KLAY from [temporary] account,
-     * @dev transaction will revert. Transaction reverts also on
-     * @dev failure to withdraw tokens from account.
+     * @dev pending requests on any of associated consumers. If one tries
+     * @dev to use it to withdraw $KLAY from [temporary] account,
+     * @dev transaction will revert. Transaction reverts also on failure to
+     * @dev withdraw tokens from account.
      * @param accId - ID of the account
      * @param amount - $KLAY amount to be withdrawn
      */
     function withdraw(uint64 accId, uint256 amount) external;
+
+    /**
+     * @notice Withdraw $KLAY from [temporary] account.
+     * @dev Account owner can withdraw $KLAY only when there are no
+     * @dev pending requests. Temporary account will be deleted upon
+     * @dev successful withdrawal. Transaction reverts also on failure to
+     * @dev withdraw tokens from account.
+     * @param accId - ID of the account
+     */
+    function withdrawTemporary(uint64 accId) external;
 
     /**
      * @notice Burn part of fee and charge protocol fee for a service
@@ -198,6 +223,7 @@ interface IPrepayment {
     /**
      * @notice Burn part of fee and charge protocol fee for a service
      * connected to [temporary] account.
+     * @dev Temporary account is deleted because we do not expect to use it again.
      * @param accId - ID of the account
      */
     function chargeFeeTemporary(

--- a/contracts/src/v0.1/interfaces/IPrepayment.sol
+++ b/contracts/src/v0.1/interfaces/IPrepayment.sol
@@ -84,7 +84,7 @@ interface IPrepayment {
 
     /*
      * @notice Check to see if there exists a request commitment
-     * @notice for an account owner of [permanent] account across
+     * @notice for an account owner of [temporary] account across
      * @notice all coordinators.
      * @dev Use to reject balance withdrawal while outstanding
      * @dev request are present.

--- a/contracts/src/v0.1/interfaces/IPrepayment.sol
+++ b/contracts/src/v0.1/interfaces/IPrepayment.sol
@@ -110,9 +110,10 @@ interface IPrepayment {
     /**
      * @notice Create a temporary account to be used with a single
      * @notice service request.
+     * @param - account owner
      * @return accId - A unique account id
      */
-    function createTemporaryAccount() external returns (uint64);
+    function createTemporaryAccount(address owner) external returns (uint64);
 
     /**
      * @notice Request account owner transfer.
@@ -195,8 +196,9 @@ interface IPrepayment {
      * @dev successful withdrawal. Transaction reverts also on failure to
      * @dev withdraw tokens from account.
      * @param accId - ID of the account
+     * @param to - recipient address
      */
-    function withdrawTemporary(uint64 accId) external;
+    function withdrawTemporary(uint64 accId, address payable to) external;
 
     /**
      * @notice Burn part of fee and charge protocol fee for a service

--- a/contracts/src/v0.1/mocks/VRFConsumerMock.sol
+++ b/contracts/src/v0.1/mocks/VRFConsumerMock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.16;
 
 import "../VRFConsumerBase.sol";
 import "../interfaces/IVRFCoordinator.sol";
+import "../interfaces/IPrepayment.sol";
 
 contract VRFConsumerMock is VRFConsumerBase {
     uint256 public sRandomWord;
@@ -61,5 +62,10 @@ contract VRFConsumerMock is VRFConsumerBase {
 
     function cancelRequest(uint256 requestId) external onlyOwner {
         COORDINATOR.cancelRequest(requestId);
+    }
+
+    function withdrawTemporary(uint64 accId) external onlyOwner {
+        address prepaymentAddress = COORDINATOR.getPrepaymentAddress();
+        IPrepayment(prepaymentAddress).withdrawTemporary(accId, payable(msg.sender));
     }
 }


### PR DESCRIPTION
# Description

Request created by temporary account can be canceled. In both VRF https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/VRFCoordinator.sol#L364-L372 and RR https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/RequestResponseCoordinator.sol#L518-L529, request commitment and owner of request are stored in contract local storage. The exactly same code is used for temporary account and permanent account. Any request can therefore be canceled using `cancelRequestFunction` https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/CoordinatorBase.sol#L124-L137. Once the request is canceled, it cannot be fulfilled by any oracle because we have a validation of response in both RR https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/RequestResponseCoordinator.sol#L554-L557 and VRF https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/VRFCoordinator.sol#L422-L425.

When the request is canceled, the request itself cannot be used to charge for service fee. In case of permanent account, we have a `witdthraw` function https://github.com/Bisonai/orakl/blob/8d4657c6587ca4346a538c651fedbc41a2ff6ce5/contracts/src/v0.1/Prepayment.sol#L366-L377, but for the temporary account $KLAY deposited during the request is basically stuck in the `Prepayment` contract, nobody can withdraw them, not even owner of the contract.

This PR allows to withdraw $KLAY from temporary account by owner of the account which requested for a service but the request was eventually canceled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
