### PR TITLE
Modify command name `eslint` -> `lint` for consistency

### DIFF
--- a/.github/workflows/contracts.test.yaml
+++ b/.github/workflows/contracts.test.yaml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./contracts
       - run: yarn solhint
         working-directory: ./contracts
-      - run: yarn eslint
+      - run: yarn lint
         working-directory: ./contracts
       - run: npx hardhat test test/v0.1/non-vrf/*.cjs
         working-directory: ./contracts

--- a/.github/workflows/vrf.contracts.test.yaml
+++ b/.github/workflows/vrf.contracts.test.yaml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./contracts
       - run: yarn solhint
         working-directory: ./contracts
-      - run: yarn eslint
+      - run: yarn lint
         working-directory: ./contracts
       - run: npx hardhat test test/v0.1/vrf/*.cjs
         working-directory: ./contracts

--- a/contracts/.husky/pre-commit
+++ b/contracts/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd contracts && yarn prettier-solidity-write && yarn eslint --fix
+cd contracts && yarn prettier-solidity-write && yarn lint --fix

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -35,7 +35,7 @@
     "solhint": "./node_modules/.bin/solhint -f table src/**/*.sol",
     "prettier-solidity-write": "./node_modules/.bin/prettier --write src",
     "prettier-solidity-check": "./node_modules/.bin/prettier --check src",
-    "eslint": "DEBUG=eslint:cli-engine npx eslint 'scripts/**'",
+    "lint": "DEBUG=eslint:cli-engine npx eslint 'scripts/**'",
     "deploy:localhost": "npx hardhat deploy --network localhost",
     "deploy:localhost:prepayment": "yarn deploy:localhost --deploy-scripts deploy/Prepayment",
     "deploy:localhost:rr": "yarn deploy:localhost --deploy-scripts deploy/RequestResponse",

--- a/core/.husky/pre-commit
+++ b/core/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd core && yarn eslint && yarn test
+cd core && yarn lint && yarn test


### PR DESCRIPTION
# Description

only `contracts` package is using name `eslint` for linting command while all other packages use `lint`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
