### PR TITLE
Rollback expected behavior, return null if empty result

### DIFF
--- a/api/src/aggregate/aggregate.service.ts
+++ b/api/src/aggregate/aggregate.service.ts
@@ -67,10 +67,10 @@ export class AggregateService {
       ORDER BY timestamp DESC
       LIMIT 1;`
     const result: Prisma.AggregateScalarFieldEnum[] = await this.prisma.$queryRaw(query)
-    if (result.length == 1) {
+    if (result && result.length == 1) {
       return result[0]
     } else {
-      throw Error(`Expected one row. Received ${result.length}`)
+      return null
     }
   }
 }


### PR DESCRIPTION
# Description

This PR will rollback behavior when item not found, it'll return `null`

previous code
```
return await this.prisma.aggregate.findFirst({
      where: { aggregator: { aggregatorHash } },
      orderBy: [
        {
          timestamp: 'desc'
        }
      ]
    })
```

this will fix current error which fetcher is not working for newly added aggregator

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
