### PR TITLE
(OraklNode) Add phase to get highest round

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -69,7 +69,7 @@ func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) e
 	log.Debug().Str("name", aggregator.Name).Msg("starting aggregator")
 	if aggregator.isRunning {
 		log.Debug().Str("name", aggregator.Name).Msg("aggregator already running")
-		return errors.New("aggregator already running")
+		return errors.New("aggregator alreadyß running")
 	}
 
 	nodeCtx, cancel := context.WithCancel(ctx)
@@ -77,7 +77,8 @@ func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) e
 	aggregator.nodeCancel = cancel
 	aggregator.isRunning = true
 
-	return aggregator.Run(ctx)
+	aggregator.Run(ctx)
+	return nil
 }
 
 func (a *App) startAggregatorById(ctx context.Context, id int64) error {

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -77,8 +77,7 @@ func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) e
 	aggregator.nodeCancel = cancel
 	aggregator.isRunning = true
 
-	aggregator.Run(ctx)
-	return nil
+	return aggregator.Run(ctx)
 }
 
 func (a *App) startAggregatorById(ctx context.Context, id int64) error {

--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -274,20 +274,6 @@ func (n *AggregatorNode) insertGlobalAggregate(ctx context.Context, name string,
 	return nil
 }
 
-func (n *AggregatorNode) loadLatestRoundId(ctx context.Context) error {
-	if os.Getenv("TEST") == "true" {
-		n.RoundID = 0
-		return nil
-	}
-	latestGlobalAggregate, err := db.QueryRow[globalAggregate](ctx, SelectLatestGlobalAggregateQuery, map[string]any{"name": n.Name})
-	if err != nil {
-		return err
-	}
-	n.RoundID = latestGlobalAggregate.Round
-	return nil
-
-}
-
 func (n *AggregatorNode) executeDeviation() error {
 	// signals for deviation job which triggers immediate aggregation and sends submission request to submitter
 	return nil

--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"sync"
 
@@ -100,8 +101,9 @@ func (n *AggregatorNode) HandleCustomMessage(message raft.Message) error {
 		return n.HandleRoundReplyMessage(message)
 	case TriggerAggregate:
 		return n.HandleTriggerAggregateMessage(message)
+	default:
+		return errors.New("unknown message type")
 	}
-	return nil
 }
 
 func (n *AggregatorNode) HandleRoundSyncMessage(msg raft.Message) error {

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -74,3 +74,18 @@ type PriceDataMessage struct {
 	RoundID   int64 `json:"roundID"`
 	PriceData int64 `json:"priceData"`
 }
+
+func GetLatestAggregateFromRdb(ctx context.Context, name string) (redisAggregate, error) {
+	key := "latestAggregate:" + name
+	var aggregate redisAggregate
+	data, err := db.Get(ctx, key)
+	if err != nil {
+		return aggregate, err
+	}
+
+	err = json.Unmarshal([]byte(data), &aggregate)
+	if err != nil {
+		return aggregate, err
+	}
+	return aggregate, nil
+}

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -10,12 +10,15 @@ import (
 )
 
 const (
-	RoundSync                        raft.MessageType = "roundSync"
-	PriceData                        raft.MessageType = "priceData"
-	SelectActiveAggregatorsQuery                      = `SELECT * FROM aggregators WHERE active = true`
-	SelectLatestLocalAggregateQuery                   = `SELECT * FROM local_aggregates WHERE name = @name ORDER BY timestamp DESC LIMIT 1`
-	InsertGlobalAggregateQuery                        = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
-	SelectLatestGlobalAggregateQuery                  = `SELECT * FROM global_aggregates WHERE name = @name ORDER BY round DESC LIMIT 1`
+	RoundSync        raft.MessageType = "roundSync"
+	RoundReply       raft.MessageType = "roundReply"
+	TriggerAggregate raft.MessageType = "triggerAggregate"
+	PriceData        raft.MessageType = "priceData"
+
+	SelectActiveAggregatorsQuery     = `SELECT * FROM aggregators WHERE active = true`
+	SelectLatestLocalAggregateQuery  = `SELECT * FROM local_aggregates WHERE name = @name ORDER BY timestamp DESC LIMIT 1`
+	InsertGlobalAggregateQuery       = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
+	SelectLatestGlobalAggregateQuery = `SELECT * FROM global_aggregates WHERE name = @name ORDER BY round DESC LIMIT 1`
 )
 
 type redisLocalAggregate struct {
@@ -59,6 +62,7 @@ type AggregatorNode struct {
 
 	LastLocalAggregateTime time.Time
 	RoundID                int64
+	RoundSyncReplies       int
 
 	nodeCtx    context.Context
 	nodeCancel context.CancelFunc
@@ -68,6 +72,14 @@ type AggregatorNode struct {
 type RoundSyncMessage struct {
 	LeaderID string `json:"leaderID"`
 	RoundID  int64  `json:"roundID"`
+}
+
+type RoundReplyMessage struct {
+	RoundId int64 `json:"roundId"`
+}
+
+type TriggerAggregateMessage struct {
+	RoundID int64 `json:"roundID"`
 }
 
 type PriceDataMessage struct {

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -86,18 +86,3 @@ type PriceDataMessage struct {
 	RoundID   int64 `json:"roundID"`
 	PriceData int64 `json:"priceData"`
 }
-
-func GetLatestAggregateFromRdb(ctx context.Context, name string) (redisAggregate, error) {
-	key := "latestAggregate:" + name
-	var aggregate redisAggregate
-	data, err := db.Get(ctx, key)
-	if err != nil {
-		return aggregate, err
-	}
-
-	err = json.Unmarshal([]byte(data), &aggregate)
-	if err != nil {
-		return aggregate, err
-	}
-	return aggregate, nil
-}

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"

--- a/node/pkg/libp2p/libp2p.go
+++ b/node/pkg/libp2p/libp2p.go
@@ -256,7 +256,7 @@ func DiscoverPeers(ctx context.Context, h host.Host, topicName string, bootstrap
 	anyConnected := false
 	var wg sync.WaitGroup
 	for !anyConnected {
-		log.Debug().Msg("Searching for peers...")
+		// log.Debug().Msg("Searching for peers...")
 		peerChan, err := routingDiscovery.FindPeers(ctx, topicName)
 		if err != nil {
 			return err

--- a/node/pkg/utils/utils.go
+++ b/node/pkg/utils/utils.go
@@ -11,6 +11,9 @@ func RandomNumberGenerator() int {
 }
 
 func FindMedian(nums []int) int {
+	if len(nums) == 0 {
+		return 0
+	}
 	sort.Ints(nums)
 	n := len(nums)
 	if n%2 == 0 {
@@ -25,6 +28,9 @@ func FindMedian(nums []int) int {
 }
 
 func FindMedianInt64(nums []int64) int64 {
+	if len(nums) == 0 {
+		return 0
+	}
 	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
 	n := len(nums)
 	if n%2 == 0 {


### PR DESCRIPTION
# Description

This is PR adding another syncing phase which has been discussed today(March 4) daily sync
I'm currently leaving it as a draft PR, as I'm thinking that it might be an overkill

It adds single phase during the process where roundId are synced into the most highest number among peers.
 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
