### PR TITLE
(OraklNode) Remove struct elements from Aggregator & Raft

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -90,27 +90,6 @@ func (a *Aggregator) SetLeaderJobTicker(d *time.Duration) error {
 	return nil
 }
 
-func (a *Aggregator) GetJobTimeout() *time.Duration {
-	return a.JobTimeout
-}
-
-func (a *Aggregator) GetJobTicker() *time.Ticker {
-	return a.JobTicker
-}
-
-func (a *Aggregator) SetJobTicker(d *time.Duration) error {
-	if d == nil {
-		a.JobTicker = nil
-		return nil
-	}
-	a.JobTicker = time.NewTicker(*d)
-	return nil
-}
-
-func (a *Aggregator) Job() error {
-	return nil
-}
-
 func (a *Aggregator) LeaderJob() error {
 	// leader continously sends roundId in regular basis and triggers all other nodes to run its job
 	a.RoundID++

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -39,15 +39,6 @@ func NewRaftNode(h host.Host, ps *pubsub.PubSub, topic *pubsub.Topic, sub *pubsu
 func (r *Raft) Run(ctx context.Context, node Node) {
 	go r.subscribe(ctx)
 	r.startElectionTimer()
-	var jobTicker <-chan time.Time
-
-	if node.GetJobTimeout() != nil {
-		err := node.SetJobTicker(node.GetJobTimeout())
-		if err != nil {
-			log.Error().Err(err).Msg("failed to set job ticker")
-		}
-		jobTicker = node.GetJobTicker().C
-	}
 
 	for {
 		select {
@@ -59,12 +50,6 @@ func (r *Raft) Run(ctx context.Context, node Node) {
 
 		case <-r.ElectionTimer.C:
 			r.startElection()
-
-		case <-jobTicker:
-			err := node.Job()
-			if err != nil {
-				log.Error().Err(err).Msg("failed to execute job")
-			}
 		}
 	}
 }

--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -73,10 +73,4 @@ type Node interface {
 	GetLeaderJobTicker() *time.Ticker
 	SetLeaderJobTicker(*time.Duration) error
 	LeaderJob() error
-
-	// define regular job run by every node
-	GetJobTimeout() *time.Duration
-	GetJobTicker() *time.Ticker
-	SetJobTicker(*time.Duration) error
-	Job() error
 }


### PR DESCRIPTION
# Description

- libp2p related variables lay inside Raft object, this pr will remove duplicate from aggregator structure.
- `job` inside Raft pkg seems better to be implemented through raft utilizing packages (aggregator & submitter), so related codes are removed

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
