### PR TITLE
Add reducer for fetcher

### DIFF
--- a/fetcher/src/job/job.errors.ts
+++ b/fetcher/src/job/job.errors.ts
@@ -15,5 +15,6 @@ export enum FetcherErrorCode {
   InvalidDataFeedFormat,
   InvalidReducer,
   MissingKeyInJson,
-  UnexpectedNumberOfJobs
+  UnexpectedNumberOfJobs,
+  DivisionByZero
 }

--- a/fetcher/src/job/job.reducer.ts
+++ b/fetcher/src/job/job.reducer.ts
@@ -5,7 +5,8 @@ export const DATA_FEED_REDUCER_MAPPING = {
   MUL: mulFn,
   POW10: pow10Fn,
   ROUND: roundFn,
-  INDEX: indexFn
+  INDEX: indexFn,
+  DIVFROM: divFromFn
 }
 
 /**
@@ -37,6 +38,13 @@ export function parseFn(args: string | string[]) {
 export function mulFn(args: number) {
   function wrapper(value: number) {
     return value * args
+  }
+  return wrapper
+}
+
+export function divFromFn(args: number) {
+  function wrapper(value: number) {
+    return args / value
   }
   return wrapper
 }

--- a/fetcher/src/job/job.reducer.ts
+++ b/fetcher/src/job/job.reducer.ts
@@ -44,6 +44,9 @@ export function mulFn(args: number) {
 
 export function divFromFn(args: number) {
   function wrapper(value: number) {
+    if (value == 0) {
+      throw new FetcherError(FetcherErrorCode.DivisionByZero)
+    }
     return args / value
   }
   return wrapper


### PR DESCRIPTION
# Description

some foreign exchange only supports reversed pairs.

for example `USD-KRW` is supported rather than `KRW-USD`.
somehow, after getting 1 USD price in KRW, for example `1USD = 1350KRW`, 
to get 1 KRW price in USD, it should be calculated with reversed division `1 KRW = 1 / 1350 USD`.

this PR adds reducer for that functionality

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
