### PR TITLE
Use `currentRoundStartedAt` instead of 2x `oracleRoundState`

### DIFF
--- a/core/src/worker/data-feed.utils.ts
+++ b/core/src/worker/data-feed.utils.ts
@@ -7,19 +7,17 @@ import { Aggregator__factory } from '@bisonai/orakl-contracts'
 /**
  * Compute the number of seconds until the next round.
  *
- * @param {string} aggregator address
+ * @param {string} oracle address
  * @param {number} heartbeat
  * @param {Logger}
  * @return {number} delay in seconds until the next round
  */
 export async function getSynchronizedDelay({
   oracleAddress,
-  operatorAddress,
   heartbeat,
   logger
 }: {
   oracleAddress: string
-  operatorAddress: string
   heartbeat: number
   logger: Logger
 }): Promise<number> {

--- a/core/src/worker/state.ts
+++ b/core/src/worker/state.ts
@@ -6,6 +6,7 @@ import { getAggregator, getAggregators } from './api'
 import { OraklError, OraklErrorCode } from '../errors'
 import { SUBMIT_HEARTBEAT_QUEUE_SETTINGS } from '../settings'
 import { IAggregatorConfig } from './types'
+import { getSynchronizedDelay } from './data-feed.utils'
 
 const FILE_NAME = import.meta.url
 
@@ -150,7 +151,11 @@ export class State {
 
     const outDataSubmitHeartbeat: IAggregatorSubmitHeartbeatWorker = {
       oracleAddress: toAddAggregator.address,
-      delay: toAddAggregator.heartbeat
+      delay: await getSynchronizedDelay({
+        oracleAddress: toAddAggregator.address,
+        heartbeat: toAddAggregator.heartbeat,
+        logger: this.logger
+      })
     }
     this.logger.debug(outDataSubmitHeartbeat, 'outDataSubmitHeartbeat')
     await this.submitHeartbeatQueue.add('state-submission', outDataSubmitHeartbeat, {


### PR DESCRIPTION
# Description

This PR changes the way how data feed worker finds out the start time of the current round. Previously, we had to call `oracleRoundState` twice. After merging this PR, we can make a single call with `currentRoundStartedAt` to obtain the same information. We hope this will speed up the data feed worker and mitigate synchronization issues.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
