### PR TITLE
remove listener state before obliterate

### DIFF
--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -43,6 +43,7 @@ export async function buildListener(
   const historyListenerQueue = new Queue(historyQueueName, BULLMQ_CONNECTION)
   const processEventQueue = new Queue(processEventQueueName, BULLMQ_CONNECTION)
 
+  await redisClient.del(stateName)
   await latestListenerQueue.obliterate({ force: true })
   await historyListenerQueue.obliterate({ force: true })
   await processEventQueue.obliterate({ force: true })

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -43,7 +43,7 @@ export async function buildListener(
   const historyListenerQueue = new Queue(historyQueueName, BULLMQ_CONNECTION)
   const processEventQueue = new Queue(processEventQueueName, BULLMQ_CONNECTION)
 
-  await redisClient.del(stateName)
+  await redisClient.set(stateName, JSON.stringify([]))
   await latestListenerQueue.obliterate({ force: true })
   await historyListenerQueue.obliterate({ force: true })
   await processEventQueue.obliterate({ force: true })


### PR DESCRIPTION
# Description

latestListenerQueue was empty after obliterate was called,
and then from `clear()`, it tried to get jobs from queue based on remaining activeListeners which was already empty leading to error

this fixes certain error by removing activeListeners before obliterate

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
