### PR TITLE
Improve how to handle and send errors to slack

### DIFF
--- a/core/src/por/reporter.ts
+++ b/core/src/por/reporter.ts
@@ -105,6 +105,7 @@ export async function reportData({
         break
       } catch (e) {
         logger.error('Failed to send transaction')
+        logger.error(e)
         throw e
       }
     }

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -46,28 +46,28 @@ let errMsg = null
 
 async function sendToSlack(error) {
   if (SLACK_WEBHOOK_URL) {
-    const e = error[1]
+    const e = error[0]
     const webhook = new IncomingWebhook(SLACK_WEBHOOK_URL)
     const text = ` :fire: _An error has occurred at_ \`${os.hostname()}\`\n \`\`\`${JSON.stringify(
       e
     )} \`\`\`\n>*System information*\n>*memory*: ${os.freemem()}/${os.totalmem()}\n>*machine*: ${os.machine()}\n>*platform*: ${os.platform()}\n>*upTime*: ${os.uptime()}\n>*version*: ${os.version()}
    `
+
     try {
-      if (errMsg == e.message) {
-        const currentDate = new Date()
-        const oneMinuteAgo = new Date(currentDate.getTime() - 60000)
-        if (slackSentTime < oneMinuteAgo.getTime()) {
+      if (e && e.message && errMsg === e.message) {
+        const now = new Date().getTime()
+        if (slackSentTime + 60_000 < now) {
           await webhook.send({ text })
-          errMsg = error[1].message
-          slackSentTime = new Date().getTime()
+          slackSentTime = now
+          errMsg = e.message
         }
       } else {
         await webhook.send({ text })
-        errMsg = e.message
+        if (e && e.message) errMsg = e.message
         slackSentTime = new Date().getTime()
       }
     } catch (e) {
-      console.log('utils:sendToSlack', `${e}`)
+      console.log('utils:sendToSlack', e)
     }
   }
 }


### PR DESCRIPTION
# Description

This PR is ready to review. 

Main change on this PR is how to handle errors to submit to `slack webhook`. Previously, we tried to access error from index `1`, but indeed we need to access from index `0`. 
Here is the example of the input params to `sendToSlack` function. 
```
Error: [Arguments] {
  '0': 'Fetching data failed for url:http://127.0.0.1:3009'
}
```




### How the error will look like in channel. 

Example: 
This line of codes produces following errors while testing on locally. 
https://github.com/Bisonai/orakl/blob/ab302a9959683d19c8d2c819c21a425385a17b68/core/src/por/fetcher.ts#L49-L50
  
 Error on slack channel:
<img width="1476" alt="image" src="https://github.com/Bisonai/orakl/assets/30230748/cea1ac6a-d3a1-4f4b-ae72-c5177492a2d7">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
