### PR TITLE
Increase fetcher workers 11 -> 20

### DIFF
--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -18,6 +18,7 @@ Orakl Network Fetcher requires to set the following environment variables.
 - `APP_PORT`
 - `CHAIN`
 - `FETCHER_TYPE`
+- `CONCURRENCY`
 
 You can copy them from `.env.example` to `.env` and fill the appropriate values.
 

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -3,7 +3,7 @@ dotenv.config()
 
 export const FETCHER_QUEUE_NAME = 'orakl-fetcher-queue'
 
-export const WORKER_OPTS = { concurrency: process.env.CONCURRENCY || 20 }
+export const WORKER_OPTS = { concurrency: Number(process.env.CONCURRENCY) || 20 }
 
 export const FETCH_FREQUENCY = 2_000
 

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -3,7 +3,7 @@ dotenv.config()
 
 export const FETCHER_QUEUE_NAME = 'orakl-fetcher-queue'
 
-export const WORKER_OPTS = { concurrency: 11 }
+export const WORKER_OPTS = { concurrency: 20 }
 
 export const FETCH_FREQUENCY = 2_000
 

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -3,7 +3,7 @@ dotenv.config()
 
 export const FETCHER_QUEUE_NAME = 'orakl-fetcher-queue'
 
-export const WORKER_OPTS = { concurrency: 20 }
+export const WORKER_OPTS = { concurrency: process.env.CONCURRENCY || 20 }
 
 export const FETCH_FREQUENCY = 2_000
 


### PR DESCRIPTION
# Description

Introduce `CONCURRENCY` environment variable to `Orakl Network Fetcher` and set its default value to 20.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
