### PR TITLE
Set prisma dependency to nohoist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
       "l2-api",
       "monitor",
       "vrf"
+    ],
+    "nohoist": [
+      "**/prisma", "**/prisma/**", "**/@prisma/client", "@prisma/client"
     ]
   },
   "dependencies": {},


### PR DESCRIPTION
# Description

Prisma client works as a singleton which leads to problem when trying to access different databases from same instance. For instance, currently if orakl api and orakl delegator server is run in the same instance, only the one which later built works. Loading prisma from each workspace can prevent this error

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
