### PR TITLE
Get contract addresses from `contracts` package

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/orakl-contracts",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "The Orakl Network Smart Contracts",
   "files": [
     "./dist",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/orakl-contracts",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "The Orakl Network Smart Contracts",
   "files": [
     "./dist",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -28,7 +28,7 @@
     "prepare": "cd .. && husky install contracts/.husky",
     "clean": "yarn hardhat clean && rm -rf dist",
     "compile": "yarn hardhat compile",
-    "prebuild": "yarn compile && yarn --cwd='../..' vrf build",
+    "prebuild": "yarn compile && yarn --cwd='../..' vrf build && cp -r ./deployments ./typechain-types/deployments && cp -r ./utils ./typechain-types/utils",
     "build": "tsc",
     "test": "yarn compile && npx hardhat test --parallel",
     "test-vrf": "yarn hardhat test test/v0.1/vrf/*.cjs --parallel",

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "module": "commonjs",
     "moduleResolution": "node",
@@ -7,7 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
   },
-  "include": ["./typechain-types"]
+  "include": ["./typechain-types", "./deployments/**/*.json", "./utils"]
 }

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "declaration": true,
   },
-  "include": ["./typechain-types", "./deployments/**/*.json", "./utils"]
+  "include": ["./typechain-types", "./typechain-types/**/*.json"]
 }

