### PR TITLE
Ignore reporters with invalid private keys

### DIFF
--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -251,3 +251,11 @@ export async function sendTransactionCaver({
     throw new OraklError(OraklErrorCode.CaverTxTransactionFailed)
   }
 }
+
+export function isPrivateKeyAddressPairValid(sk: string, addr: string): boolean {
+  try {
+    return ethers.utils.computeAddress(sk) == addr
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
# Description

Ignore reporters with invalid private keys. The detection of invalid private keys is integrated to reporter's `State` class in which we build a wallet inside of two methods: `add` and `refresh`.

When `refresh`, reporters with invalid private keys are filtered. In case of `add`, wallet with invalid private key cannot be built and function throws an exception.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
