### PR TITLE
Fallback for data feed reporter when delegator fails

### DIFF
--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -57,5 +57,7 @@ export enum OraklErrorCode {
   ListenerNotFoundInState,
   ReporterNotFoundInState,
   UnknownRequestResponseJob,
-  MissingSignedRawTx
+  MissingSignedRawTx,
+  CaverTxTransactionFailed,
+  DelegatorServerIssue
 }

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -21,7 +21,7 @@ export function reporter(state: State, logger: Logger) {
 
     let delegatorOkay = true
     const NUM_TRANSACTION_TRIALS = 3
-    let txParams = { wallet, to, payload, gasLimit, logger }
+    const txParams = { wallet, to, payload, gasLimit, logger }
 
     for (let i = 0; i < NUM_TRANSACTION_TRIALS; ++i) {
       if (state.delegatedFee && delegatorOkay) {

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq'
 import { Logger } from 'pino'
-import { sendTransaction, sendTransactionDelegatedFee } from './utils'
+import { sendTransaction, sendTransactionDelegatedFee, sendTransactionCaver } from './utils'
 import { State } from './state'
 import { ITransactionParameters } from '../types'
 import { OraklError, OraklErrorCode } from '../errors'
@@ -19,28 +19,44 @@ export function reporter(state: State, logger: Logger) {
       throw new OraklError(OraklErrorCode.WalletNotActive, msg)
     }
 
+    let delegatorOkay = true
     const NUM_TRANSACTION_TRIALS = 3
     for (let i = 0; i < NUM_TRANSACTION_TRIALS; ++i) {
-      try {
-        if (state.delegatedFee) {
-          await sendTransactionDelegatedFee({ wallet, to, payload, logger, gasLimit })
-        } else {
-          await sendTransaction({ wallet, to, payload, logger, gasLimit })
+      if (state.delegatedFee && delegatorOkay) {
+        try {
+          await sendTransactionDelegatedFee({ wallet, to, payload, gasLimit, logger })
+          break
+        } catch (e) {
+          if (e.code == OraklErrorCode.DelegatorServerIssue) {
+            delegatorOkay = false
+          }
         }
-
-        break
-      } catch (e) {
-        if (
-          ![
-            OraklErrorCode.TxNotMined,
-            OraklErrorCode.TxProcessingResponseError,
-            OraklErrorCode.TxMissingResponseError
-          ].includes(e.code)
-        ) {
-          throw e
+      } else if (state.delegatedFee) {
+        try {
+          await sendTransactionCaver({ wallet, to, payload, gasLimit, logger })
+          break
+        } catch (e) {
+          if (![OraklErrorCode.CaverTxTransactionFailed].includes(e.code)) {
+            throw e
+          }
         }
+      } else {
+        try {
+          await sendTransaction({ wallet, to, payload, gasLimit, logger })
+          break
+        } catch (e) {
+          if (
+            ![
+              OraklErrorCode.TxNotMined,
+              OraklErrorCode.TxProcessingResponseError,
+              OraklErrorCode.TxMissingResponseError
+            ].includes(e.code)
+          ) {
+            throw e
+          }
 
-        logger.info(`Retrying transaction. Trial number: ${i}`)
+          logger.info(`Retrying transaction. Trial number: ${i}`)
+        }
       }
     }
   }

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -21,10 +21,12 @@ export function reporter(state: State, logger: Logger) {
 
     let delegatorOkay = true
     const NUM_TRANSACTION_TRIALS = 3
+    let txParams = { wallet, to, payload, gasLimit, logger }
+
     for (let i = 0; i < NUM_TRANSACTION_TRIALS; ++i) {
       if (state.delegatedFee && delegatorOkay) {
         try {
-          await sendTransactionDelegatedFee({ wallet, to, payload, gasLimit, logger })
+          await sendTransactionDelegatedFee(txParams)
           break
         } catch (e) {
           if (e.code == OraklErrorCode.DelegatorServerIssue) {
@@ -33,7 +35,7 @@ export function reporter(state: State, logger: Logger) {
         }
       } else if (state.delegatedFee) {
         try {
-          await sendTransactionCaver({ wallet, to, payload, gasLimit, logger })
+          await sendTransactionCaver(txParams)
           break
         } catch (e) {
           if (![OraklErrorCode.CaverTxTransactionFailed].includes(e.code)) {
@@ -42,7 +44,7 @@ export function reporter(state: State, logger: Logger) {
         }
       } else {
         try {
-          await sendTransaction({ wallet, to, payload, gasLimit, logger })
+          await sendTransaction(txParams)
           break
         } catch (e) {
           if (

--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -195,7 +195,7 @@ export async function sendTransactionDelegatedFee({
       throw new OraklError(OraklErrorCode.MissingSignedRawTx)
     }
   } catch (e) {
-    _logger.error(e, 'e')
+    _logger.error(e)
     throw e
   }
 }
@@ -215,19 +215,24 @@ export async function sendTransactionCaver({
   logger: Logger
   value?: number | string
 }) {
+  const _logger = logger.child({ name: 'sendTransactionCaver', file: FILE_NAME })
+
   const txParams = {
     from: wallet.address,
     to,
     input: payload,
-    gasLimit,
+    gas: gasLimit,
     value: value || '0x00'
   }
 
   try {
     const tx = wallet.caver.transaction.smartContractExecution.create(txParams)
+    await tx.fillTransaction()
     await wallet.caver.wallet.sign(wallet.address, tx)
     const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(tx.getRawTransaction())
+    _logger.debug(txReceipt, 'txReceipt')
   } catch (e) {
+    _logger.error(e)
     throw new OraklError(OraklErrorCode.CaverTxTransactionFailed)
   }
 }

--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -147,13 +147,14 @@ export async function sendTransactionDelegatedFee({
 }) {
   const _logger = logger.child({ name: 'sendTransactionDelegatedFee', file: FILE_NAME })
 
-  const tx = wallet.caver.transaction.feeDelegatedSmartContractExecution.create({
+  const txParams = {
     from: wallet.address,
     to,
     input: payload,
     gas: gasLimit,
     value: value || '0x00'
-  })
+  }
+  const tx = wallet.caver.transaction.feeDelegatedSmartContractExecution.create(txParams)
   await wallet.caver.wallet.sign(wallet.address, tx)
 
   const transactionData: ITransactionData = {
@@ -174,16 +175,21 @@ export async function sendTransactionDelegatedFee({
 
   const endpoint = buildUrl(ORAKL_NETWORK_DELEGATOR_URL, `sign`)
 
+  let response
   try {
-    const result = (
+    response = (
       await axios.post(endpoint, {
         ...transactionData
       })
     )?.data
-    if (result?.signedRawTx) {
-      const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(result.signedRawTx)
-      _logger.debug(txReceipt, 'txReceipt')
+  } catch (e) {
+    throw new OraklError(OraklErrorCode.DelegatorServerIssue)
+  }
 
+  try {
+    if (response?.signedRawTx) {
+      const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(response.signedRawTx)
+      _logger.debug(txReceipt, 'txReceipt')
       return txReceipt
     } else {
       throw new OraklError(OraklErrorCode.MissingSignedRawTx)
@@ -191,5 +197,37 @@ export async function sendTransactionDelegatedFee({
   } catch (e) {
     _logger.error(e, 'e')
     throw e
+  }
+}
+
+export async function sendTransactionCaver({
+  wallet,
+  to,
+  payload,
+  gasLimit,
+  logger,
+  value
+}: {
+  wallet: CaverWallet
+  to: string
+  payload: string
+  gasLimit: number | string
+  logger: Logger
+  value?: number | string
+}) {
+  const txParams = {
+    from: wallet.address,
+    to,
+    input: payload,
+    gasLimit,
+    value: value || '0x00'
+  }
+
+  try {
+    const tx = wallet.caver.transaction.smartContractExecution.create(txParams)
+    await wallet.caver.wallet.sign(wallet.address, tx)
+    const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(tx.getRawTransaction())
+  } catch (e) {
+    throw new OraklError(OraklErrorCode.CaverTxTransactionFailed)
   }
 }


### PR DESCRIPTION
# Description

This PR defines a fallback function for `Orakl Network Data Feed` reporters in case they cannot reach `Orakl Network Delegator`. If `Orakl Network Delegator` cannot be reached, reporters will submit transactions and pay for it by themselves.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
