### PR TITLE
Remove fetcher build from core prebuild step

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepare": "cd .. && husky install core/.husky",
     "clean": "rm -rf dist",
-    "prebuild": "yarn --cwd='../..' vrf build && yarn --cwd='../..' contracts build && yarn --cwd='../..' fetcher build && yarn --cwd='../..' util build",
+    "prebuild": "yarn --cwd='../..' vrf build && yarn --cwd='../..' contracts build && yarn --cwd='../..' util build",
     "build": "yarn clean && tsc",
     "start:listener": "node --no-warnings --import=specifier-resolution-node/register --experimental-json-modules dist/listener/main.js",
     "start:listener:vrf": "yarn start:listener --service VRF",


### PR DESCRIPTION
# Description

Remove fetcher build from core prebuild step since it's no more referenced. This fixes docker-compose build failure issue for core image

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