--- a/contracts/utils/index.ts
+++ b/contracts/utils/index.ts
@@ -35,9 +35,9 @@ const readDeployments = async (folderPath: string): Promise<deployments> => {
           let contractName = path.basename(file, '.json')
           if (contractName.split('_').length > 1) {
             // remove last part which normally holds version name
-            const splitted = contractName.split('_')
+            const splitted = contractName.replace(' ', '').split('_')
             splitted.pop()
-            contractName = splitted.join('_').replace(' ', '')
+            contractName = splitted.join('_')
           }
 
           try {

--- a/contracts/utils/index.ts
+++ b/contracts/utils/index.ts
@@ -1,10 +1,25 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-const projectRootPath = path.resolve(__dirname, '..')
+const deploymentsPath = path.resolve(__dirname, '..') + '/deployments/'
 
-const readJsonFilesRecursively = async (folderPath: string): Promise<{ [key: string]: any }> => {
-  const result: { [key: string]: any } = {}
+const isValidPath = (_path: string): boolean => {
+  const splitted = _path.replace(deploymentsPath, '').split('/')
+  return splitted.length == 2
+}
+
+const readJsonFilesRecursively = async (
+  folderPath: string
+): Promise<{
+  [network: string]: {
+    [contractName: string]: string
+  }
+}> => {
+  const result: {
+    [network: string]: {
+      [contractName: string]: string
+    }
+  } = {}
 
   const readFolder = async (currentFolderPath: string): Promise<void> => {
     const files = await fs.promises.readdir(currentFolderPath)
@@ -12,19 +27,32 @@ const readJsonFilesRecursively = async (folderPath: string): Promise<{ [key: str
     await Promise.all(
       files.map(async (file) => {
         const filePath = path.join(currentFolderPath, file)
+        // console.log(filePath)
         const stats = await fs.promises.stat(filePath)
 
         if (stats.isDirectory()) {
           // If it's a directory, recursively read its content
           await readFolder(filePath)
-        } else if (path.extname(file) === '.json') {
-          console.log(filePath)
+        } else if (path.extname(file) === '.json' && isValidPath(filePath)) {
+          const network = filePath.replace(deploymentsPath, '').split('/')[0]
+
           // If it's a JSON file, read and parse it
           const fileContent = await fs.promises.readFile(filePath, 'utf-8')
-          const fileNameWithoutExtension = path.basename(file, '.json')
+          let contractName = path.basename(file, '.json')
+          if (contractName.split('_').length > 1) {
+            const splitted = contractName.split('_')
+            splitted.pop()
+            contractName = splitted.join('_')
+          }
 
           try {
-            result[fileNameWithoutExtension] = JSON.parse(fileContent)
+            const jsonObject = JSON.parse(fileContent)
+            const contractAddress = jsonObject.address
+            if (!contractAddress) {
+              return
+            }
+
+            result[network] = { ...result[network], [contractName]: contractAddress }
           } catch (error: any) {
             console.error(`Error parsing JSON file ${file}: ${error.message}`)
           }
@@ -37,13 +65,47 @@ const readJsonFilesRecursively = async (folderPath: string): Promise<{ [key: str
   return result
 }
 
-// const getAddress = (network: string, contract: string): string => {
-
-// }
-
-const main = async () => {
-  const result = await readJsonFilesRecursively(projectRootPath + '/deployments/')
-  // console.log(result)
+export const getContractAddressExact = async (network: string, contractName: string) => {
+  const contractAddressObject = await readJsonFilesRecursively(deploymentsPath)
+  const contracts = contractAddressObject[network]
+  return contracts[contractName] || ''
 }
 
-main()
+export const getAggregatorAddress = async (network: string, pair_0: string, pair_1: string) => {
+  const contractAddressObject = await readJsonFilesRecursively(deploymentsPath)
+  const contracts = contractAddressObject[network]
+
+  let result = ''
+  Object.keys(contracts).forEach((contractName) => {
+    if (
+      contractName.toLowerCase().startsWith('aggregator_') &&
+      contractName.toLowerCase().includes(pair_0.toLowerCase()) &&
+      contractName.toLowerCase().includes(pair_1.toLowerCase())
+    ) {
+      result = contracts[contractName]
+      return
+    }
+  })
+  return result
+}
+
+export const getAggregatorProxyAddress = async (
+  network: string,
+  pair_0: string,
+  pair_1: string
+) => {
+  const contractAddressObject = await readJsonFilesRecursively(deploymentsPath)
+  const contracts = contractAddressObject[network]
+  let result = ''
+  Object.keys(contracts).forEach((contractName) => {
+    if (
+      contractName.toLowerCase().startsWith('aggregatorproxy_') &&
+      contractName.toLowerCase().includes(pair_0.toLowerCase()) &&
+      contractName.toLowerCase().includes(pair_1.toLowerCase())
+    ) {
+      result = contracts[contractName]
+      return
+    }
+  })
+  return result
+}

--- a/contracts/utils/index.ts
+++ b/contracts/utils/index.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const projectRootPath = path.resolve(__dirname, '..')
+
+const readJsonFilesRecursively = async (folderPath: string): Promise<{ [key: string]: any }> => {
+  const result: { [key: string]: any } = {}
+
+  const readFolder = async (currentFolderPath: string): Promise<void> => {
+    const files = await fs.promises.readdir(currentFolderPath)
+
+    await Promise.all(
+      files.map(async (file) => {
+        const filePath = path.join(currentFolderPath, file)
+        const stats = await fs.promises.stat(filePath)
+
+        if (stats.isDirectory()) {
+          // If it's a directory, recursively read its content
+          await readFolder(filePath)
+        } else if (path.extname(file) === '.json') {
+          console.log(filePath)
+          // If it's a JSON file, read and parse it
+          const fileContent = await fs.promises.readFile(filePath, 'utf-8')
+          const fileNameWithoutExtension = path.basename(file, '.json')
+
+          try {
+            result[fileNameWithoutExtension] = JSON.parse(fileContent)
+          } catch (error: any) {
+            console.error(`Error parsing JSON file ${file}: ${error.message}`)
+          }
+        }
+      })
+    )
+  }
+
+  await readFolder(folderPath)
+  return result
+}
+
+// const getAddress = (network: string, contract: string): string => {
+
+// }
+
+const main = async () => {
+  const result = await readJsonFilesRecursively(projectRootPath + '/deployments/')
+  // console.log(result)
+}
+
+main()


### PR DESCRIPTION
# Description

Adds functionality to get contract address from the package

use following functions to get contract addresses
`import {getContractAddressExact, getAggregatorAddress, getAggregatorProxyAddress} from @bisonai/orakl-contracts/utils`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
