### PR TITLE
(GO-Delegator) Remove provider url

### DIFF
--- a/go-delegator/utils/utils.go
+++ b/go-delegator/utils/utils.go
@@ -68,7 +68,6 @@ func Setup(options ...string) (AppConfig, error) {
 	app.Use(func(c *fiber.Ctx) error {
 		c.Locals("feePayer", feePayer)
 		c.Locals("pgxConn", pgxPool)
-		c.Locals("providerUrl", os.Getenv("PROVIDER_URL"))
 		return c.Next()
 	})
 
@@ -156,15 +155,6 @@ func GetPgx(c *fiber.Ctx) (*pgxpool.Pool, error) {
 		return con, errors.New("failed to get pgxConn")
 	} else {
 		return con, nil
-	}
-}
-
-func GetProviderUrl(c *fiber.Ctx) (string, error) {
-	providerUrl, ok := c.Locals("providerUrl").(string)
-	if !ok {
-		return providerUrl, errors.New("failed to get providerUrl")
-	} else {
-		return providerUrl, nil
 	}
 }
 


### PR DESCRIPTION
# Description

Provider url has been declared but never been used in production code, only being used in test code. so removing it from application initialization

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
