### PR TITLE
Update headers type to match axios request parameter

### DIFF
--- a/fetcher/src/job/job.types.ts
+++ b/fetcher/src/job/job.types.ts
@@ -11,7 +11,7 @@ export interface IData {
 }
 
 interface IHeader {
-  'Content-Type': string
+  [key: string]: string
 }
 
 interface IReducer {
@@ -22,7 +22,7 @@ interface IReducer {
 interface IDefinition {
   url: string
   method: string
-  headers: IHeader[]
+  headers: IHeader
   reducers: IReducer[]
 }
 


### PR DESCRIPTION
# Description

previous feed headers definition had array of IHeader type and `IHeader` type contained only `Content-Type` key which wasn't compatible with axios request parameter type. now fixing the data type to object that can have multiple headers attributes.

it was running without any errors since type checking wasn't happening in `fetcher/src/job/job.utils.ts`, sending parameter with `any` type.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
