### PR TITLE
Detailed err message on wrong request url

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -74,9 +74,9 @@ export async function isOraklFetcherHealthy(url: string) {
       return false
     }
   } catch (error) {
-      console.error(
-        `An error occurred while checking the Orakl Network Fetcher [${url}]: ${error.message}`
-      )
+    console.error(
+      `An error occurred while checking the Orakl Network Fetcher [${url}]: ${error.message}`
+    )
     return false
   }
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -60,11 +60,12 @@ export async function isOraklNetworkApiHealthy() {
 }
 
 export async function isOraklFetcherHealthy(url: string) {
-  try {
-    if (!(await isValidUrl(url))) {
-      throw new Error('Invalid URL')
-    }
+  if (!(await isValidUrl(url))) {
+    console.error('Invalid URL')
+    return false
+  }
 
+  try {
     const response = await axios.get(url)
     if (response.status === 200) {
       return true
@@ -73,13 +74,9 @@ export async function isOraklFetcherHealthy(url: string) {
       return false
     }
   } catch (error) {
-    if (error.message === 'Invalid URL') {
-      console.error(error.message)
-    } else {
       console.error(
         `An error occurred while checking the Orakl Network Fetcher [${url}]: ${error.message}`
       )
-    }
     return false
   }
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -52,7 +52,6 @@ export function buildFetcherUrl(host: string, port: string, apiVersion: string) 
 
 export async function isOraklNetworkApiHealthy() {
   try {
-    
     return 200 === (await axios.get(ORAKL_NETWORK_API_URL))?.status
   } catch (e) {
     console.error(`Orakl Network API [${ORAKL_NETWORK_API_URL}] is down`)
@@ -63,7 +62,6 @@ export async function isOraklNetworkApiHealthy() {
 export async function isOraklFetcherHealthy(url: string) {
   try {
     if (!(await isValidUrl(url))) throw new Error('invalid url')
-
     return 200 === (await axios.get(url))?.status
   } catch (e) {
     console.error(`Orakl Network Fetcher [${url}] is down`)
@@ -84,7 +82,7 @@ export async function isServiceHealthy(url: string) {
   const healthEndpoint = buildUrl(url, 'health')
   try {
     if (!(await isValidUrl(url))) throw new Error('invalid url')
-    
+
     return 200 === (await axios.get(healthEndpoint))?.status
   } catch (e) {
     console.log(e)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -61,10 +61,25 @@ export async function isOraklNetworkApiHealthy() {
 
 export async function isOraklFetcherHealthy(url: string) {
   try {
-    if (!(await isValidUrl(url))) throw new Error('invalid url')
-    return 200 === (await axios.get(url))?.status
-  } catch (e) {
-    console.error(`Orakl Network Fetcher [${url}] is down`)
+    if (!(await isValidUrl(url))) {
+      throw new Error('Invalid URL')
+    }
+
+    const response = await axios.get(url)
+    if (response.status === 200) {
+      return true
+    } else {
+      console.error(`Orakl Network Fetcher [${url}] is down. HTTP Status: ${response.status}`)
+      return false
+    }
+  } catch (error) {
+    if (error.message === 'Invalid URL') {
+      console.error(error.message)
+    } else {
+      console.error(
+        `An error occurred while checking the Orakl Network Fetcher [${url}]: ${error.message}`
+      )
+    }
     return false
   }
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -52,6 +52,7 @@ export function buildFetcherUrl(host: string, port: string, apiVersion: string) 
 
 export async function isOraklNetworkApiHealthy() {
   try {
+    
     return 200 === (await axios.get(ORAKL_NETWORK_API_URL))?.status
   } catch (e) {
     console.error(`Orakl Network API [${ORAKL_NETWORK_API_URL}] is down`)
@@ -61,6 +62,8 @@ export async function isOraklNetworkApiHealthy() {
 
 export async function isOraklFetcherHealthy(url: string) {
   try {
+    if (!(await isValidUrl(url))) throw new Error('invalid url')
+
     return 200 === (await axios.get(url))?.status
   } catch (e) {
     console.error(`Orakl Network Fetcher [${url}] is down`)
@@ -80,6 +83,8 @@ export async function isOraklDelegatorHealthy() {
 export async function isServiceHealthy(url: string) {
   const healthEndpoint = buildUrl(url, 'health')
   try {
+    if (!(await isValidUrl(url))) throw new Error('invalid url')
+    
     return 200 === (await axios.get(healthEndpoint))?.status
   } catch (e) {
     console.log(e)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -96,8 +96,6 @@ export async function isOraklDelegatorHealthy() {
 export async function isServiceHealthy(url: string) {
   const healthEndpoint = buildUrl(url, 'health')
   try {
-    if (!(await isValidUrl(url))) throw new Error('invalid url')
-
     return 200 === (await axios.get(healthEndpoint))?.status
   } catch (e) {
     console.log(e)


### PR DESCRIPTION
# Description

Previously, when requested `cli fetcher active` with wrong host and port, it returned following message
`Orakl Network Fetcher [${url}] is down`.

Now it checks if url is valid and returns
`Invalid URL` on wrong request

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
