### PR TITLE
Define timeout for Fetcher calls

### DIFF
--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -1,6 +1,7 @@
 import { buildReducer, checkDataFormat, pipe, REDUCER_MAPPING } from '@bisonai/orakl-util'
 import { Logger } from '@nestjs/common'
 import axios from 'axios'
+import { FETCH_TIMEOUT } from '../settings'
 import { LOCAL_AGGREGATOR_FN } from './job.aggregator'
 import { FetcherError, FetcherErrorCode } from './job.errors'
 import { IAdapter, IFetchedData, IProxy } from './job.types'
@@ -36,6 +37,7 @@ async function fetchRawDataWithProxy(adapter, logger) {
     {
       method: adapter.method,
       headers: adapter.headers,
+      timeout: FETCH_TIMEOUT,
       proxy: {
         protocol: adapter.proxy.protocol,
         host: adapter.proxy.host,
@@ -51,7 +53,8 @@ async function fetchRawDataWithoutProxy(adapter, logger) {
     adapter.url,
     {
       method: adapter.method,
-      headers: adapter.headers
+      headers: adapter.headers,
+      timeout: FETCH_TIMEOUT
     },
     logger
   )

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -7,6 +7,8 @@ export const WORKER_OPTS = { concurrency: Number(process.env.CONCURRENCY) || 20 
 
 export const FETCH_FREQUENCY = 2_000
 
+export const FETCH_TIMEOUT = 1_000
+
 export const DEVIATION_QUEUE_NAME = 'orakl-deviation-queue'
 
 export const FETCHER_TYPE = process.env.FETCHER_TYPE || 0


### PR DESCRIPTION
# Description

This PR adds a timeout to every fetcher call. The default timeout is set to 1 second.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
