### PR TITLE
Allow to submit on previous round

### DIFF
--- a/contracts/src/v0.1/Aggregator.sol
+++ b/contracts/src/v0.1/Aggregator.sol
@@ -618,22 +618,6 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
         return currentRound + 1;
     }
 
-    /**
-     * @dev In general, oracles are supposed to submit to the current
-     * round that is denoted by `reportingRoundId` variable. In some
-     * cases, when the current round is `supersedable`, we allow them to
-     * submit to the next round.
-     * The only exception of submitting on previous round
-     * (`reportingRound - 1`) is when the current round has not
-     * received enough submissions to produce an aggregate value.
-     */
-    function previousAndCurrentUnanswered(
-        uint32 _roundId,
-        uint32 _rrId
-    ) private view returns (bool) {
-        return _roundId + 1 == _rrId && rounds[_rrId].updatedAt == 0;
-    }
-
     function addOracle(address _oracle) private {
         if (oracleEnabled(_oracle)) {
             revert OracleAlreadyEnabled();
@@ -679,9 +663,8 @@ contract Aggregator is Ownable, IAggregator, ITypeAndVersion {
             _roundId != rrId &&
             // Not reporting on next round.
             _roundId != rrId + 1 &&
-            // Not reporting on the previous round while the current
-            // round has not finished yet.
-            !previousAndCurrentUnanswered(_roundId, rrId)
+            // Not reporting on previous round
+            _roundId != rrId - 1
         ) return "invalid round to report";
         if (_roundId != 1 && !supersedable(_roundId - 1)) return "previous round not supersedable";
 

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -527,13 +527,6 @@ describe('Aggregator', function () {
     await aggregator.contract.changeOracles([], [oracle0.address], 1, 1, 0)
 
     {
-      const roundId = 2
-      await expect(aggregator.contract.connect(oracle0).submit(roundId, answer)).to.be.revertedWith(
-        'invalid round to report'
-      )
-    }
-
-    {
       const roundId = 1
       await aggregator.contract.connect(oracle0).submit(roundId, answer)
       await expect(aggregator.contract.connect(oracle0).submit(roundId, answer)).to.be.revertedWith(

--- a/contracts/test/v0.1/Aggregator.test.cjs
+++ b/contracts/test/v0.1/Aggregator.test.cjs
@@ -563,4 +563,31 @@ describe('Aggregator', function () {
       ).to.be.revertedWith('no longer allowed oracle')
     }
   })
+
+  it('Submission to previous round', async function () {
+    const { aggregator, account2: oracle0, account3: oracle1 } = await loadFixture(deploy)
+
+    await aggregator.contract.changeOracles([], [oracle0.address, oracle1.address], 1, 2, 0)
+
+    {
+      const round = 1
+      await aggregator.contract.connect(oracle0).submit(round, 123)
+      await aggregator.contract.connect(oracle1).submit(round, 123)
+    }
+
+    {
+      const round = 2
+      await aggregator.contract.connect(oracle0).submit(round, 123)
+    }
+
+    {
+      const round = 3
+      await aggregator.contract.connect(oracle0).submit(round, 123)
+    }
+
+    {
+      const round = 2
+      await aggregator.contract.connect(oracle1).submit(round, 123)
+    }
+  })
 })


### PR DESCRIPTION
# Description

There are few rare cases when it is possible to submit on previous round in the original code.. However, when executing frequent data submissions to aggregator, there are inevitable desynchronization issues between reporters. This PR allows to submit on previous round, not only in few rare edge cases.

This will help us to increase the speed of submission in long term, and if we want to be more precise in future, we will have to modify the contract overall to be able to support such uses.

Fixes # (issue)

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
