### PR TITLE
Update insertion with job containing roundId

### DIFF
--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -461,6 +461,7 @@ export interface MockQueue {
   add: any // eslint-disable-line @typescript-eslint/no-explicit-any
   process: any // eslint-disable-line @typescript-eslint/no-explicit-any
   on: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  getJobs: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export type QueueType = Queue | MockQueue

--- a/core/test/utils.ts
+++ b/core/test/utils.ts
@@ -4,5 +4,6 @@ import { MockQueue } from '../src/types'
 export const QUEUE: MockQueue = {
   add: jest.fn(),
   process: jest.fn(),
-  on: jest.fn()
+  on: jest.fn(),
+  getJobs: jest.fn()
 }


### PR DESCRIPTION
# Description

(datafeed) when adding job to reporterQueue and listenerWorkerQueue following process is added
- remove all jobs except largest `roundId` which are having same oracleAddress
> - if the job with largest `roundId` in the queue is larger than job which is to be added, now throws error
> - if the job with largest `roundId` is smaller, remove the job and add new job
> - if no jobs are found with the same oracle address, add new job

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
