### PR TITLE
(OraklNode) Setup host and pubsub from `New()`

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -15,15 +15,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func New(bus *bus.MessageBus) *App {
+func New(bus *bus.MessageBus, h host.Host, ps *pubsub.PubSub) *App {
 	return &App{
 		Aggregators: make(map[int64]*AggregatorNode, 0),
 		Bus:         bus,
+		Host:        h,
+		Pubsub:      ps,
 	}
 }
 
-func (a *App) Run(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
-	err := a.initialize(ctx, h, ps)
+func (a *App) Run(ctx context.Context) error {
+	err := a.setAggregators(ctx, a.Host, a.Pubsub)
 	if err != nil {
 		return err
 	}
@@ -31,13 +33,6 @@ func (a *App) Run(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
 	a.subscribe(ctx)
 
 	return a.startAllAggregators(ctx)
-}
-
-func (a *App) initialize(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
-	a.Host = h
-	a.Pubsub = ps
-
-	return a.setAggregators(ctx, h, ps)
 }
 
 func (a *App) setAggregators(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {

--- a/node/pkg/aggregator/aggregator_test.go
+++ b/node/pkg/aggregator/aggregator_test.go
@@ -20,7 +20,7 @@ func TestInit(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -51,7 +51,7 @@ func TestStartAggregator(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -69,7 +69,7 @@ func TestStartAggregatorById(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -87,7 +87,7 @@ func TestStopAggregator(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -110,7 +110,7 @@ func TestStopAggregatorById(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -133,7 +133,7 @@ func TestGetAggregatorByName(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -156,7 +156,7 @@ func TestActivateAggregatorByAdmin(t *testing.T) {
 
 	testItems.app.subscribe(ctx)
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -186,7 +186,7 @@ func TestDeactivateAggregatorByAdmin(t *testing.T) {
 
 	testItems.app.subscribe(ctx)
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -220,7 +220,7 @@ func TestStartAppByAdmin(t *testing.T) {
 
 	testItems.app.subscribe(ctx)
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -243,7 +243,7 @@ func TestStopAppByAdmin(t *testing.T) {
 
 	testItems.app.subscribe(ctx)
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}
@@ -272,7 +272,7 @@ func TestRefreshAppByAdmin(t *testing.T) {
 
 	testItems.app.subscribe(ctx)
 
-	err = testItems.app.initialize(ctx, *testItems.host, testItems.pubsub)
+	err = testItems.app.setAggregators(ctx, testItems.app.Host, testItems.app.Pubsub)
 	if err != nil {
 		t.Fatal("error initializing app")
 	}

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -13,8 +13,6 @@ import (
 	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/libp2p"
 	"github.com/gofiber/fiber/v2"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog"
 )
 
@@ -35,8 +33,6 @@ type TmpData struct {
 type TestItems struct {
 	app         *App
 	admin       *fiber.App
-	host        *host.Host
-	pubsub      *pubsub.PubSub
 	topicString string
 	messageBus  *bus.MessageBus
 	tmpData     *TmpData
@@ -57,20 +53,18 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	}
 	testItems.admin = admin
 
-	app := New(mb)
-	testItems.app = app
-
 	h, err := libp2p.MakeHost(10001)
 	if err != nil {
 		return nil, nil, err
 	}
-	testItems.host = &h
 
 	ps, err := libp2p.MakePubsub(ctx, h)
 	if err != nil {
 		return nil, nil, err
 	}
-	testItems.pubsub = ps
+
+	app := New(mb, h, ps)
+	testItems.app = app
 
 	testItems.topicString = "test-topic"
 

--- a/node/pkg/aggregator/node_test.go
+++ b/node/pkg/aggregator/node_test.go
@@ -17,7 +17,7 @@ func TestNewNode(t *testing.T) {
 	}
 	defer cleanup()
 
-	_, err = NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	_, err = NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -31,7 +31,7 @@ func TestGetLeaderJobTimeout(t *testing.T) {
 	}
 	defer cleanup()
 
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	node, err := NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -47,7 +47,7 @@ func TestLeaderJob(t *testing.T) {
 	}
 	defer cleanup()
 
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	node, err := NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -66,7 +66,7 @@ func TestGetLatestLocalAggregate(t *testing.T) {
 	}
 	defer cleanup()
 
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	node, err := NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 
 	if err != nil {
 		t.Fatal("error creating new node")
@@ -94,7 +94,7 @@ func TestGetLatestRoundId(t *testing.T) {
 	}
 	defer cleanup()
 
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	node, err := NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -117,7 +117,7 @@ func TestInsertGlobalAggregate(t *testing.T) {
 	}
 	defer cleanup()
 
-	node, err := NewNode(*testItems.host, testItems.pubsub, testItems.topicString)
+	node, err := NewNode(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}


### PR DESCRIPTION
# Description

`host` and `pubsub` was part of `App` type structure of aggregator, yet it was initialized on calling `Run`. it seems more natural to be initialized on `New`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the initialization process in the aggregator module to enhance integration with host and pubsub systems.
	- Simplified test setup by aligning test initialization with the updated aggregator logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->