### PR TITLE
Use delegated fee only from `cypress` and `baobab`

### DIFF
--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -3,18 +3,23 @@ import type { RedisClientType } from 'redis'
 import {
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
-  REPORTER_AGGREGATOR_QUEUE_NAME
+  REPORTER_AGGREGATOR_QUEUE_NAME,
+  PROVIDER_URL
 } from '../settings'
 import { factory } from './factory'
+import ethers from 'ethers'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
+  const provider = new ethers.providers.JsonRpcProvider(PROVIDER_URL)
+  const chainId = (await provider.getNetwork()).chainId;
+
   await factory({
     redisClient,
     stateName: DATA_FEED_REPORTER_STATE_NAME,
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: 10,
-    delegatedFee: true,
+    delegatedFee: [1001, 8217].includes(chainId) ? true : false,
     _logger: logger
   })
 }

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -1,17 +1,17 @@
+import ethers from 'ethers'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
-  REPORTER_AGGREGATOR_QUEUE_NAME,
-  PROVIDER_URL
+  PROVIDER_URL,
+  REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
-import ethers from 'ethers'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
   const provider = new ethers.providers.JsonRpcProvider(PROVIDER_URL)
-  const chainId = (await provider.getNetwork()).chainId;
+  const chainId = (await provider.getNetwork()).chainId
 
   await factory({
     redisClient,

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -4,14 +4,15 @@ import type { RedisClientType } from 'redis'
 import {
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
-  PROVIDER_URL,
-  REPORTER_AGGREGATOR_QUEUE_NAME
+  REPORTER_AGGREGATOR_QUEUE_NAME,
+  PROVIDER,
+  BAOBAB_CHAIN_ID,
+  CYPRESS_CHAIN_ID
 } from '../settings'
 import { factory } from './factory'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
-  const provider = new ethers.providers.JsonRpcProvider(PROVIDER_URL)
-  const chainId = (await provider.getNetwork()).chainId
+  const chainId = (await PROVIDER.getNetwork()).chainId
 
   await factory({
     redisClient,
@@ -19,7 +20,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: 10,
-    delegatedFee: [1001, 8217].includes(chainId) ? true : false,
+    delegatedFee: [BAOBAB_CHAIN_ID, CYPRESS_CHAIN_ID].includes(chainId) ? true : false,
     _logger: logger
   })
 }

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -1,13 +1,12 @@
-import ethers from 'ethers'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
+  BAOBAB_CHAIN_ID,
+  CYPRESS_CHAIN_ID,
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
-  REPORTER_AGGREGATOR_QUEUE_NAME,
   PROVIDER,
-  BAOBAB_CHAIN_ID,
-  CYPRESS_CHAIN_ID
+  REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -79,6 +79,9 @@ export const HEARTBEAT_JOB_NAME = `${DEPLOYMENT_NAME}-heartbeat-job`
 export const L2_CHAIN = process.env.L2_CHAIN || 'localhost'
 export const L2_PROVIDER_URL = process.env.L2_PROVIDER_URL || 'http://127.0.0.1:8545'
 
+export const BAOBAB_CHAIN_ID = 1001
+export const CYPRESS_CHAIN_ID = 8217
+
 export const ALL_QUEUES = [
   LISTENER_REQUEST_RESPONSE_LATEST_QUEUE_NAME,
   LISTENER_VRF_LATEST_QUEUE_NAME,


### PR DESCRIPTION
# Description

checks current chainId on building reporter and allow delegated fee only from `baobab` and `cypress`.
`baobab`: 1001
`cypress`: 8217

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
