### PR TITLE
Increase VRF_FULFILL_GAS_MINIMUM to 450k

### DIFF
--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -22,7 +22,7 @@ export const LOCAL_AGGREGATOR = process.env.LOCAL_AGGREGATOR || 'MEDIAN'
 export const LISTENER_DELAY = Number(process.env.LISTENER_DELAY) || 500
 
 // Gas mimimums
-export const VRF_FULFILL_GAS_MINIMUM = 400_000
+export const VRF_FULFILL_GAS_MINIMUM = 450_000
 export const REQUEST_RESPONSE_FULFILL_GAS_MINIMUM = 400_000
 export const DATA_FEED_FULFILL_GAS_MINIMUM = 400_000
 export const VRF_FULLFILL_GAS_PER_WORD = 1_000


### PR DESCRIPTION
# Description

Increase `VRF_FULFILL_GAS_MINIMUM` because of nondeterministic computation of VRF proof verification on chain. We can observe the  gas used for verification over the time and then lower it if necessary.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
