### PR TITLE
(OraklNode) Use global error instead of env load everytime

### DIFF
--- a/node/pkg/db/redis.go
+++ b/node/pkg/db/redis.go
@@ -21,6 +21,7 @@ type RedisConnectionInfo struct {
 var (
 	initRdbOnce sync.Once
 	rdb         *redis.Conn
+	rdbErr      error
 )
 
 func GetRedisConn(ctx context.Context) (*redis.Conn, error) {
@@ -28,17 +29,17 @@ func GetRedisConn(ctx context.Context) (*redis.Conn, error) {
 }
 
 func getRedisConn(ctx context.Context, once *sync.Once) (*redis.Conn, error) {
-	var err error
-
-	connectionInfo, err := loadRedisConnectionString()
-	if err != nil {
-		return nil, err
-	}
 
 	once.Do(func() {
-		rdb, err = connectToRedis(ctx, connectionInfo)
+		connectionInfo, err := loadRedisConnectionString()
+		if err != nil {
+			rdbErr = err
+			return
+		}
+
+		rdb, rdbErr = connectToRedis(ctx, connectionInfo)
 	})
-	return rdb, err
+	return rdb, rdbErr
 
 }
 


### PR DESCRIPTION
# Description

### AS-IS

Keeps calling `os.Getenv()` whenever there is an access to db

### TO-BE

Save error from `once.Do()` and refer to error on db access

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
