### PR TITLE
use `call()` method before sending transaction

### DIFF
--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -93,9 +93,8 @@ export async function sendTransaction({
   _logger.debug(tx, 'tx')
 
   try {
-    // Evaluate transaction against current blockchain state. Throws
-    // an exception when transaction fails.
-    await await wallet.call(tx)
+    // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
+    await wallet.call(tx)
     const txReceipt = await (await wallet.sendTransaction(tx)).wait(1)
     _logger.debug(txReceipt, 'txReceipt')
     if (txReceipt === null) {
@@ -103,9 +102,6 @@ export async function sendTransaction({
     }
   } catch (e) {
     _logger.debug(e, 'e')
-
-    _logger.debug('Error:', e.reason)
-    _logger.debug('Error:', e.value)
 
     let msg
     let error
@@ -238,8 +234,7 @@ export async function sendTransactionCaver({
     await tx.fillTransaction()
     await wallet.caver.wallet.sign(wallet.address, tx)
 
-    // Evaluate transaction against current blockchain state. Throws
-    // an exception when transaction fails.
+    // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
     await wallet.caver.rpc.klay.call(tx)
     const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(tx.getRawTransaction())
     _logger.debug(txReceipt, 'txReceipt')

--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -93,6 +93,9 @@ export async function sendTransaction({
   _logger.debug(tx, 'tx')
 
   try {
+    // Evaluate transaction against current blockchain state. Throws
+    // an exception when transaction fails.
+    await await wallet.call(tx)
     const txReceipt = await (await wallet.sendTransaction(tx)).wait(1)
     _logger.debug(txReceipt, 'txReceipt')
     if (txReceipt === null) {
@@ -100,6 +103,9 @@ export async function sendTransaction({
     }
   } catch (e) {
     _logger.debug(e, 'e')
+
+    _logger.debug('Error:', e.reason)
+    _logger.debug('Error:', e.value)
 
     let msg
     let error
@@ -188,6 +194,8 @@ export async function sendTransactionDelegatedFee({
 
   try {
     if (response?.signedRawTx) {
+      // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
+      await wallet.caver.rpc.klay.call(response.signedRawTx)
       const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(response.signedRawTx)
       _logger.debug(txReceipt, 'txReceipt')
       return txReceipt
@@ -229,6 +237,10 @@ export async function sendTransactionCaver({
     const tx = wallet.caver.transaction.smartContractExecution.create(txParams)
     await tx.fillTransaction()
     await wallet.caver.wallet.sign(wallet.address, tx)
+
+    // Evaluate transaction against current blockchain state. Throws
+    // an exception when transaction fails.
+    await wallet.caver.rpc.klay.call(tx)
     const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(tx.getRawTransaction())
     _logger.debug(txReceipt, 'txReceipt')
   } catch (e) {

--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -93,7 +93,6 @@ export async function sendTransaction({
   _logger.debug(tx, 'tx')
 
   try {
-    // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
     await wallet.call(tx)
     const txReceipt = await (await wallet.sendTransaction(tx)).wait(1)
     _logger.debug(txReceipt, 'txReceipt')
@@ -190,7 +189,6 @@ export async function sendTransactionDelegatedFee({
 
   try {
     if (response?.signedRawTx) {
-      // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
       await wallet.caver.rpc.klay.call(response.signedRawTx)
       const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(response.signedRawTx)
       _logger.debug(txReceipt, 'txReceipt')
@@ -233,8 +231,6 @@ export async function sendTransactionCaver({
     const tx = wallet.caver.transaction.smartContractExecution.create(txParams)
     await tx.fillTransaction()
     await wallet.caver.wallet.sign(wallet.address, tx)
-
-    // Evaluate transaction against current blockchain state. Throws an exception when transaction fails.
     await wallet.caver.rpc.klay.call(tx)
     const txReceipt = await wallet.caver.rpc.klay.sendRawTransaction(tx.getRawTransaction())
     _logger.debug(txReceipt, 'txReceipt')


### PR DESCRIPTION
# Description

This PR is ready to review and merge. The main change with this PR is to use `.call()` before sending transaction on `orakl-core` reporter to check if the transaction compatible to execute with latest blockchain state. 
This change effect for all `orakl-services` such as `Price-Feed`, `RR`, and `VRF`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
