### PR TITLE
Remove jobs from queue on starting data feed

### DIFF
--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -1,10 +1,12 @@
 import { Aggregator__factory } from '@bisonai/orakl-contracts'
+import { Queue } from 'bullmq'
 import { ethers } from 'ethers'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import { getOperatorAddress } from '../api'
 import {
   AGGREGATOR_QUEUE_SETTINGS,
+  BULLMQ_CONNECTION,
   CHAIN,
   DATA_FEED_LISTENER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
@@ -36,6 +38,14 @@ export async function buildListener(
   const workerQueueName = WORKER_AGGREGATOR_QUEUE_NAME
   const abi = Aggregator__factory.abi
   const iface = new ethers.utils.Interface(abi)
+
+  const latestListenerQueue = new Queue(latestQueueName, BULLMQ_CONNECTION)
+  const historyListenerQueue = new Queue(historyQueueName, BULLMQ_CONNECTION)
+  const processEventQueue = new Queue(processEventQueueName, BULLMQ_CONNECTION)
+
+  await latestListenerQueue.obliterate()
+  await historyListenerQueue.obliterate()
+  await processEventQueue.obliterate()
 
   listenerService({
     config,

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -1,7 +1,9 @@
+import { Queue } from 'bullmq'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
   BAOBAB_CHAIN_ID,
+  BULLMQ_CONNECTION,
   CYPRESS_CHAIN_ID,
   DATA_FEED_REPORTER_CONCURRENCY,
   DATA_FEED_REPORTER_STATE_NAME,
@@ -13,6 +15,9 @@ import { factory } from './factory'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
   const chainId = (await PROVIDER.getNetwork()).chainId
+
+  const reporterAggregateQueue = new Queue(REPORTER_AGGREGATOR_QUEUE_NAME, BULLMQ_CONNECTION)
+  await reporterAggregateQueue.obliterate()
 
   await factory({
     redisClient,

--- a/core/src/worker/data-feed.ts
+++ b/core/src/worker/data-feed.ts
@@ -58,14 +58,12 @@ export async function worker(redisClient: RedisClientType, _logger: Logger) {
   const submitHeartbeatQueue = new Queue(SUBMIT_HEARTBEAT_QUEUE_NAME, BULLMQ_CONNECTION)
   const reporterQueue = new Queue(REPORTER_AGGREGATOR_QUEUE_NAME, BULLMQ_CONNECTION)
   const checkHeartbeatQueue = new Queue(WORKER_CHECK_HEARTBEAT_QUEUE_NAME, BULLMQ_CONNECTION)
-  const deviationQUeue = new Queue(WORKER_DEVIATION_QUEUE_NAME, BULLMQ_CONNECTION)
 
   // Clear queues
   await aggregatorQueue.obliterate()
   await heartbeatQueue.obliterate()
   await submitHeartbeatQueue.obliterate()
   await checkHeartbeatQueue.obliterate()
-  await deviationQUeue.obliterate()
 
   // Clear previous jobs from repeatable [checkHeartbeat] queue
   const repeatableJobs = await checkHeartbeatQueue.getRepeatableJobs()

--- a/core/src/worker/data-feed.ts
+++ b/core/src/worker/data-feed.ts
@@ -58,6 +58,14 @@ export async function worker(redisClient: RedisClientType, _logger: Logger) {
   const submitHeartbeatQueue = new Queue(SUBMIT_HEARTBEAT_QUEUE_NAME, BULLMQ_CONNECTION)
   const reporterQueue = new Queue(REPORTER_AGGREGATOR_QUEUE_NAME, BULLMQ_CONNECTION)
   const checkHeartbeatQueue = new Queue(WORKER_CHECK_HEARTBEAT_QUEUE_NAME, BULLMQ_CONNECTION)
+  const deviationQUeue = new Queue(WORKER_DEVIATION_QUEUE_NAME, BULLMQ_CONNECTION)
+
+  // Clear queues
+  await aggregatorQueue.obliterate()
+  await heartbeatQueue.obliterate()
+  await submitHeartbeatQueue.obliterate()
+  await checkHeartbeatQueue.obliterate()
+  await deviationQUeue.obliterate()
 
   // Clear previous jobs from repeatable [checkHeartbeat] queue
   const repeatableJobs = await checkHeartbeatQueue.getRepeatableJobs()

--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -24,6 +24,7 @@ export class JobController {
     this.proxyList = await loadProxies({ logger: this.logger })
     const chain = process.env.CHAIN
     const activeAggregators = await this.activeAggregators()
+    await this.queue.obliterate()
     for (const aggregator of activeAggregators) {
       await this.startFetcher({ aggregatorHash: aggregator.aggregatorHash, chain, isInitial: true })
     }

--- a/fetcher/src/job/job.controller.ts
+++ b/fetcher/src/job/job.controller.ts
@@ -1,7 +1,12 @@
 import { InjectQueue } from '@nestjs/bullmq'
 import { Body, Controller, Get, HttpException, HttpStatus, Logger, Param } from '@nestjs/common'
 import { Queue } from 'bullmq'
-import { FETCHER_QUEUE_NAME, FETCHER_TYPE, FETCH_FREQUENCY } from '../settings'
+import {
+  DEVIATION_QUEUE_NAME,
+  FETCHER_QUEUE_NAME,
+  FETCHER_TYPE,
+  FETCH_FREQUENCY
+} from '../settings'
 import {
   activateAggregator,
   deactivateAggregator,
@@ -18,13 +23,17 @@ import { extractFeeds } from './job.utils'
 export class JobController {
   private readonly logger = new Logger(JobController.name)
   private proxyList: IProxy[] = []
-  constructor(@InjectQueue(FETCHER_QUEUE_NAME) private queue: Queue) {}
+  constructor(
+    @InjectQueue(FETCHER_QUEUE_NAME) private queue: Queue,
+    @InjectQueue(DEVIATION_QUEUE_NAME) private deviationQueue: Queue
+  ) {}
 
   async onModuleInit() {
     this.proxyList = await loadProxies({ logger: this.logger })
     const chain = process.env.CHAIN
     const activeAggregators = await this.activeAggregators()
     await this.queue.obliterate()
+    await this.deviationQueue.obliterate()
     for (const aggregator of activeAggregators) {
       await this.startFetcher({ aggregatorHash: aggregator.aggregatorHash, chain, isInitial: true })
     }


### PR DESCRIPTION
# Description

obliterate queues when launching data-feed l,w,r and fetcher
expected to remove necessity of redis flush queue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
