### PR TITLE
Use `processVrfRequest` from `@bisonai/orakl-vrf` rather than redefine it in worker

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@bisonai/orakl-contracts": "^1.3.2",
-    "@bisonai/orakl-vrf": "0.1.1",
+    "@bisonai/orakl-vrf": "^0.2.1",
     "@ethersproject/experimental": "^5.7.0",
     "@slack/webhook": "^6.1.0",
     "axios": "^1.2.2",

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -30,13 +30,6 @@ export interface IRequestOperation {
   args: string
 }
 
-export interface IVrfResponse {
-  pk: [string, string]
-  proof: [string, string, string, string]
-  uPoint: [string, string]
-  vComponents: [string, string, string, string]
-}
-
 export interface ILatestRoundData {
   roundId: BigNumber
   answer: BigNumber

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -318,10 +318,10 @@
   resolved "https://registry.yarnpkg.com/@bisonai/orakl-contracts/-/orakl-contracts-1.3.2.tgz#3321abde27db8d6caf16cfab391147225a8ffb74"
   integrity sha512-ImnAKAAy981DGJOWaOoABs7f4UI0PSMxEH91xReOeCgYQ++ZgxE45OO+wwORHcbbSuXP5JHBKOUQzVtvL8fJpQ==
 
-"@bisonai/orakl-vrf@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@bisonai/orakl-vrf/-/orakl-vrf-0.1.1.tgz#61e90a44520a7d9abf1a20c2c863201742c0b2e2"
-  integrity sha512-mz1DhGQEgKXwk78ZAe9EG1C9tat/fqAch13K7muK2r1xCSAVMoFJU0II39HbH99cC2mz6/l6I3B0szeyrMw+Zw==
+"@bisonai/orakl-vrf@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@bisonai/orakl-vrf/-/orakl-vrf-0.2.1.tgz#e8747f50d0b9a5e810bd1296bc8700508663735c"
+  integrity sha512-HO4ULe1xLA8fcWAe8//UFL9IaWhga9mvf548saBKzxJ8bzuY75P6AePSItDy8ZyJ2QJtn1UV5BDUYaR3mnjy/g==
   dependencies:
     bn.js "^5.2.1"
     elliptic "^6.5.4"

--- a/vrf/package.json
+++ b/vrf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/orakl-vrf",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "The Orakl Network VRF",
   "files": [

--- a/vrf/src/index.ts
+++ b/vrf/src/index.ts
@@ -13,7 +13,7 @@ const elliptic = ellipticPkg
 
 import { BN } from 'bn.js'
 import { createHmac, createHash } from 'crypto'
-import { IVrfConfig } from './types'
+import { IVrfConfig, IVrfResponse } from './types'
 import { VrfError, VrfErrorCode } from './errors.js'
 
 const EC = new elliptic.ec('secp256k1')
@@ -251,7 +251,7 @@ const getFastVerifyComponents = (Y, pi_string, alpha_string) => {
   }
 }
 
-const processVrfRequest = (alpha: string, config: IVrfConfig) => {
+const processVrfRequest = (alpha: string, config: IVrfConfig): IVrfResponse => {
   const proof = ECVRF_prove(config.sk, alpha)
   const [Gamma, c, s] = ECVRF_decode_proof(proof)
   const fast = getFastVerifyComponents(config.pk, proof, alpha)

--- a/vrf/src/types.ts
+++ b/vrf/src/types.ts
@@ -4,3 +4,10 @@ export interface IVrfConfig {
   pkX: string
   pkY: string
 }
+
+export interface IVrfResponse {
+  pk: [string, string]
+  proof: [string, string, string, string]
+  uPoint: [string, string]
+  vComponents: [string, string, string, string]
+}


### PR DESCRIPTION
# Description

This PR removes duplicated function definition `processVrfRequest` from `@bisonai/orakl` and instead uses the same function defined from `@bisonai/orakl-vrf`.

This change required an update to `@bisonai/orakl-vrf` which defines output type `IVrfResponse` and version of `@bisonai/orakl-vrf` has been increased to `0.2.1`.

## Test

We have a test which checks whether VRF functionality has been affected at https://github.com/Bisonai/orakl/blob/master/core/test/vrf-worker.test.ts triggered at https://github.com/Bisonai/orakl/actions/runs/7001192921/job/19042932016?pr=976

```
PASS test/vrf-worker.test.ts (13.702 s)
  VRF Worker
    ✓ Composability test (1127 ms)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
