### PR TITLE
`lowercase` delegator `contract` and `reporter` account addresses

### DIFF
--- a/delegator/src/contract/contract.service.ts
+++ b/delegator/src/contract/contract.service.ts
@@ -10,6 +10,7 @@ export class ContractService {
   constructor(private prisma: PrismaService) {}
 
   async create(data: ContractDto) {
+    data.address = data.address.toLocaleLowerCase()
     return await this.prisma.contract.create({ data })
   }
 

--- a/delegator/src/reporter/reporter.service.ts
+++ b/delegator/src/reporter/reporter.service.ts
@@ -9,6 +9,7 @@ export class ReporterService {
   constructor(private prisma: PrismaService) {}
 
   async create(reporterDto: ReporterDto) {
+    reporterDto.address = reporterDto.address.toLocaleLowerCase()
     const data: Prisma.ReporterUncheckedCreateInput = {
       address: reporterDto.address,
       organizationId: reporterDto.organizationId

--- a/delegator/src/sign/sign.service.ts
+++ b/delegator/src/sign/sign.service.ts
@@ -22,6 +22,8 @@ export class SignService {
 
   async create(data: SignDto) {
     try {
+      data.from = data.from.toLocaleLowerCase()
+      data.to = data.to.toLocaleLowerCase()
       const transaction = await this.prisma.transaction.create({ data })
       const validatedResult = await this.validateTransaction(transaction)
       const signedRawTx = await this.signTxByFeePayer(transaction)


### PR DESCRIPTION
# Description

This PR is to solve address mismatch with delegator and transaction. I provide solution for this problem by taking lowercase `contract` and `reporter` account address.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
