### PR TITLE
(OraklNode) Update raft stability

### DIFF
--- a/node/pkg/aggregator/node_test.go
+++ b/node/pkg/aggregator/node_test.go
@@ -39,45 +39,6 @@ func TestGetLeaderJobTimeout(t *testing.T) {
 	assert.Equal(t, node.GetLeaderJobTimeout(), node.LeaderJobTimeout)
 }
 
-func TestGetLeaderJobTicker(t *testing.T) {
-	ctx := context.Background()
-	cleanup, testItems, err := setup(ctx)
-	if err != nil {
-		t.Fatalf("error setting up test: %v", err)
-	}
-	defer cleanup()
-
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
-	if err != nil {
-		t.Fatal("error creating new node")
-	}
-
-	assert.Equal(t, node.GetLeaderJobTicker(), node.LeaderJobTicker)
-}
-
-func TestSetLeaderJobTicker(t *testing.T) {
-	ctx := context.Background()
-	cleanup, testItems, err := setup(ctx)
-	if err != nil {
-		t.Fatalf("error setting up test: %v", err)
-	}
-	defer cleanup()
-
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
-	if err != nil {
-		t.Fatal("error creating new node")
-	}
-
-	assert.Nil(t, node.LeaderJobTicker)
-	duration := 10 * time.Second
-	err = node.SetLeaderJobTicker(&duration)
-	if err != nil {
-		t.Fatal("error setting leader job ticker")
-	}
-
-	assert.NotNil(t, node.LeaderJobTicker)
-}
-
 func TestLeaderJob(t *testing.T) {
 	ctx := context.Background()
 	cleanup, testItems, err := setup(ctx)

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -162,7 +162,7 @@ func (r *Raft) handleRequestVote(msg Message) error {
 		return r.sendReplyVote(msg.SentFrom, false)
 	}
 
-	if r.GetRole() == Candidate && RequestVoteMessage.Term == currentTerm {
+	if r.GetRole() == Candidate && RequestVoteMessage.Term == currentTerm && msg.SentFrom != r.GetHostId() {
 		// Deny the vote and revert to follower
 		r.UpdateRole(Follower)
 		return r.sendReplyVote(msg.SentFrom, false)
@@ -173,7 +173,7 @@ func (r *Raft) handleRequestVote(msg Message) error {
 		voteGranted = true
 		r.UpdateVotedFor(msg.SentFrom)
 	}
-
+	log.Debug().Bool("vote granted", voteGranted).Msg("vote granted")
 	return r.sendReplyVote(msg.SentFrom, voteGranted)
 }
 

--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -70,7 +70,6 @@ type Node interface {
 
 	// define job run by leader
 	GetLeaderJobTimeout() *time.Duration
-	GetLeaderJobTicker() *time.Ticker
-	SetLeaderJobTicker(*time.Duration) error
+
 	LeaderJob() error
 }


### PR DESCRIPTION
# Description

Tried to fix issues found while running nodes locally. 

### Issues fixed

- When there are more than 3 nodes connected and leader disconnects, sometimes leader job ticks twice every 5 seconds
-> used timer instead of ticker
-> added condition on triggering `becomeLeader` to be called only if current role is candidate

- When there are more than 2 nodes connected and another node joins, sometimes leader resigns and joined node hangs as a candidate. and nodes keeps doing infinite voting
-> added condition to `handleHeartbeat` function to prevent unexpected resign of leader
-> added condition to `handleRequestVote` function to prevent unexpected grant denial

- When new node has joined or new leader has been elected, sometimes the roundID is synced to lower ones
-> sync roundID only if current role is not leader

- New joined node becomes leader unexpectedly
-> increase terms on roundId increase
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
