### PR TITLE
Display `address` and `oracleAddress` during reporter launch

### DIFF
--- a/core/src/reporter/factory.ts
+++ b/core/src/reporter/factory.ts
@@ -42,7 +42,13 @@ export async function factory({
   })
   await state.refresh()
 
-  logger.debug(await state.active(), 'Active reporters')
+  const activeReporters = await state.active()
+  logger.debug(
+    activeReporters.map((x) => {
+      return { address: x.address, oracleAddress: x.oracleAddress }
+    }),
+    'Active reporters'
+  )
 
   const reporterWorker = new Worker(reporterQueueName, await reporter(state, logger), {
     ...BULLMQ_CONNECTION,


### PR DESCRIPTION
# Description

AS-IS
Print out every information about reporter in factory.

TO-BE
Print out only `address` and `oracleAddress` about reporter in factory.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
