### PR TITLE
POR updates

### DIFF
--- a/core/src/por/main.ts
+++ b/core/src/por/main.ts
@@ -1,17 +1,11 @@
 import { logger } from 'ethers'
 import { buildLogger } from '../logger'
-import { POR_AGGREGATOR_HASH, POR_TIMEOUT } from '../settings'
+import { callWithTimeout, POR_AGGREGATOR_HASH, POR_TIMEOUT } from '../settings'
 import { hookConsoleError } from '../utils'
 import { fetchWithAggregator } from './fetcher'
 import { reportData } from './reporter'
 
 const LOGGER = buildLogger()
-
-const callWithTimeout = (promise, timeout) =>
-  Promise.race([
-    promise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
-  ])
 
 const _main = async () => {
   hookConsoleError(LOGGER)

--- a/core/src/por/main.ts
+++ b/core/src/por/main.ts
@@ -18,6 +18,10 @@ const main = async () => {
   logger.info(`Fetched data:${value}`)
 
   await reportData({ value, aggregator, logger: LOGGER })
+
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('Timeout')), 15000) // 15 seconds in milliseconds
+  })
 }
 
 main().catch((error) => {

--- a/core/src/por/main.ts
+++ b/core/src/por/main.ts
@@ -6,8 +6,9 @@ import { fetchWithAggregator } from './fetcher'
 import { reportData } from './reporter'
 
 const LOGGER = buildLogger()
+const TIMEOUT = 10000
 
-const main = async () => {
+const _main = async () => {
   hookConsoleError(LOGGER)
 
   const { value, aggregator } = await fetchWithAggregator({
@@ -18,10 +19,21 @@ const main = async () => {
   logger.info(`Fetched data:${value}`)
 
   await reportData({ value, aggregator, logger: LOGGER })
+}
 
-  return new Promise((_, reject) => {
-    setTimeout(() => reject(new Error('Timeout')), 15000) // 15 seconds in milliseconds
-  })
+const main = async () => {
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('Timeout')), TIMEOUT)
+  )
+  try {
+    await Promise.race([timeoutPromise, _main()])
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Timeout') {
+      throw new Error(`Main function timed out`)
+    } else {
+      throw error
+    }
+  }
 }
 
 main().catch((error) => {

--- a/core/src/por/main.ts
+++ b/core/src/por/main.ts
@@ -1,9 +1,10 @@
 import { logger } from 'ethers'
 import { buildLogger } from '../logger'
-import { callWithTimeout, POR_AGGREGATOR_HASH, POR_TIMEOUT } from '../settings'
+import { POR_AGGREGATOR_HASH, POR_TIMEOUT } from '../settings'
 import { hookConsoleError } from '../utils'
 import { fetchWithAggregator } from './fetcher'
 import { reportData } from './reporter'
+import { callWithTimeout } from './utils'
 
 const LOGGER = buildLogger()
 

--- a/core/src/por/reporter.ts
+++ b/core/src/por/reporter.ts
@@ -5,6 +5,8 @@ import { getReporterByOracleAddress } from '../api'
 import { buildWallet, sendTransaction } from '../reporter/utils'
 import {
   CHAIN,
+  checkRpcUrl,
+  FALLBACK_PROVIDER_URL,
   POR_GAS_MINIMUM,
   POR_LATENCY_BUFFER,
   POR_SERVICE_NAME,
@@ -17,13 +19,15 @@ import { buildTransaction } from '../worker/data-feed.utils'
 async function shouldReport({
   aggregator,
   value,
-  logger
+  logger,
+  provider
 }: {
   aggregator: IAggregator
   value: bigint
   logger: Logger
+  provider: ethers.providers.JsonRpcProvider
 }) {
-  const contract = new ethers.Contract(aggregator.address, Aggregator__factory.abi, PROVIDER)
+  const contract = new ethers.Contract(aggregator.address, Aggregator__factory.abi, provider)
   const latestRoundData = await contract.latestRoundData()
 
   // Check Submission Hearbeat
@@ -68,6 +72,18 @@ export async function reportData({
   aggregator: IAggregator
   logger: Logger
 }) {
+  let provider = PROVIDER
+  let providerUrl = PROVIDER_URL
+  if (!(await checkRpcUrl(providerUrl)) && FALLBACK_PROVIDER_URL) {
+    if (!(await checkRpcUrl(FALLBACK_PROVIDER_URL))) {
+      throw Error(
+        `PROVIDER_URL(${PROVIDER_URL}) and FALLBACK_PROVIDER_URL(${FALLBACK_PROVIDER_URL}) are both dead`
+      )
+    }
+    provider = new ethers.providers.JsonRpcProvider(FALLBACK_PROVIDER_URL)
+    providerUrl = String(FALLBACK_PROVIDER_URL)
+  }
+
   const oracleAddress = aggregator.address
   const reporter: IReporterConfig = await getReporterByOracleAddress({
     service: POR_SERVICE_NAME,
@@ -77,12 +93,12 @@ export async function reportData({
   })
 
   const iface = new ethers.utils.Interface(Aggregator__factory.abi)
-  const contract = new ethers.Contract(oracleAddress, Aggregator__factory.abi, PROVIDER)
+  const contract = new ethers.Contract(oracleAddress, Aggregator__factory.abi, provider)
   const queriedRoundId = 0
   const state = await contract.oracleRoundState(reporter.address, queriedRoundId)
   const roundId = state._roundId
 
-  if (roundId == 1 || (await shouldReport({ aggregator, value, logger }))) {
+  if (roundId == 1 || (await shouldReport({ aggregator, value, logger, provider }))) {
     const tx = buildTransaction({
       payloadParameters: {
         roundId,
@@ -94,7 +110,7 @@ export async function reportData({
       logger
     })
 
-    const wallet = await buildWallet({ privateKey: reporter.privateKey, providerUrl: PROVIDER_URL })
+    const wallet = await buildWallet({ privateKey: reporter.privateKey, providerUrl: providerUrl })
     const txParams = { wallet, ...tx, logger }
 
     const NUM_TRANSACTION_TRIALS = 3

--- a/core/src/por/reporter.ts
+++ b/core/src/por/reporter.ts
@@ -5,7 +5,6 @@ import { getReporterByOracleAddress } from '../api'
 import { buildWallet, sendTransaction } from '../reporter/utils'
 import {
   CHAIN,
-  checkRpcUrl,
   FALLBACK_PROVIDER_URL,
   POR_GAS_MINIMUM,
   POR_LATENCY_BUFFER,
@@ -15,6 +14,7 @@ import {
 } from '../settings'
 import { IAggregator, IReporterConfig } from '../types'
 import { buildTransaction } from '../worker/data-feed.utils'
+import { checkRpcUrl } from './utils'
 
 async function shouldReport({
   aggregator,
@@ -81,7 +81,7 @@ export async function reportData({
       )
     }
     provider = new ethers.providers.JsonRpcProvider(FALLBACK_PROVIDER_URL)
-    providerUrl = String(FALLBACK_PROVIDER_URL)
+    providerUrl = FALLBACK_PROVIDER_URL
   }
 
   const oracleAddress = aggregator.address

--- a/core/src/por/utils.ts
+++ b/core/src/por/utils.ts
@@ -1,0 +1,27 @@
+import { ethers } from 'ethers'
+import { RPC_URL_TIMEOUT } from '../settings'
+
+export async function checkRpcUrl(url: string) {
+  try {
+    const provider = new ethers.providers.JsonRpcProvider(url)
+    const blockNumberPromise = provider.getBlockNumber()
+    const result = await callWithTimeout(blockNumberPromise, RPC_URL_TIMEOUT)
+
+    if (result instanceof Error && result.message === 'Timeout') {
+      console.error(`failed to connect rpc url due to timeout: ${url}`)
+      return false
+    } else {
+      console.info(`json rpc is alive: ${url}`)
+      return true
+    }
+  } catch (error) {
+    console.error(`Error connecting to URL ${url}: ${error.message}`)
+    return false
+  }
+}
+
+export const callWithTimeout = (promise, timeout) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
+  ])

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -237,7 +237,7 @@ export async function checkRpcUrl(url: string) {
       setTimeout(() => reject(new Error('Timeout')), RPC_URL_TIMEOUT)
     })
     const result = await Promise.race([blockNumberPromise, timeoutPromise])
-    if (result instanceof Error) {
+    if (result instanceof Error && result.message === 'Timeout') {
       console.error(`failed to connect rpc url due to timeout: ${url}`)
       return false
     } else {

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -229,28 +229,3 @@ export const WORKER_JOB_SETTINGS = {
 export function getObservedBlockRedisKey(contractAddress: string) {
   return `${contractAddress}-listener-${DEPLOYMENT_NAME}`
 }
-
-export async function checkRpcUrl(url: string) {
-  try {
-    const provider = new ethers.providers.JsonRpcProvider(url)
-    const blockNumberPromise = provider.getBlockNumber()
-    const result = await callWithTimeout(blockNumberPromise, RPC_URL_TIMEOUT)
-
-    if (result instanceof Error && result.message === 'Timeout') {
-      console.error(`failed to connect rpc url due to timeout: ${url}`)
-      return false
-    } else {
-      console.info(`json rpc is alive: ${url}`)
-      return true
-    }
-  } catch (error) {
-    console.error(`Error connecting to URL ${url}: ${error.message}`)
-    return false
-  }
-}
-
-export const callWithTimeout = (promise, timeout) =>
-  Promise.race([
-    promise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
-  ])

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -170,8 +170,7 @@ export const BULLMQ_CONNECTION = {
 }
 
 function createJsonRpcProvider(providerUrl: string = PROVIDER_URL) {
-  let provider = new ethers.providers.JsonRpcProvider(providerUrl)
-  return provider
+  return new ethers.providers.JsonRpcProvider(providerUrl)
 }
 
 export const PROVIDER = createJsonRpcProvider()

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -176,7 +176,6 @@ function createJsonRpcProvider(providerUrl: string = PROVIDER_URL) {
 
 export const PROVIDER = createJsonRpcProvider()
 export const L2_PROVIDER = createJsonRpcProvider(L2_PROVIDER_URL)
-
 export const L1_ENDPOINT = process.env.L1_ENDPOINT || ''
 export const L2_ENDPOINT = process.env.L2_ENDPOINT || ''
 

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -234,10 +234,8 @@ export async function checkRpcUrl(url: string) {
   try {
     const provider = new ethers.providers.JsonRpcProvider(url)
     const blockNumberPromise = provider.getBlockNumber()
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Timeout')), RPC_URL_TIMEOUT)
-    })
-    const result = await Promise.race([blockNumberPromise, timeoutPromise])
+    const result = await callWithTimeout(blockNumberPromise, RPC_URL_TIMEOUT)
+
     if (result instanceof Error && result.message === 'Timeout') {
       console.error(`failed to connect rpc url due to timeout: ${url}`)
       return false
@@ -250,3 +248,9 @@ export async function checkRpcUrl(url: string) {
     return false
   }
 }
+
+export const callWithTimeout = (promise, timeout) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), timeout))
+  ])

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -9,6 +9,7 @@ export const ORAKL_NETWORK_DELEGATOR_URL =
 
 export const DELEGATOR_TIMEOUT = Number(process.env.DELEGATOR_TIMEOUT) || 3000
 export const RPC_URL_TIMEOUT = Number(process.env.RPC_URL_TIMEOUT) || 3000
+export const POR_TIMEOUT = Number(process.env.POR_TIMEOUT) || 5000
 
 export const DEPLOYMENT_NAME = process.env.DEPLOYMENT_NAME || 'orakl'
 export const NODE_ENV = process.env.NODE_ENV
@@ -241,7 +242,7 @@ export async function checkRpcUrl(url: string) {
       console.error(`failed to connect rpc url due to timeout: ${url}`)
       return false
     } else {
-      console.info(`json rpc alive: ${url}`)
+      console.info(`json rpc is alive: ${url}`)
       return true
     }
   } catch (error) {


### PR DESCRIPTION
# Description

- use timeout for por call and rpc check
- adds `checkRpcUrl()` function to check if rpc url is alive 
- adds `FALLBACK_PROVIDER_URL` to be used in case of default rpc url fail
- adds `POR_TIMEOUT` to set total por run timeout ms
- adds `RPC_URL_TIMEOUT` to set timeout for RPC url alive

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
