### PR TITLE
(API) Fix default behavior of empty row on `ErrNoRows`

### DIFF
--- a/go-api/aggregate/controller.go
+++ b/go-api/aggregate/controller.go
@@ -2,12 +2,10 @@ package aggregate
 
 import (
 	"encoding/json"
-	"errors"
 	"go-api/utils"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/jackc/pgx/v5"
 )
 
 type AggregateRedisValueModel struct {
@@ -109,9 +107,6 @@ func getLatestById(c *fiber.Ctx) error {
 	if err != nil {
 		pgsqlResult, err := utils.QueryRow[AggregateModel](c, GetLatestAggregateById, map[string]any{"aggregator_id": id})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return c.JSON(result)
-			}
 			panic(err)
 		}
 		return c.JSON(pgsqlResult)

--- a/go-api/utils/utils.go
+++ b/go-api/utils/utils.go
@@ -104,6 +104,9 @@ func QueryRow[T any](c *fiber.Ctx, query string, args map[string]any) (T, error)
 	}
 
 	result, err = pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[T])
+	if errors.Is(err, pgx.ErrNoRows) {
+		return result, nil
+	}
 	return result, err
 }
 
@@ -120,6 +123,9 @@ func QueryRows[T any](c *fiber.Ctx, query string, args map[string]any) ([]T, err
 	}
 
 	results, err = pgx.CollectRows(rows, pgx.RowToStructByName[T])
+	if errors.Is(err, pgx.ErrNoRows) {
+		return results, nil
+	}
 	return results, err
 }
 

--- a/go-api/utils/utils.go
+++ b/go-api/utils/utils.go
@@ -103,7 +103,7 @@ func QueryRow[T any](c *fiber.Ctx, query string, args map[string]any) (T, error)
 		return result, err
 	}
 
-	result, err = pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[T])
+	result, err = pgx.CollectOneRow(rows, pgx.RowToStructByName[T])
 	if errors.Is(err, pgx.ErrNoRows) {
 		return result, nil
 	}


### PR DESCRIPTION
# Description

it'll no more panic on empty query result, but rather return empty result

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
