### PR TITLE
(API) Hotfix adapter removal

### DIFF
--- a/go-api/adapter/controller.go
+++ b/go-api/adapter/controller.go
@@ -132,7 +132,7 @@ func getById(c *fiber.Ctx) error {
 func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 
-	err := utils.RawQueryWithoutReturn(c, feed.DeleteFeedById, map[string]any{"id": id})
+	err := utils.RawQueryWithoutReturn(c, feed.DeleteFeedByAdapterId, map[string]any{"id": id})
 	if err != nil {
 		panic(err)
 	}

--- a/go-api/adapter/controller.go
+++ b/go-api/adapter/controller.go
@@ -132,6 +132,11 @@ func getById(c *fiber.Ctx) error {
 func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 
+	err := utils.RawQueryWithoutReturn(c, feed.DeleteFeedById, map[string]any{"id": id})
+	if err != nil {
+		panic(err)
+	}
+
 	result, err := utils.QueryRow[AdapterModel](c, RemoveAdapter, map[string]any{"id": id})
 	if err != nil {
 		panic(err)

--- a/go-api/adapter/controller.go
+++ b/go-api/adapter/controller.go
@@ -131,12 +131,6 @@ func getById(c *fiber.Ctx) error {
 
 func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
-
-	err := utils.RawQueryWithoutReturn(c, feed.DeleteFeedByAdapterId, map[string]any{"id": id})
-	if err != nil {
-		panic(err)
-	}
-
 	result, err := utils.QueryRow[AdapterModel](c, RemoveAdapter, map[string]any{"id": id})
 	if err != nil {
 		panic(err)

--- a/go-api/feed/queries.go
+++ b/go-api/feed/queries.go
@@ -8,6 +8,4 @@ const (
 	DeleteFeedById = `DELETE FROM feeds WHERE feed_id = @id RETURNING *`
 
 	GetFeedsByAdapterId = `SELECT * FROM feeds WHERE adapter_id = @id;`
-
-	DeleteFeedByAdapterId = `DELETE FROM feeds WHERE adapter_id = @id RETURNING *`
 )

--- a/go-api/feed/queries.go
+++ b/go-api/feed/queries.go
@@ -8,4 +8,6 @@ const (
 	DeleteFeedById = `DELETE FROM feeds WHERE feed_id = @id RETURNING *`
 
 	GetFeedsByAdapterId = `SELECT * FROM feeds WHERE adapter_id = @id;`
+
+	DeleteFeedByAdapterId = `DELETE FROM feeds WHERE adapter_id = @id RETURNING *`
 )

--- a/go-api/migrations/000001_initialize_tables.up.sql
+++ b/go-api/migrations/000001_initialize_tables.up.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS "aggregates" (
     aggregator_id BIGINT NOT NULL,
     timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
     value BIGINT NOT NULL,
-    CONSTRAINT "aggregates_aggregator_id_fkey" FOREIGN KEY ("aggregator_id") REFERENCES "public"."aggregators" ("aggregator_id"),
+    CONSTRAINT "aggregates_aggregator_id_fkey" FOREIGN KEY ("aggregator_id") REFERENCES "public"."aggregators" ("aggregator_id") ON DELETE CASCADE,
     CONSTRAINT "aggregates_pkey" PRIMARY KEY ("aggregate_id")
 );
 
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS "feeds" (
     definition JSONB NOT NULL,
     feed_id BIGSERIAL NOT NULL,
     name TEXT NOT NULL,
-    CONSTRAINT "feeds_adapter_id_fkey" FOREIGN KEY ("adapter_id") REFERENCES "public"."adapters" ("adapter_id"),
+    CONSTRAINT "feeds_adapter_id_fkey" FOREIGN KEY ("adapter_id") REFERENCES "public"."adapters" ("adapter_id") ON DELETE CASCADE,
     CONSTRAINT "feeds_pkey" PRIMARY KEY ("feed_id")
 );
 
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS "data" (
     feed_id BIGINT NOT NULL,
     timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
     value BIGINT NOT NULL,
-    CONSTRAINT "data_aggregator_id_fkey" FOREIGN KEY ("aggregator_id") REFERENCES "public"."aggregators" ("aggregator_id"),
+    CONSTRAINT "data_aggregator_id_fkey" FOREIGN KEY ("aggregator_id") REFERENCES "public"."aggregators" ("aggregator_id") ON DELETE CASCADE,
     CONSTRAINT "data_pkey" PRIMARY KEY ("data_id"),
     CONSTRAINT "data_feed_id_fkey" FOREIGN KEY ("feed_id") REFERENCES "public"."feeds" ("feed_id")
 );


### PR DESCRIPTION
# Description

Prisma used to auto handle constraint deletion, so it deleted feeds when adapter deletion requested. However, it wasn't handled in go-api. This PR adds feature to remove all related feeds on removing adapter

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
