### PR TITLE
Don't publish images on closed PRs

### DIFF
--- a/.github/workflows/admin.image+upload.yaml
+++ b/.github/workflows/admin.image+upload.yaml
@@ -1,13 +1,11 @@
-name: ADMIN Deploy to Amazon ECR
+name: Admin Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "admin/**"
-    types:
-      - closed
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-general
@@ -35,7 +33,7 @@ jobs:
         id: package
         run: |
           echo "version=$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
-          
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -69,7 +67,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(admin)
         run: |

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -1,13 +1,11 @@
 name: API Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "api/**"
-    types:
-      - closed
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-api
@@ -35,7 +33,7 @@ jobs:
         id: package
         run: |
           echo "version=$(node -p -e "require('./api/package.json').version")" >> $GITHUB_OUTPUT
-          
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -65,7 +63,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(api)
         run: |

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -1,13 +1,11 @@
 name: CLI Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "cli/**"
-    types:
-      - closed
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-cli
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -65,7 +63,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(cli)
         run: |

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -1,13 +1,11 @@
 name: Core Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "core/**"
-    types:
-      - closed  
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-core
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -65,7 +63,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(core)
         run: |

--- a/.github/workflows/delegator.image+upload.yaml
+++ b/.github/workflows/delegator.image+upload.yaml
@@ -1,14 +1,12 @@
 name: Delegator Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "delegator/**"
-    types:
-      - closed  
-  
+
   push:
     branches:
       - i-519/delegator-git-actions-building-image
@@ -47,7 +45,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -69,7 +67,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(delegator)
         run: |

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -1,13 +1,11 @@
 name: Fetcher Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "fetcher/**"
-    types:
-      - closed
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-fetcher
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -65,7 +63,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR(fetcher)
         run: |

--- a/.github/workflows/monitor.image+upload.yaml
+++ b/.github/workflows/monitor.image+upload.yaml
@@ -1,13 +1,11 @@
 name: Monitor Deploy to Amazon ECR
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
       - "monitor/**"
-    types:
-      - closed
 
 env:
   ecr_url: public.ecr.aws/bisonai/orakl-general
@@ -35,7 +33,7 @@ jobs:
         id: package
         run: |
           echo "version=$(node -p -e "require('./package.json').version")" >> $GITHUB_OUTPUT
-          
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -43,7 +41,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     outputs:
       tag_date: ${{ steps.tag.outputs.date }}
@@ -65,7 +63,7 @@ jobs:
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registry-type: public        
+          registry-type: public
 
       - name: Publish Image to ECR
         run: |


### PR DESCRIPTION
# Description

This PR updates Github action pipelines that generated images and publish them to Amazon ECR. These pipelines are triggered by `closing` PR, however, we want to trigger such pipelines when PR is merged to master branch.

Recently, one PR was accidentally closed https://github.com/Bisonai/orakl/pull/847 which caused to trigger the pipeline https://github.com/Bisonai/orakl/actions/runs/6821457480. 

The change is from on `pull_request` to on `push`, and removes `closed` activity.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
