### PR TITLE
fix listener `bullmq` `worker_id` collusion

### DIFF
--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -213,6 +213,7 @@ export class State {
     }
     await this.latestListenerQueue.add('latest-repeatable', outData, {
       ...LISTENER_JOB_SETTINGS,
+      jobId: contractAddress,
       repeat: {
         every: LISTENER_DELAY
       }

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -248,6 +248,22 @@ export class State {
 
     const removedListener = activeListeners.splice(index, 1)[0]
 
+    const jobs = (await this.latestListenerQueue.getRepeatableJobs()).filter(
+      (job) => job.id == removedListener.address
+    )
+
+    if (jobs.length != 1) {
+      throw new OraklError(
+        OraklErrorCode.UnexpectedNumberOfJobsInQueue,
+        `Number of jobs ${jobs.length}`
+      )
+    } else {
+      const deleyedJob = jobs[0]
+      await this.latestListenerQueue.removeRepeatableByKey(deleyedJob.key)
+
+      this.logger.debug({ job: 'deleted' }, `Listener deleyed job with KEY=${deleyedJob.key}`)
+    }
+
     const numUpdatedActiveListeners = activeListeners.length
     if (numActiveListeners === numUpdatedActiveListeners) {
       const msg = `Listener with ID=${id} was not removed.`

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -258,10 +258,10 @@ export class State {
         `Number of jobs ${jobs.length}`
       )
     } else {
-      const deleyedJob = jobs[0]
-      await this.latestListenerQueue.removeRepeatableByKey(deleyedJob.key)
+      const delayedJob = jobs[0]
+      await this.latestListenerQueue.removeRepeatableByKey(delayedJob.key)
 
-      this.logger.debug({ job: 'deleted' }, `Listener deleyed job with KEY=${deleyedJob.key}`)
+      this.logger.debug({ job: 'deleted' }, `Listener delayed job with KEY=${delayedJob.key}`)
     }
 
     const numUpdatedActiveListeners = activeListeners.length


### PR DESCRIPTION
# Description

This PR is ready to review and merge. 

This PR is to fix running multiple reporters with `repeatable delayed jobs`. The problems is when we start all the reporters at once, all of the jobs will have same job id. 

- This collusion `jobId` is fixed by adding manual repeat job id as listening contract address. By making this all of the jobs will be unique by contract address. 

<img width="879" alt="image" src="https://github.com/Bisonai/orakl/assets/30230748/8e60b4b9-a50e-43c0-8cd1-e081a07e0688">

- Additional, this PR is also include fixing of deactivation of listeners. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
