### PR TITLE
Queue optimization based on roundId

### DIFF
--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -72,5 +72,7 @@ export enum OraklErrorCode {
   AxiosBadRequest,
   AxiosCanceledByUser,
   AxiosNotSupported,
-  AxiosInvalidUrl
+  AxiosInvalidUrl,
+  StaleRoundId,
+  UnexpectedJobId
 }

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -73,6 +73,5 @@ export enum OraklErrorCode {
   AxiosCanceledByUser,
   AxiosNotSupported,
   AxiosInvalidUrl,
-  StaleRoundId,
   UnexpectedJobId
 }

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -1,5 +1,5 @@
 import { Aggregator__factory } from '@bisonai/orakl-contracts'
-import { Queue } from 'bullmq'
+import { Queue, UnrecoverableError } from 'bullmq'
 import { ethers } from 'ethers'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
@@ -78,8 +78,9 @@ async function processEvent({ iface, logger }: { iface: ethers.utils.Interface; 
 
     if (eventData.startedBy == operatorAddress) {
       _logger.debug(`Ignore event emitted by ${eventData.startedBy} for round ${roundId}`)
+      return
     } else if (!(await isRoundIdFresh(this.workerQueue, oracleAddress, roundId))) {
-      _logger.debug(
+      throw new UnrecoverableError(
         `Low roundId, Ignore event emitted by ${eventData.startedBy} for round ${roundId}`
       )
     } else {

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -17,7 +17,7 @@ import {
   WORKER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { IDataFeedListenerWorker, IListenerConfig, INewRound } from '../types'
-import { buildSubmissionRoundJobId, isRoundIdValid } from '../utils'
+import { buildSubmissionRoundJobId, isRoundIdFresh } from '../utils'
 import { listenerService } from './listener'
 import { ProcessEventOutputType } from './types'
 
@@ -78,7 +78,7 @@ async function processEvent({ iface, logger }: { iface: ethers.utils.Interface; 
 
     if (eventData.startedBy == operatorAddress) {
       _logger.debug(`Ignore event emitted by ${eventData.startedBy} for round ${roundId}`)
-    } else if (!(await isRoundIdValid(this.workerQueue, oracleAddress, roundId))) {
+    } else if (!(await isRoundIdFresh(this.workerQueue, oracleAddress, roundId))) {
       _logger.debug(
         `Low roundId, Ignore event emitted by ${eventData.startedBy} for round ${roundId}`
       )

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -17,7 +17,7 @@ import {
   WORKER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { IDataFeedListenerWorker, IListenerConfig, INewRound } from '../types'
-import { buildSubmissionRoundJobId } from '../utils'
+import { buildSubmissionRoundJobId, shouldAddJobWithRoundId } from '../utils'
 import { listenerService } from './listener'
 import { ProcessEventOutputType } from './types'
 
@@ -78,6 +78,10 @@ async function processEvent({ iface, logger }: { iface: ethers.utils.Interface; 
 
     if (eventData.startedBy == operatorAddress) {
       _logger.debug(`Ignore event emitted by ${eventData.startedBy} for round ${roundId}`)
+    } else if (!(await shouldAddJobWithRoundId(this.workerQueue, oracleAddress, roundId))) {
+      _logger.debug(
+        `Low roundId, Ignore event emitted by ${eventData.startedBy} for round ${roundId}`
+      )
     } else {
       // NewRound emitted by somebody else
       const jobName = 'event'

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -17,7 +17,7 @@ import {
   WORKER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { IDataFeedListenerWorker, IListenerConfig, INewRound } from '../types'
-import { buildSubmissionRoundJobId, shouldAddJobWithRoundId } from '../utils'
+import { buildSubmissionRoundJobId, isRoundIdValid } from '../utils'
 import { listenerService } from './listener'
 import { ProcessEventOutputType } from './types'
 
@@ -78,7 +78,7 @@ async function processEvent({ iface, logger }: { iface: ethers.utils.Interface; 
 
     if (eventData.startedBy == operatorAddress) {
       _logger.debug(`Ignore event emitted by ${eventData.startedBy} for round ${roundId}`)
-    } else if (!(await shouldAddJobWithRoundId(this.workerQueue, oracleAddress, roundId))) {
+    } else if (!(await isRoundIdValid(this.workerQueue, oracleAddress, roundId))) {
       _logger.debug(
         `Low roundId, Ignore event emitted by ${eventData.startedBy} for round ${roundId}`
       )

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -12,6 +12,7 @@ import {
   REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
+import { dataFeedReporter } from './reporter'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
   const chainId = (await PROVIDER.getNetwork()).chainId
@@ -26,6 +27,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: DATA_FEED_REPORTER_CONCURRENCY,
     delegatedFee: [BAOBAB_CHAIN_ID, CYPRESS_CHAIN_ID].includes(chainId) ? true : false,
-    _logger: logger
+    _logger: logger,
+    _worker: dataFeedReporter
   })
 }

--- a/core/src/reporter/factory.ts
+++ b/core/src/reporter/factory.ts
@@ -4,6 +4,7 @@ import type { RedisClientType } from 'redis'
 import { BULLMQ_CONNECTION, CHAIN, PROVIDER_URL } from '../settings'
 import { reporter } from './reporter'
 import { State } from './state'
+import { workerType } from './types'
 import { watchman } from './watchman'
 
 const FILE_NAME = import.meta.url
@@ -17,7 +18,8 @@ export async function factory({
   delegatedFee,
   _logger,
   providerUrl = PROVIDER_URL,
-  chain = CHAIN
+  chain = CHAIN,
+  _worker = reporter
 }: {
   redisClient: RedisClientType
   stateName: string
@@ -28,6 +30,7 @@ export async function factory({
   providerUrl?: string
   chain?: string
   _logger: Logger
+  _worker?: workerType
 }) {
   const logger = _logger.child({ name: 'reporter', file: FILE_NAME })
 
@@ -44,7 +47,7 @@ export async function factory({
 
   logger.debug(await state.active(), 'Active reporters')
 
-  const reporterWorker = new Worker(reporterQueueName, await reporter(state, logger), {
+  const reporterWorker = new Worker(reporterQueueName, await _worker(state, logger), {
     ...BULLMQ_CONNECTION,
     concurrency
   })

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -3,7 +3,7 @@ import { Logger } from 'pino'
 import { OraklError, OraklErrorCode } from '../errors'
 import { BULLMQ_CONNECTION, REPORTER_AGGREGATOR_QUEUE_NAME } from '../settings'
 import { ITransactionParameters } from '../types'
-import { isRoundIdValid } from '../utils'
+import { isRoundIdFresh } from '../utils'
 import { State } from './state'
 import { wrapperType } from './types'
 import { sendTransaction, sendTransactionCaver, sendTransactionDelegatedFee } from './utils'
@@ -82,7 +82,7 @@ export function dataFeedReporter(state: State, logger: Logger) {
     }
     const [roundId, oracleAddress, _] = tmp
 
-    if (!isRoundIdValid(reporterAggregateQueue, oracleAddress, Number(roundId))) {
+    if (!isRoundIdFresh(reporterAggregateQueue, oracleAddress, Number(roundId))) {
       const msg = `not reporting for stake roundId: ${roundId}`
       logger.error(msg)
       throw new OraklError(OraklErrorCode.StaleRoundId, msg)

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -73,14 +73,14 @@ export function reporter(state: State, logger: Logger): wrapperType {
 export function dataFeedReporter(state: State, logger: Logger) {
   const reporterAggregateQueue = new Queue(REPORTER_AGGREGATOR_QUEUE_NAME, BULLMQ_CONNECTION)
   async function wrapper(job: Job) {
-    const tmp = job.id?.split('-')
-    if (!tmp || tmp.length < 3) {
+    const splittedJobId = job.id?.split('-')
+    if (!splittedJobId || splittedJobId.length < 3) {
       throw new OraklError(
         OraklErrorCode.UnexpectedJobId,
         `unexpected jobId from dataFeedReporter: ${job.id}`
       )
     }
-    const [roundId, oracleAddress, _] = tmp
+    const [roundId, oracleAddress, _] = splittedJobId
 
     if (!isRoundIdFresh(reporterAggregateQueue, oracleAddress, Number(roundId))) {
       logger.error(`not reporting for stale roundId: ${roundId}`)

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -1,11 +1,14 @@
-import { Job } from 'bullmq'
+import { Job, Queue } from 'bullmq'
 import { Logger } from 'pino'
 import { OraklError, OraklErrorCode } from '../errors'
+import { BULLMQ_CONNECTION, REPORTER_AGGREGATOR_QUEUE_NAME } from '../settings'
 import { ITransactionParameters } from '../types'
+import { isRoundIdValid } from '../utils'
 import { State } from './state'
+import { wrapperType } from './types'
 import { sendTransaction, sendTransactionCaver, sendTransactionDelegatedFee } from './utils'
 
-export function reporter(state: State, logger: Logger) {
+export function reporter(state: State, logger: Logger): wrapperType {
   async function wrapper(job: Job) {
     const inData: ITransactionParameters = job.data
     logger.debug(inData, 'inData')
@@ -64,5 +67,27 @@ export function reporter(state: State, logger: Logger) {
   }
 
   logger.debug('Reporter job built')
+  return wrapper
+}
+
+export function dataFeedReporter(state: State, logger: Logger) {
+  const reporterAggregateQueue = new Queue(REPORTER_AGGREGATOR_QUEUE_NAME, BULLMQ_CONNECTION)
+  async function wrapper(job: Job) {
+    const tmp = job.id?.split('-')
+    if (!tmp) {
+      throw new OraklError(
+        OraklErrorCode.UnexpectedJobId,
+        `unexpected jobId from dataFeedReporter: ${job.id}`
+      )
+    }
+    const [roundId, oracleAddress, _] = tmp
+
+    if (!isRoundIdValid(reporterAggregateQueue, oracleAddress, Number(roundId))) {
+      const msg = `not reporting for stake roundId: ${roundId}`
+      logger.error(msg)
+      throw new OraklError(OraklErrorCode.StaleRoundId, msg)
+    }
+    await reporter(state, logger)(job)
+  }
   return wrapper
 }

--- a/core/src/reporter/types.ts
+++ b/core/src/reporter/types.ts
@@ -1,6 +1,12 @@
+import { Job } from 'bullmq'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
+import { State } from './state'
 
 export interface IReporters {
   [index: string]: (redisClient: RedisClientType, _logger: Logger) => Promise<void>
 }
+
+export type wrapperType = (job: Job) => Promise<void>
+
+export type workerType = (state: State, logger: Logger) => wrapperType

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -461,6 +461,7 @@ export interface MockQueue {
   add: any // eslint-disable-line @typescript-eslint/no-explicit-any
   process: any // eslint-disable-line @typescript-eslint/no-explicit-any
   on: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  getJobs: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export type QueueType = Queue | MockQueue

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -6,6 +6,7 @@ import type { RedisClientType } from 'redis'
 import { createClient } from 'redis'
 import { OraklErrorCode } from './errors'
 import { SLACK_WEBHOOK_URL } from './settings'
+import { QueueType } from './types'
 
 export async function loadJson(filepath) {
   const json = await Fs.readFile(filepath, 'utf8')
@@ -104,6 +105,27 @@ export function buildHeartbeatJobId({
   deploymentName: string
 }) {
   return `${oracleAddress}-${deploymentName}`
+}
+
+export async function shouldAddJobWithRoundId(
+  queue: QueueType,
+  oracleAddress: string,
+  roundId: number
+) {
+  const jobs = await queue.getJobs()
+  const jobsWithSameOracleAddress = jobs.filter((_job) => _job.id?.split('-')[1] === oracleAddress)
+
+  if (!jobsWithSameOracleAddress) {
+    return true
+  }
+
+  let maxRoundId = 0
+  for (const _job of jobsWithSameOracleAddress) {
+    const _roundId = Number(_job.id?.split('-')[0]) || 0
+    maxRoundId = Math.max(maxRoundId, _roundId)
+  }
+
+  return maxRoundId < roundId
 }
 
 /*

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -107,7 +107,7 @@ export function buildHeartbeatJobId({
   return `${oracleAddress}-${deploymentName}`
 }
 
-export async function isRoundIdValid(queue: QueueType, oracleAddress: string, roundId: number) {
+export async function isRoundIdFresh(queue: QueueType, oracleAddress: string, roundId: number) {
   const jobs = await queue.getJobs()
   const jobsWithSameOracleAddress = jobs.filter((_job) => _job.id?.split('-')[1] === oracleAddress)
 

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -107,11 +107,7 @@ export function buildHeartbeatJobId({
   return `${oracleAddress}-${deploymentName}`
 }
 
-export async function shouldAddJobWithRoundId(
-  queue: QueueType,
-  oracleAddress: string,
-  roundId: number
-) {
+export async function isRoundIdValid(queue: QueueType, oracleAddress: string, roundId: number) {
   const jobs = await queue.getJobs()
   const jobsWithSameOracleAddress = jobs.filter((_job) => _job.id?.split('-')[1] === oracleAddress)
 

--- a/core/src/worker/data-feed.ts
+++ b/core/src/worker/data-feed.ts
@@ -32,7 +32,7 @@ import {
   IDataFeedListenerWorker,
   QueueType
 } from '../types'
-import { buildHeartbeatJobId, buildSubmissionRoundJobId, isRoundIdValid } from '../utils'
+import { buildHeartbeatJobId, buildSubmissionRoundJobId, isRoundIdFresh } from '../utils'
 import { fetchDataFeedByAggregatorId, getAggregatorGivenAddress, getAggregators } from './api'
 import { buildTransaction, isStale, oracleRoundStateCall } from './data-feed.utils'
 import { State } from './state'
@@ -224,7 +224,7 @@ export function aggregatorJob(
 
       if (!submission || isStale({ timestamp, logger })) {
         logger.warn(`Data became stale (> ${MAX_DATA_STALENESS}). Not reporting.`)
-      } else if (!(await isRoundIdValid(reporterQueue, oracleAddress, roundId))) {
+      } else if (!(await isRoundIdFresh(reporterQueue, oracleAddress, roundId))) {
         logger.warn(`Data having low roundId:${roundId}. Not reporting`)
       } else {
         const tx = buildTransaction({
@@ -340,7 +340,7 @@ function heartbeatJob(aggregatorQueue: Queue, state: State, _logger: Logger) {
       if (!eligibleToSubmit) {
         const msg = `Non-eligible to submit for oracle ${oracleAddress} with operator ${operatorAddress}`
         throw new OraklError(OraklErrorCode.NonEligibleToSubmit, msg)
-      } else if (!(await isRoundIdValid(aggregatorQueue, oracleAddress, roundId))) {
+      } else if (!(await isRoundIdFresh(aggregatorQueue, oracleAddress, roundId))) {
         const msg = `low roundId to submit for oracle ${oracleAddress} with roundId: ${roundId}`
         throw new OraklError(OraklErrorCode.NonEligibleToSubmit, msg)
       } else {
@@ -554,7 +554,7 @@ export function deviationJob(reporterQueue: QueueType, _logger: Logger) {
       logger.debug({ aggregatorHash, fetchedAt: timestamp, submission }, 'Latest data aggregate')
       if (isStale({ timestamp, logger })) {
         logger.warn(`Data became stale (> ${MAX_DATA_STALENESS}). Not reporting.`)
-      } else if (!(await isRoundIdValid(reporterQueue, oracleAddress, roundId))) {
+      } else if (!(await isRoundIdFresh(reporterQueue, oracleAddress, roundId))) {
         logger.warn(`Data having low roundId:${roundId}. Not reporting`)
       } else {
         const tx = buildTransaction({

--- a/core/test/utils.ts
+++ b/core/test/utils.ts
@@ -4,5 +4,6 @@ import { MockQueue } from '../src/types'
 export const QUEUE: MockQueue = {
   add: jest.fn(),
   process: jest.fn(),
-  on: jest.fn()
+  on: jest.fn(),
+  getJobs: jest.fn()
 }


### PR DESCRIPTION
# Description
Datafeed related queue optimization based on roundId

## Added functions

<details>
<summary>Click to expand</summary>

- isRoundIdFresh: checks if given roundId is new inside given queue
https://github.com/Bisonai/orakl/blob/53f2e18a5877455a337537eacf728283b62f5d1a/core/src/utils.ts#L110-L125

- dataFeedReporter: add functionality to skip reporting for old roundId
https://github.com/Bisonai/orakl/blob/53f2e18a5877455a337537eacf728283b62f5d1a/core/src/reporter/reporter.ts#L73-L92


</details>

## Job added only if roundId is fresh

If roundId is low, jobs won't be added to following queues

- workerQueue
- reporterQueue (aggregatorQueue)

## Job skipped for old roundId

If roundId is low, reporter will skip reporting.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
