### PR TITLE
Increase data feed reporter concurrency from 5 to 10

### DIFF
--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -13,7 +13,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     stateName: DATA_FEED_REPORTER_STATE_NAME,
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
-    concurrency: 5,
+    concurrency: 10,
     delegatedFee: true,
     _logger: logger
   })


### PR DESCRIPTION
# Description

Running many data feeds requires higher reporter concurrency. Trying to double and see how much it helps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
