### PR TITLE
Add proxy location

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -132,3 +132,10 @@ GET http://localhost:3000/api/v1/proxy
 3. Insert `Aggregator` (initial settings)
 4. Insert `Proxy` (during fetching data with Orakl Network Fetcher)
 5. Insert `Data` (during regular data fetching with Orakl Network Fetcher)
+
+## Proxy Location codes
+
+| location  | code |
+| --------- | ---- |
+| Korea     | kr   |
+| Singapore | sg   |

--- a/api/prisma/migrations/20231116075406_add_proxy_location/migration.sql
+++ b/api/prisma/migrations/20231116075406_add_proxy_location/migration.sql
@@ -6,17 +6,3 @@
 */
 -- AlterTable
 ALTER TABLE "proxies" ADD COLUMN     "location" TEXT NOT NULL;
-
--- CreateTable
-CREATE TABLE "L2AggregatorPair" (
-    "id" BIGSERIAL NOT NULL,
-    "l1_aggregator_addresss" TEXT NOT NULL,
-    "l2_aggregator_addresss" TEXT NOT NULL,
-    "active" BOOLEAN NOT NULL DEFAULT false,
-    "chain_id" BIGINT NOT NULL,
-
-    CONSTRAINT "L2AggregatorPair_pkey" PRIMARY KEY ("id")
-);
-
--- AddForeignKey
-ALTER TABLE "L2AggregatorPair" ADD CONSTRAINT "L2AggregatorPair_chain_id_fkey" FOREIGN KEY ("chain_id") REFERENCES "chains"("chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/migrations/20231116075406_add_proxy_location/migration.sql
+++ b/api/prisma/migrations/20231116075406_add_proxy_location/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - Added the required column `location` to the `proxies` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "proxies" ADD COLUMN     "location" TEXT NOT NULL;
+
+-- CreateTable
+CREATE TABLE "L2AggregatorPair" (
+    "id" BIGSERIAL NOT NULL,
+    "l1_aggregator_addresss" TEXT NOT NULL,
+    "l2_aggregator_addresss" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT false,
+    "chain_id" BIGINT NOT NULL,
+
+    CONSTRAINT "L2AggregatorPair_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "L2AggregatorPair" ADD CONSTRAINT "L2AggregatorPair_chain_id_fkey" FOREIGN KEY ("chain_id") REFERENCES "chains"("chain_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/migrations/20231116080058_set_proxy_location_optional/migration.sql
+++ b/api/prisma/migrations/20231116080058_set_proxy_location_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "proxies" ALTER COLUMN "location" DROP NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -148,11 +148,11 @@ model Error {
 }
 
 model Proxy {
-  id       BigInt @id @default(autoincrement())
+  id       BigInt  @id @default(autoincrement())
   protocol String
   host     String
   port     Int
-  location String
+  location String?
 
   @@unique([protocol, host, port])
   @@map("proxies")

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -152,6 +152,7 @@ model Proxy {
   protocol String
   host     String
   port     Int
+  location String
 
   @@unique([protocol, host, port])
   @@map("proxies")

--- a/api/src/proxy/dto/proxy.ts
+++ b/api/src/proxy/dto/proxy.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { ApiProperty } from '@nestjs/swagger'
 
 export class ProxyDto {
   @ApiProperty()

--- a/api/src/proxy/dto/proxy.ts
+++ b/api/src/proxy/dto/proxy.ts
@@ -9,4 +9,7 @@ export class ProxyDto {
 
   @ApiProperty()
   port: number
+
+  @ApiProperty()
+  location: string
 }

--- a/api/src/proxy/dto/proxy.ts
+++ b/api/src/proxy/dto/proxy.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 
 export class ProxyDto {
   @ApiProperty()
@@ -11,5 +11,5 @@ export class ProxyDto {
   port: number
 
   @ApiProperty()
-  location: string
+  location?: string
 }

--- a/api/src/proxy/proxy.service.spec.ts
+++ b/api/src/proxy/proxy.service.spec.ts
@@ -48,7 +48,7 @@ describe('ProxyService', () => {
     expect(proxyObjWithoutLocation.protocol).toBe(proxyDataWithoutLocation.protocol)
     expect(proxyObjWithoutLocation.host).toBe(proxyDataWithoutLocation.host)
     expect(proxyObjWithoutLocation.port).toBe(proxyDataWithoutLocation.port)
-
+    expect(proxyObjWithoutLocation.location).toBe(null)
     // The same proxy cannot be defined twice
     await expect(async () => {
       await proxy.create(proxyData)

--- a/api/src/proxy/proxy.service.spec.ts
+++ b/api/src/proxy/proxy.service.spec.ts
@@ -38,6 +38,17 @@ describe('ProxyService', () => {
     expect(proxyObj.port).toBe(proxyData.port)
     expect(proxyObj.location).toBe(proxyData.location)
 
+    const proxyDataWithoutLocation = {
+      protocol: 'http',
+      host: '127.0.0.2',
+      port: 80
+    }
+
+    const proxyObjWithoutLocation = await proxy.create(proxyDataWithoutLocation)
+    expect(proxyObjWithoutLocation.protocol).toBe(proxyData.protocol)
+    expect(proxyObjWithoutLocation.host).toBe(proxyData.host)
+    expect(proxyObjWithoutLocation.port).toBe(proxyData.port)
+
     // The same proxy cannot be defined twice
     await expect(async () => {
       await proxy.create(proxyData)

--- a/api/src/proxy/proxy.service.spec.ts
+++ b/api/src/proxy/proxy.service.spec.ts
@@ -29,12 +29,14 @@ describe('ProxyService', () => {
     const proxyData = {
       protocol: 'http',
       host: '127.0.0.1',
-      port: 80
+      port: 80,
+      location: 'kr'
     }
     const proxyObj = await proxy.create(proxyData)
     expect(proxyObj.protocol).toBe(proxyData.protocol)
     expect(proxyObj.host).toBe(proxyData.host)
     expect(proxyObj.port).toBe(proxyData.port)
+    expect(proxyObj.location).toBe(proxyData.location)
 
     // The same proxy cannot be defined twice
     await expect(async () => {

--- a/api/src/proxy/proxy.service.spec.ts
+++ b/api/src/proxy/proxy.service.spec.ts
@@ -45,9 +45,9 @@ describe('ProxyService', () => {
     }
 
     const proxyObjWithoutLocation = await proxy.create(proxyDataWithoutLocation)
-    expect(proxyObjWithoutLocation.protocol).toBe(proxyData.protocol)
-    expect(proxyObjWithoutLocation.host).toBe(proxyData.host)
-    expect(proxyObjWithoutLocation.port).toBe(proxyData.port)
+    expect(proxyObjWithoutLocation.protocol).toBe(proxyDataWithoutLocation.protocol)
+    expect(proxyObjWithoutLocation.host).toBe(proxyDataWithoutLocation.host)
+    expect(proxyObjWithoutLocation.port).toBe(proxyDataWithoutLocation.port)
 
     // The same proxy cannot be defined twice
     await expect(async () => {

--- a/cli/src/proxy.ts
+++ b/cli/src/proxy.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { command, subcommands, option, string as cmdstring, number } from 'cmd-ts'
-import { idOption, buildUrl, isOraklNetworkApiHealthy } from './utils'
+import { idOption, buildUrl, isOraklNetworkApiHealthy, proxyOptionalOption } from './utils'
 import { ORAKL_NETWORK_API_URL } from './settings'
 
 const PROXY_ENDPOINT = buildUrl(ORAKL_NETWORK_API_URL, 'proxy')
@@ -30,7 +30,8 @@ export function proxySub() {
       port: option({
         type: number,
         long: 'port'
-      })
+      }),
+      location: proxyOptionalOption
     },
     handler: insertHandler()
   })
@@ -70,16 +71,18 @@ export function insertHandler() {
   async function wrapper({
     protocol,
     host,
-    port
+    port,
+    location
   }: {
     protocol: string
     host: string
     port: number
+    location?: string
   }) {
     if (!(await isOraklNetworkApiHealthy())) return
 
     try {
-      const response = (await axios.post(PROXY_ENDPOINT, { protocol, host, port }))?.data
+      const response = (await axios.post(PROXY_ENDPOINT, { protocol, host, port, location }))?.data
       console.dir(response, { depth: null })
     } catch (e) {
       console.error('Proxy was not inserted. Reason:')

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -18,6 +18,11 @@ export const fetcherTypeOptionalOption = option({
   long: 'fetcherType'
 })
 
+export const proxyOptionalOption = option({
+  type: optional(cmdstring),
+  long: 'location'
+})
+
 export const idOption = option({
   type: cmdnumber,
   long: 'id'

--- a/fetcher/src/job/job.types.ts
+++ b/fetcher/src/job/job.types.ts
@@ -78,4 +78,5 @@ export interface IProxy {
   protocol: string | undefined
   host: string | undefined
   port: number | undefined
+  location?: string | undefined
 }

--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -183,7 +183,9 @@ export function extractFeeds(
       if (!f.definition.location) {
         proxy = proxySelector(f.definition.url)
       } else {
-        const availableProxies = proxies.filter((item) => item.location === f.definition.location)
+        const availableProxies = proxies.filter(
+          (item) => item.location && item.location === f.definition.location
+        )
         if (availableProxies.length == 0) {
           throw `no proxies available for location:${f.definition.location}`
         }

--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -180,12 +180,12 @@ export function extractFeeds(
   const feeds = adapter.feeds.map((f) => {
     let proxy: IProxy
     try {
-      if (!f.location) {
+      if (!f.definition.location) {
         proxy = proxySelector(f.definition.url)
       } else {
-        const availableProxies = proxies.filter((item) => item.location === f.location)
+        const availableProxies = proxies.filter((item) => item.location === f.definition.location)
         if (availableProxies.length == 0) {
-          throw `no proxies available for location:${f.location}`
+          throw `no proxies available for location:${f.definition.location}`
         }
         const randomIndex = Math.floor(Math.random() * availableProxies.length)
         proxy = availableProxies[randomIndex]

--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -180,7 +180,16 @@ export function extractFeeds(
   const feeds = adapter.feeds.map((f) => {
     let proxy: IProxy
     try {
-      proxy = proxySelector(f.definition.url)
+      if (!f.location) {
+        proxy = proxySelector(f.definition.url)
+      } else {
+        const availableProxies = proxies.filter((item) => item.location === f.location)
+        if (availableProxies.length == 0) {
+          throw `no proxies available for location:${f.location}`
+        }
+        const randomIndex = Math.floor(Math.random() * availableProxies.length)
+        proxy = availableProxies[randomIndex]
+      }
     } catch (e) {
       logger.error('Assigning proxy has failed')
       logger.error(e)


### PR DESCRIPTION
# Description

Some data source url requires ip of specific area. To deal with this problem, certain url should be requested by certain proxy with appropriate ip address. To use locational proxy following updates are made.

- adds `location` column to `proxy` table.
- `cli` is now able to add proxy with optional `location` parameter
- when distributing proxies for each element in adapter feeds, if `location` is defined, it'll randomly assign proxy with same location value -> any suggestion for better logic is welcomed

- further notes: adapters for recently added foreign exchange should be redefined

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
