### PR TITLE
Improve api logging

### DIFF
--- a/go-api/adapter/controller.go
+++ b/go-api/adapter/controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type AdapterHashModel struct {
@@ -49,17 +48,17 @@ type FeedIdModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(AdapterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	err := computeAdapterHash(payload, true)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	row, err := utils.QueryRow[AdapterIdModel](c, InsertAdapter, map[string]any{
@@ -67,7 +66,7 @@ func insert(c *fiber.Ctx) error {
 		"name":         payload.Name,
 		"decimals":     payload.Decimals})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	for _, item := range payload.Feeds {
@@ -77,7 +76,7 @@ func insert(c *fiber.Ctx) error {
 			"definition": item.Definition,
 			"adapter_id": item.AdapterId})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 	}
 
@@ -90,23 +89,23 @@ func hash(c *fiber.Ctx) error {
 	verifyRaw := c.Query("verify")
 	verify, err := strconv.ParseBool(verifyRaw)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	var payload AdapterInsertModel
 
 	if err := c.BodyParser(&payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	err = computeAdapterHash(&payload, verify)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(payload)
 }
@@ -114,7 +113,7 @@ func hash(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[AdapterModel](c, GetAdapter, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -124,7 +123,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AdapterModel](c, GetAdpaterById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -135,7 +134,7 @@ func deleteById(c *fiber.Ctx) error {
 
 	result, err := utils.QueryRow[AdapterModel](c, RemoveAdapter, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -154,7 +153,7 @@ func computeAdapterHash(data *AdapterInsertModel, verify bool) error {
 
 	out, err := json.Marshal(input)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	hash := crypto.Keccak256Hash([]byte(out))

--- a/go-api/aggregate/controller.go
+++ b/go-api/aggregate/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type AggregateRedisValueModel struct {
@@ -39,13 +38,13 @@ type AggregateIdModel struct {
 func insert(c *fiber.Ctx) error {
 	_payload := new(WrappedInsertModel)
 	if err := c.BodyParser(_payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	payload := _payload.Data
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	row, err := utils.QueryRow[AggregateIdModel](c, InsertAggregate, map[string]any{
@@ -53,18 +52,18 @@ func insert(c *fiber.Ctx) error {
 		"value":         payload.Value,
 		"aggregator_id": payload.AggregatorId})
 	if err != nil {
-		log.Errorf("failed to query row:" + err.Error())
+		panic(err)
 	}
 
 	key := "latestAggregate:" + payload.AggregatorId.String()
 	value, err := json.Marshal(AggregateRedisValueModel{Timestamp: payload.Timestamp, Value: payload.Value})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	err = utils.SetRedis(c, key, string(value))
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result := AggregateModel{AggregateId: row.AggregateId, Timestamp: payload.Timestamp, Value: payload.Value, AggregatorId: payload.AggregatorId}
@@ -74,7 +73,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[AggregateModel](c, GetAggregate, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(results)
 }
@@ -83,7 +82,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AggregateModel](c, GetAggregateById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -93,7 +92,7 @@ func getLatestByHash(c *fiber.Ctx) error {
 	hash := c.Params("hash")
 	result, err := utils.QueryRow[AggregateModel](c, GetLatestAggregateByHash, map[string]any{"aggregator_hash": hash})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -113,14 +112,14 @@ func getLatestById(c *fiber.Ctx) error {
 	if err != nil {
 		pgsqlResult, err := utils.QueryRow[AggregateModel](c, GetLatestAggregateById, map[string]any{"aggregator_id": id})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		return c.JSON(pgsqlResult)
 	}
 
 	err = json.Unmarshal([]byte(rawResult), &result)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -130,17 +129,17 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(AggregateInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[AggregateModel](c, UpdateAggregateById, map[string]any{"timestamp": payload.Timestamp.String(), "value": payload.Value, "aggregator_id": payload.AggregatorId, "id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -150,7 +149,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AggregateModel](c, DeleteAggregateById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/aggregator/controller.go
+++ b/go-api/aggregator/controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type WrappedUpdateModel struct {
@@ -89,22 +88,22 @@ type AggregatorIdModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(AggregatorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	adapter_result, err := utils.QueryRow[adapter.AdapterModel](c, adapter.GetAdapterByHash, map[string]any{"adapter_hash": payload.AdapterHash})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	hashComputeParam := AggregatorHashComputeInputModel{
@@ -119,7 +118,7 @@ func insert(c *fiber.Ctx) error {
 	}
 	err = computeAggregatorHash(&hashComputeParam, true)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	insertParam := _AggregatorInsertModel{
@@ -158,7 +157,7 @@ func insert(c *fiber.Ctx) error {
 		"fetcher_type":       insertParam.FetcherType,
 	})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result := AggregatorResultModel{
@@ -182,17 +181,17 @@ func hash(c *fiber.Ctx) error {
 	verifyRaw := c.Query("verify")
 	verify, err := strconv.ParseBool(verifyRaw)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	payload := new(AggregatorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	hashComputeParam := AggregatorHashComputeInputModel{
@@ -208,7 +207,7 @@ func hash(c *fiber.Ctx) error {
 
 	err = computeAggregatorHash(&hashComputeParam, verify)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(hashComputeParam)
@@ -223,12 +222,12 @@ func get(c *fiber.Ctx) error {
 	}
 	queryString, err := GenerateGetAggregatorQuery(queryParam)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	results, err := utils.QueryRows[AggregatorResultModel](c, queryString, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -241,7 +240,7 @@ func getByHashAndChain(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": _chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result.AggregatorResultModel, err = utils.QueryRow[AggregatorResultModel](c, GetAggregatorByChainAndHash, map[string]any{
@@ -249,17 +248,17 @@ func getByHashAndChain(c *fiber.Ctx) error {
 		"chain_id":        chain_result.ChainId,
 	})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result.Adapter.AdapterModel, err = utils.QueryRow[adapter.AdapterModel](c, adapter.GetAdpaterById, map[string]any{"id": result.AggregatorResultModel.AdapterId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result.Adapter.Feeds, err = utils.QueryRows[feed.FeedModel](c, feed.GetFeedsByAdapterId, map[string]any{"id": result.AggregatorResultModel.AdapterId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(result)
 }
@@ -268,7 +267,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AggregatorResultModel](c, RemoveAggregator, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -278,14 +277,14 @@ func updateByHash(c *fiber.Ctx) error {
 	hash := c.Params("hash")
 	_payload := new(WrappedUpdateModel)
 	if err := c.BodyParser(_payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	payload := _payload.Data
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	if payload.Active == nil {
@@ -295,7 +294,7 @@ func updateByHash(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[AggregatorResultModel](c, UpdateAggregatorByHash, map[string]any{
@@ -303,7 +302,7 @@ func updateByHash(c *fiber.Ctx) error {
 		"hash":     hash,
 		"chain_id": chain_result.ChainId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -314,13 +313,13 @@ func computeAggregatorHash(data *AggregatorHashComputeInputModel, verify bool) e
 	processData := input.AggregatorHashComputeProcessModel
 	out, err := json.Marshal(processData)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	hash := crypto.Keccak256Hash([]byte(out))
 	hashString := fmt.Sprintf("0x%x", hash)
 	if verify && data.AggregatorHash != hashString {
-		log.Panic(err)
+		panic(err)
 	}
 
 	data.AggregatorHash = hashString

--- a/go-api/apierr/controller.go
+++ b/go-api/apierr/controller.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ErrorInsertModel struct {
@@ -29,12 +28,12 @@ type ErrorModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ErrorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ErrorModel](c, InsertError, map[string]any{
@@ -45,7 +44,7 @@ func insert(c *fiber.Ctx) error {
 		"stack":      payload.Stack})
 
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -54,7 +53,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ErrorModel](c, GetError, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(results)
 }
@@ -63,7 +62,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ErrorModel](c, GetErrorById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -71,12 +70,12 @@ func getById(c *fiber.Ctx) error {
 
 func deleteById(c *fiber.Ctx) error {
 	if !utils.IsTesting(c) {
-		log.Panic(fmt.Errorf("not allowed"))
+		panic(fmt.Errorf("not allowed"))
 	}
 	id := c.Params("id")
 	result, err := utils.QueryRow[ErrorModel](c, RemoveErrorById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/chain/controller.go
+++ b/go-api/chain/controller.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ChainInsertModel struct {
@@ -21,17 +20,17 @@ func insert(c *fiber.Ctx) error {
 	payload := new(ChainInsertModel)
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ChainModel](c, InsertChain, map[string]any{"name": payload.Name})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -40,7 +39,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ChainModel](c, GetChain, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -50,7 +49,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ChainModel](c, GetChainByID, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -61,12 +60,12 @@ func patchById(c *fiber.Ctx) error {
 	payload := new(ChainInsertModel)
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ChainModel](c, UpdateChain, map[string]any{"name": payload.Name, "id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -77,7 +76,7 @@ func deleteById(c *fiber.Ctx) error {
 
 	result, err := utils.QueryRow[ChainModel](c, RemoveChain, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/data/controller.go
+++ b/go-api/data/controller.go
@@ -5,7 +5,6 @@ import (
 	"go-api/utils"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type BulkInsertModel struct {
@@ -34,17 +33,17 @@ type BulkInsertResultModel struct {
 func bulkInsert(c *fiber.Ctx) error {
 	payload := new(BulkInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	query, err := GenerateBulkInsertQuery(payload.Data)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	err = utils.RawQueryWithoutReturn(c, query, nil)
 
 	if err != nil {
-		log.Error(err)
+		panic(err)
 	}
 
 	countResult := BulkInsertResultModel{Count: len(payload.Data)}
@@ -55,8 +54,7 @@ func bulkInsert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[DataResultModel](c, GetData, nil)
 	if err != nil {
-		log.Error(err)
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -66,7 +64,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[DataResultModel](c, GetDataById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -74,12 +72,12 @@ func getById(c *fiber.Ctx) error {
 
 func getByFeedId(c *fiber.Ctx) error {
 	if !utils.IsTesting(c) {
-		log.Panic(fmt.Errorf("not allowed"))
+		panic(fmt.Errorf("not allowed"))
 	}
 	id := c.Params("id")
 	results, err := utils.QueryRows[DataResultModel](c, GetDataByFeedId, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -87,12 +85,12 @@ func getByFeedId(c *fiber.Ctx) error {
 
 func deleteById(c *fiber.Ctx) error {
 	if !utils.IsTesting(c) {
-		log.Panic(fmt.Errorf("not allowed"))
+		panic(fmt.Errorf("not allowed"))
 	}
 	id := c.Params("id")
 	result, err := utils.QueryRow[DataResultModel](c, DeleteDataById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/feed/controller.go
+++ b/go-api/feed/controller.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type FeedWithoutAdapterIdModel struct {
@@ -31,7 +30,7 @@ type FeedModel struct {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[FeedModel](c, GetFeed, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -41,7 +40,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[FeedModel](c, GetFeedById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -49,24 +48,24 @@ func getById(c *fiber.Ctx) error {
 
 func getByAdpaterId(c *fiber.Ctx) error {
 	if !utils.IsTesting(c) {
-		log.Panic(fmt.Errorf("not allowed"))
+		panic(fmt.Errorf("not allowed"))
 	}
 	id := c.Params("id")
 	results, err := utils.QueryRows[FeedModel](c, GetFeedsByAdapterId, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(results)
 }
 
 func removeById(c *fiber.Ctx) error {
 	if !utils.IsTesting(c) {
-		log.Panic(fmt.Errorf("not allowed"))
+		panic(fmt.Errorf("not allowed"))
 	}
 	id := c.Params("id")
 	result, err := utils.QueryRow[FeedModel](c, DeleteFeedById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/l2aggregator/controller.go
+++ b/go-api/l2aggregator/controller.go
@@ -5,7 +5,6 @@ import (
 	"go-api/utils"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type l2agregatorPairModel struct {
@@ -22,12 +21,12 @@ func get(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": _chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[l2agregatorPairModel](c, GetL2AggregatorPair, map[string]any{"l1_aggregator_address": l1Address, "chain_id": chain_result.ChainId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/listener/controller.go
+++ b/go-api/listener/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ListenerUpdateModel struct {
@@ -38,22 +37,22 @@ type ListenerInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ListenerInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ListenerModel](c, InsertListener, map[string]any{
@@ -62,7 +61,7 @@ func insert(c *fiber.Ctx) error {
 		"chain_id":   chain_result.ChainId,
 		"service_id": service_result.ServiceId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -75,20 +74,20 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[ListenerModel](c, GenerateGetListenerQuery(params), nil)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 
 		return c.JSON(results)
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -96,14 +95,14 @@ func get(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ListenerModel](c, GenerateGetListenerQuery(params), nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -113,7 +112,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ListenerModel](c, GetListenerById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -123,12 +122,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ListenerUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ListenerModel](c, UpdateListenerById, map[string]any{
@@ -136,7 +135,7 @@ func updateById(c *fiber.Ctx) error {
 		"address":    payload.Address,
 		"event_name": payload.EventName})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -147,7 +146,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ListenerModel](c, DeleteListenerById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/main.go
+++ b/go-api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"go-api/adapter"
 	"go-api/aggregate"
 	"go-api/aggregator"
@@ -13,16 +14,12 @@ import (
 	"go-api/proxy"
 	"go-api/reporter"
 	"go-api/service"
+	"go-api/utils"
 	"go-api/vrf"
-
-	_ "embed"
-	"os"
+	"log"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 	"github.com/joho/godotenv"
-
-	"go-api/utils"
 )
 
 //go:embed .version
@@ -31,14 +28,13 @@ var version string
 func main() {
 	err := godotenv.Load()
 	if err != nil {
-		log.Info("env file is not found, continueing without .env file")
+		log.Println("env file is not found, continueing without .env file")
 	}
 	config := utils.LoadEnvVars()
 
 	appConfig, err := utils.Setup(version)
 	if err != nil {
-		log.Panic(err)
-		os.Exit(1)
+		panic(err)
 	}
 
 	postgres := appConfig.Postgres
@@ -60,7 +56,7 @@ func main() {
 
 	err = app.Listen(":" + port)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 }
 

--- a/go-api/main.go
+++ b/go-api/main.go
@@ -28,7 +28,7 @@ var version string
 func main() {
 	err := godotenv.Load()
 	if err != nil {
-		log.Println("env file is not found, continueing without .env file")
+		log.Println("env file is not found, continuing without .env file")
 	}
 	config := utils.LoadEnvVars()
 

--- a/go-api/proxy/controller.go
+++ b/go-api/proxy/controller.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ProxyModel struct {
@@ -26,12 +25,12 @@ type ProxyInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ProxyInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ProxyModel](c, InsertProxy, map[string]any{
@@ -40,7 +39,7 @@ func insert(c *fiber.Ctx) error {
 		"port":     payload.Port,
 		"location": &payload.Location})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -49,7 +48,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ProxyModel](c, GetProxy, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -59,7 +58,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ProxyModel](c, GetProxyById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -70,12 +69,12 @@ func updateById(c *fiber.Ctx) error {
 
 	payload := new(ProxyInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ProxyModel](c, UpdateProxyById, map[string]any{
@@ -85,7 +84,7 @@ func updateById(c *fiber.Ctx) error {
 		"port":     payload.Port,
 		"location": &payload.Location})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -95,7 +94,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ProxyModel](c, DeleteProxyById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/reporter/controller.go
+++ b/go-api/reporter/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ReporterUpdateModel struct {
@@ -47,27 +46,27 @@ type ReporterSearchByOracleAddressModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ReporterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	encrypted, err := utils.EncryptText(payload.PrivateKey)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, InsertReporter, map[string]any{
@@ -77,7 +76,7 @@ func insert(c *fiber.Ctx) error {
 		"chain_id":      chain_result.ChainId,
 		"service_id":    service_result.ServiceId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result.PrivateKey = payload.PrivateKey
@@ -92,12 +91,12 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		for i := range results {
 			decrypted, err := utils.DecryptText(results[i].PrivateKey)
 			if err != nil {
-				log.Panic(err)
+				panic(err)
 			}
 			results[i].PrivateKey = decrypted
 		}
@@ -106,13 +105,13 @@ func get(c *fiber.Ctx) error {
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -120,20 +119,20 @@ func get(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	for i := range results {
 		decrypted, err := utils.DecryptText(results[i].PrivateKey)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		results[i].PrivateKey = decrypted
 	}
@@ -147,7 +146,7 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	params := GetReporterQueryParams{}
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	params.OracleAddress = oracleAddress
@@ -155,7 +154,7 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -163,20 +162,20 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	for i := range results {
 		decrypted, err := utils.DecryptText(results[i].PrivateKey)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		results[i].PrivateKey = decrypted
 	}
@@ -188,12 +187,12 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ReporterModel](c, GetReporterById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	decrypted, err := utils.DecryptText(result.PrivateKey)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	result.PrivateKey = decrypted
 
@@ -204,17 +203,17 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ReporterUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	encrypted, err := utils.EncryptText(payload.PrivateKey)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, UpdateReporterById, map[string]any{
@@ -224,7 +223,7 @@ func updateById(c *fiber.Ctx) error {
 		"oracleAddress": payload.OracleAddress})
 
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result.PrivateKey = payload.PrivateKey
@@ -236,12 +235,12 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ReporterModel](c, DeleteReporterById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	decrypted, err := utils.DecryptText(result.PrivateKey)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	result.PrivateKey = decrypted
 

--- a/go-api/service/controller.go
+++ b/go-api/service/controller.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type ServiceModel struct {
@@ -20,17 +19,17 @@ type ServiceInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ServiceInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ServiceModel](c, InsertService, map[string]any{"name": payload.Name})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -39,7 +38,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ServiceModel](c, GetService, nil)
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(results)
 }
@@ -48,7 +47,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ServiceModel](c, GetServiceById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 	return c.JSON(result)
 }
@@ -57,12 +56,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ServiceInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[ServiceModel](c, UpdateServiceById, map[string]any{"id": id, "name": payload.Name})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -72,7 +71,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ServiceModel](c, DeleteServiceById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)

--- a/go-api/utils/utils.go
+++ b/go-api/utils/utils.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
-	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -158,7 +157,6 @@ func Setup(options ...string) (AppConfig, error) {
 	})
 
 	app.Use(recover.New())
-	app.Use(logger.New())
 	app.Use(cors.New())
 	app.Use(func(c *fiber.Ctx) error {
 		c.Locals("rdb", *rdb)

--- a/go-api/vrf/controller.go
+++ b/go-api/vrf/controller.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 )
 
 type VrfModel struct {
@@ -39,17 +38,17 @@ type VrfInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(VrfInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[VrfModel](c, InsertVrf, map[string]any{
@@ -60,7 +59,7 @@ func insert(c *fiber.Ctx) error {
 		"key_hash": payload.KeyHash,
 		"chain_id": chain_result.ChainId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -74,23 +73,23 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[VrfModel](c, GetVrfWithoutChainId, nil)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
 		return c.JSON(results)
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.CHAIN})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	results, err := utils.QueryRows[VrfModel](c, GetVrf, map[string]any{"chain_id": chain_result.ChainId})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(results)
@@ -100,7 +99,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[VrfModel](c, GetVrfById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -110,12 +109,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(VrfUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	result, err := utils.QueryRow[VrfModel](c, UpdateVrfById, map[string]any{
@@ -126,7 +125,7 @@ func updateById(c *fiber.Ctx) error {
 		"pk_y":     payload.PkY,
 		"key_hash": payload.KeyHash})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)
@@ -136,7 +135,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[VrfModel](c, DeleteVrfById, map[string]any{"id": id})
 	if err != nil {
-		log.Panic(err)
+		panic(err)
 	}
 
 	return c.JSON(result)


### PR DESCRIPTION
# Description

**it's okay to only review utils/utils.go file**

## AS-IS
- Mostly relies on fiber logger middleware
- No information for stacktrace or filepath
- Unintended status code 200 on panic

```bash
2024/02/03 12:15:19.630830 controller.go:127: [Panic] no rows in result set
12:15:19 | 200 |   38.638583ms | 127.0.0.1 | GET | /api/v1/adapter/94 | -
```

```bash
12:18:03 | 404 |    2.466833ms | 127.0.0.1 | GET | /api/v1/docs | Cannot GET /api/v1/docs
```


## TO-BE
- No more logs for successful requests
- Panic error will print out stack trace
```bash
2024/02/03 11:43:51 | (adapter/controller.go:126) panic: no rows in result set
goroutine 26 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/debug/stack.go:24 +0x64
go-api/utils.CustomStackTraceHandler(0x0?, {0x1026ecca0?, 0x102b2cd40})
        /Users/nick/dev/orakl/go-api/utils/utils.go:295 +0x1d8
go-api/utils.Setup.New.func2.1()
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/recover/recover.go:31 +0x70
panic({0x1026ecca0?, 0x102b2cd40?})
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/panic.go:914 +0x218
go-api/adapter.getById(0x1400060e000?)
        /Users/nick/dev/orakl/go-api/adapter/controller.go:126 +0x17c
github.com/gofiber/fiber/v2.(*App).next(0x14000498500, 0x1400022c300)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:145 +0x188
github.com/gofiber/fiber/v2.(*Ctx).Next(0x1027b7260?)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1030 +0x5c
go-api/utils.Setup.func1(0x8?)
        /Users/nick/dev/orakl/go-api/utils/utils.go:174 +0x104
github.com/gofiber/fiber/v2.(*Ctx).Next(0x14000014330?)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1027 +0x48
github.com/gofiber/fiber/v2/middleware/cors.New.func1(0x1400022c300)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/cors/cors.go:166 +0x318
github.com/gofiber/fiber/v2.(*Ctx).Next(0x1400007daf8?)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1027 +0x48
go-api/utils.Setup.New.func2(0x1026f8460?)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/recover/recover.go:43 +0xa4
github.com/gofiber/fiber/v2.(*App).next(0x14000498500, 0x1400022c300)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:145 +0x188
github.com/gofiber/fiber/v2.(*App).handler(0x14000498500, 0x10235fbd8?)
        /Users/nick/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:172 +0x74
github.com/valyala/fasthttp.(*Server).serveConn(0x1400043fc00, {0x1027cefb0?, 0x1400006a000})
        /Users/nick/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/server.go:2359 +0xdd0
github.com/valyala/fasthttp.(*workerPool).workerFunc(0x1400048e000, 0x14000174c00)
        /Users/nick/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/workerpool.go:224 +0x70
github.com/valyala/fasthttp.(*workerPool).getCh.func1()
        /Users/nick/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/workerpool.go:196 +0x38
created by github.com/valyala/fasthttp.(*workerPool).getCh in goroutine 1
        /Users/nick/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/workerpool.go:195 +0x208

2024/02/03 11:43:51 | 500 | 127.0.0.1 | GET | /api/v1/adapter/94 | no rows in result set
```
- Non-panic error such as requesting for path not existing, will only print out request info
```bash
2024/02/03 12:11:59 | 404 | 127.0.0.1 | GET | /api/v1/docs | Cannot GET /api/v1/docs
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
