### PR TITLE
Fix return type of `startedAt` on price feed worker

### DIFF
--- a/core/src/worker/data-feed.utils.ts
+++ b/core/src/worker/data-feed.utils.ts
@@ -23,7 +23,7 @@ export async function getSynchronizedDelay({
 }): Promise<number> {
   logger.debug('getSynchronizedDelay')
 
-  const { startedAt } = await currentRoundStartedAtCall({
+  const startedAt = await currentRoundStartedAtCall({
     oracleAddress,
     logger
   })


### PR DESCRIPTION
# Description

I found a small issue where we get data in wrong format in data feed worker. While we launch `data-feed worker` or `activate data-feed` we checks the remaining time to submit for the round. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
