### PR TITLE
hardhat task to transfer Klay

### DIFF
--- a/contracts/hardhat.config.cjs
+++ b/contracts/hardhat.config.cjs
@@ -188,4 +188,5 @@ task('send-klay', 'Send $KLAY from faucet')
     console.log(`After balance of account ${to}: ${balanceKlay} Klay`)
     console.log(txReceipt)
   })
+
 module.exports = config

--- a/contracts/hardhat.config.cjs
+++ b/contracts/hardhat.config.cjs
@@ -158,19 +158,19 @@ task('send-klay', 'Send $KLAY from faucet')
   .addParam('amount', 'The amount of $KLAY to be send')
   .setAction(async (taskArgs, hre) => {
     let wallet
-    const PROVIDER = process.env.PROVIDER || ''
+    const PROVIDER = process.env.PROVIDER
     const provider = new ethers.providers.JsonRpcProvider(PROVIDER)
 
     if (process.env.PRIVATE_KEY) {
-      const PRIVATE_KEY = process.env.PRIVATE_KEY || ''
+      const PRIVATE_KEY = process.env.PRIVATE_KEY
       wallet = await new ethers.Wallet(PRIVATE_KEY, provider)
     } else {
-      const MNEMONIC = process.env.MNEMONIC || ''
+      const MNEMONIC = process.env.MNEMONIC
       wallet = ethers.Wallet.fromMnemonic(MNEMONIC).connect(provider)
     }
 
-    const to = taskArgs.address || ''
-    const amount = taskArgs.amount || '0'
+    const to = taskArgs.address
+    const amount = taskArgs.amount
     const value = ethers.utils.parseUnits(amount, 'ether')
 
     console.log(`Transfer ${amount} Klay from ${wallet.address} to ${to}`)

--- a/contracts/hardhat.config.cjs
+++ b/contracts/hardhat.config.cjs
@@ -153,4 +153,39 @@ task('set-burn-fee-ratio', 'Change the burn fee ratio')
     console.log(`Burn Fee Ratio changed from:${curBurnFeeRatio} to ${newBurnFeeRatio}`)
   })
 
+task('send-klay', 'Send $KLAY from faucet')
+  .addParam('address', 'The receiving address')
+  .addParam('amount', 'The amount of $KLAY to be send')
+  .setAction(async (taskArgs, hre) => {
+    let wallet
+    const PROVIDER = process.env.PROVIDER || ''
+    const provider = new ethers.providers.JsonRpcProvider(PROVIDER)
+
+    if (process.env.PRIVATE_KEY) {
+      const PRIVATE_KEY = process.env.PRIVATE_KEY || ''
+      wallet = await new ethers.Wallet(PRIVATE_KEY, provider)
+    } else {
+      const MNEMONIC = process.env.MNEMONIC || ''
+      wallet = ethers.Wallet.fromMnemonic(MNEMONIC).connect(provider)
+    }
+
+    const to = taskArgs.address || ''
+    const amount = taskArgs.amount || '0'
+    const value = ethers.utils.parseUnits(amount, 'ether')
+
+    console.log(`Transfer ${amount} Klay from ${wallet.address} to ${to}`)
+
+    const tx = {
+      from: wallet.address,
+      to: taskArgs.address,
+      value
+    }
+    const txReceipt = await (await wallet.sendTransaction(tx)).wait()
+
+    const balance = await provider.getBalance(to)
+    const balanceKlay = hre.web3.utils.fromWei(balance.toString(), 'ether')
+
+    console.log(`After balance of account ${to}: ${balanceKlay} Klay`)
+    console.log(txReceipt)
+  })
 module.exports = config


### PR DESCRIPTION
# Description

This PR is ready to review and merge. With this PR I added new hardhat task, to transfer native token from the wallet to any account. Wallet will be created from `PRIVATE_KEY` or `MNEMONIC` env variable. 
  
How to use

- The following command is how to transfer money with address and amount as a input variable. 
` npx hardhat send-klay --address ${address} --amount 1`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
