### PR TITLE
Allow to set data feed reporter concurrency through env var

### DIFF
--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -3,6 +3,7 @@ import type { RedisClientType } from 'redis'
 import {
   BAOBAB_CHAIN_ID,
   CYPRESS_CHAIN_ID,
+  DATA_FEED_REPORTER_CONCURRENCY,
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
   PROVIDER,
@@ -18,7 +19,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     stateName: DATA_FEED_REPORTER_STATE_NAME,
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
-    concurrency: 10,
+    concurrency: DATA_FEED_REPORTER_CONCURRENCY,
     delegatedFee: [BAOBAB_CHAIN_ID, CYPRESS_CHAIN_ID].includes(chainId) ? true : false,
     _logger: logger
   })

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -44,6 +44,7 @@ export const MAX_DATA_STALENESS = 5_000
 export const REMOVE_ON_COMPLETE = 500
 export const REMOVE_ON_FAIL = 1_000
 export const CONCURRENCY = 12
+export const DATA_FEED_REPORTER_CONCURRENCY = process.env.DATA_FEED_REPORTER_CONCURRENCY || 15
 
 export const LISTENER_REQUEST_RESPONSE_LATEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-listener-request-response-latest-queue`
 export const LISTENER_VRF_LATEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-listener-vrf-latest-queue`

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -44,7 +44,8 @@ export const MAX_DATA_STALENESS = 5_000
 export const REMOVE_ON_COMPLETE = 500
 export const REMOVE_ON_FAIL = 1_000
 export const CONCURRENCY = 12
-export const DATA_FEED_REPORTER_CONCURRENCY = process.env.DATA_FEED_REPORTER_CONCURRENCY || 15
+export const DATA_FEED_REPORTER_CONCURRENCY =
+  Number(process.env.DATA_FEED_REPORTER_CONCURRENCY) || 15
 
 export const LISTENER_REQUEST_RESPONSE_LATEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-listener-request-response-latest-queue`
 export const LISTENER_VRF_LATEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-listener-vrf-latest-queue`


### PR DESCRIPTION
# Description

This PR allows to set a data feed reporter concurrency without rebuilding reporter. The data feed concurrency can be set through `DATA_FEED_REPORTER_CONCURRENCY` environment variable. If environment variable is not supplied, the default value of 15 workers is used.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
