### PR TITLE
(OraklNode) Improve message bus to take msg response

### DIFF
--- a/node/pkg/admin/aggregator/controller.go
+++ b/node/pkg/admin/aggregator/controller.go
@@ -19,32 +19,38 @@ type AggregatorInsertModel struct {
 }
 
 func start(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.AGGREGATOR, bus.START_AGGREGATOR_APP, nil)
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.START_AGGREGATOR_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to start aggregator: " + err.Error())
 	}
-	// delay for message to be processed
-	time.Sleep(10 * time.Millisecond)
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to start aggregator: " + resp.Args["error"].(string))
+	}
 	return c.SendString("aggregator started")
 }
 
 func stop(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.AGGREGATOR, bus.STOP_AGGREGATOR_APP, nil)
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.STOP_AGGREGATOR_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to stop aggregator: " + err.Error())
 	}
-	// delay for message to be processed
-	time.Sleep(10 * time.Millisecond)
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to stop aggregator: " + resp.Args["error"].(string))
+	}
 	return c.SendString("aggregator stopped")
 }
 
 func refresh(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.AGGREGATOR, bus.REFRESH_AGGREGATOR_APP, nil)
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.REFRESH_AGGREGATOR_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to refresh aggregator: " + err.Error())
 	}
-	// delay for message to be processed TODO: update message bus communication with a better solution
-	time.Sleep(100 * time.Millisecond)
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to refresh aggregator: " + resp.Args["error"].(string))
+	}
 	return c.SendString("aggregator refreshed")
 }
 

--- a/node/pkg/admin/aggregator/controller.go
+++ b/node/pkg/admin/aggregator/controller.go
@@ -1,8 +1,6 @@
 package aggregator
 
 import (
-	"time"
-
 	"bisonai.com/orakl/node/pkg/admin/utils"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
@@ -113,12 +111,16 @@ func activate(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute aggregator activate query: " + err.Error())
 	}
 
-	err = utils.SendMessage(c, bus.AGGREGATOR, bus.ACTIVATE_AGGREGATOR, map[string]any{"id": id})
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.ACTIVATE_AGGREGATOR, map[string]any{"id": id})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to send message to aggregator: " + err.Error())
 	}
 
-	time.Sleep(10 * time.Millisecond)
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to activate aggregator: " + resp.Args["error"].(string))
+	}
+
 	return c.JSON(result)
 }
 
@@ -129,11 +131,15 @@ func deactivate(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute aggregator deactivate query: " + err.Error())
 	}
 
-	err = utils.SendMessage(c, bus.AGGREGATOR, bus.DEACTIVATE_AGGREGATOR, map[string]any{"id": id})
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.DEACTIVATE_AGGREGATOR, map[string]any{"id": id})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to send message to aggregator: " + err.Error())
 	}
 
-	time.Sleep(10 * time.Millisecond)
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to deactivate aggregator: " + resp.Args["error"].(string))
+	}
+
 	return c.JSON(result)
 }

--- a/node/pkg/admin/fetcher/controller.go
+++ b/node/pkg/admin/fetcher/controller.go
@@ -1,7 +1,7 @@
 package fetcher
 
 import (
-	"time"
+	"strconv"
 
 	"bisonai.com/orakl/node/pkg/admin/utils"
 	"bisonai.com/orakl/node/pkg/bus"
@@ -9,31 +9,39 @@ import (
 )
 
 func start(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.FETCHER, bus.START_FETCHER_APP, nil)
+	msg, err := utils.SendMessage(c, bus.FETCHER, bus.START_FETCHER_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to start fetcher: " + err.Error())
 	}
-	// delay for message to be processed
-	time.Sleep(10 * time.Millisecond)
-	return c.SendString("fetcher started")
+	resp := <-msg.Response
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to start fetcher: " + resp.Args["error"].(string))
+	}
+	return c.SendString("fetcher started: " + strconv.FormatBool(resp.Success))
 }
 
 func stop(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.FETCHER, bus.STOP_FETCHER_APP, nil)
+	msg, err := utils.SendMessage(c, bus.FETCHER, bus.STOP_FETCHER_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to stop fetcher: " + err.Error())
 	}
-	// delay for message to be processed
-	time.Sleep(10 * time.Millisecond)
-	return c.SendString("fetcher stopped")
+	resp := <-msg.Response
+
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to stop fetcher: " + resp.Args["error"].(string))
+	}
+	return c.SendString("fetcher stopped: " + strconv.FormatBool(resp.Success))
 }
 
 func refresh(c *fiber.Ctx) error {
-	err := utils.SendMessage(c, bus.FETCHER, bus.REFRESH_FETCHER_APP, nil)
+	msg, err := utils.SendMessage(c, bus.FETCHER, bus.REFRESH_FETCHER_APP, nil)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to refresh fetcher: " + err.Error())
 	}
-	// delay for message to be processed
-	time.Sleep(10 * time.Millisecond)
-	return c.SendString("fetcher refreshed")
+	resp := <-msg.Response
+
+	if !resp.Success {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to refresh fetcher: " + resp.Args["error"].(string))
+	}
+	return c.SendString("fetcher refreshed: " + strconv.FormatBool(resp.Success))
 }

--- a/node/pkg/admin/tests/aggregator_test.go
+++ b/node/pkg/admin/tests/aggregator_test.go
@@ -23,21 +23,24 @@ func TestAggregatorStart(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.AGGREGATOR)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.START_AGGREGATOR_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/aggregator/start", nil)
 	if err != nil {
 		t.Fatalf("error starting aggregator: %v", err)
 	}
 
 	assert.Equal(t, string(result), "aggregator started")
-
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.START_AGGREGATOR_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
 }
 
 func TestAggregatorStop(t *testing.T) {
@@ -50,6 +53,18 @@ func TestAggregatorStop(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.AGGREGATOR)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.STOP_AGGREGATOR_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/aggregator/stop", nil)
 	if err != nil {
 		t.Fatalf("error stopping aggregator: %v", err)
@@ -57,14 +72,6 @@ func TestAggregatorStop(t *testing.T) {
 
 	assert.Equal(t, string(result), "aggregator stopped")
 
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.STOP_AGGREGATOR_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
 }
 
 func TestAggregatorRefresh(t *testing.T) {
@@ -77,6 +84,18 @@ func TestAggregatorRefresh(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.AGGREGATOR)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.REFRESH_AGGREGATOR_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/aggregator/refresh", nil)
 	if err != nil {
 		t.Fatalf("error refreshing aggregator: %v", err)
@@ -84,14 +103,6 @@ func TestAggregatorRefresh(t *testing.T) {
 
 	assert.Equal(t, string(result), "aggregator refreshed")
 
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.AGGREGATOR || msg.Content.Command != bus.REFRESH_AGGREGATOR_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
 }
 
 func TestAggregatorInsert(t *testing.T) {

--- a/node/pkg/admin/tests/fetcher_test.go
+++ b/node/pkg/admin/tests/fetcher_test.go
@@ -4,6 +4,7 @@ package tests
 import (
 	"context"
 	"testing"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
 	"github.com/stretchr/testify/assert"
@@ -19,21 +20,24 @@ func TestFetcherStart(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.FETCHER)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.START_FETCHER_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/fetcher/start", nil)
 	if err != nil {
 		t.Fatalf("error starting fetcher: %v", err)
 	}
 
-	assert.Equal(t, string(result), "fetcher started")
-
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.START_FETCHER_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
+	assert.Equal(t, string(result), "fetcher started: true")
 }
 
 func TestFetcherStop(t *testing.T) {
@@ -46,21 +50,24 @@ func TestFetcherStop(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.FETCHER)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.STOP_FETCHER_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/fetcher/stop", nil)
 	if err != nil {
 		t.Fatalf("error stopping fetcher: %v", err)
 	}
 
-	assert.Equal(t, string(result), "fetcher stopped")
-
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.STOP_FETCHER_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
+	assert.Equal(t, string(result), "fetcher stopped: true")
 }
 
 func TestFetcherRefresh(t *testing.T) {
@@ -73,19 +80,22 @@ func TestFetcherRefresh(t *testing.T) {
 
 	channel := testItems.mb.Subscribe(bus.FETCHER)
 
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.REFRESH_FETCHER_APP {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
 	result, err := RawPostRequest(testItems.app, "/api/v1/fetcher/refresh", nil)
 	if err != nil {
 		t.Fatalf("error refreshing fetcher: %v", err)
 	}
 
-	assert.Equal(t, string(result), "fetcher refreshed")
-
-	select {
-	case msg := <-channel:
-		if msg.From != bus.ADMIN || msg.To != bus.FETCHER || msg.Content.Command != bus.REFRESH_FETCHER_APP {
-			t.Fatalf("unexpected message: %v", msg)
-		}
-	default:
-		t.Fatalf("no message received on channel")
-	}
+	assert.Equal(t, string(result), "fetcher refreshed: true")
 }

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -79,7 +79,7 @@ func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) e
 	aggregator.nodeCancel = cancel
 	aggregator.isRunning = true
 
-	aggregator.Run(ctx)
+	go aggregator.Run(ctx)
 	return nil
 }
 
@@ -149,7 +149,7 @@ func (a *App) subscribe(ctx context.Context) {
 					Str("from", msg.From).
 					Str("to", msg.To).
 					Str("command", msg.Content.Command).
-					Msg("aggregator received message")
+					Msg("fetcher received message")
 				go a.handleMessage(ctx, msg)
 			case <-ctx.Done():
 				log.Debug().Msg("stopping aggregator subscription goroutine")
@@ -182,12 +182,14 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 	case bus.ACTIVATE_AGGREGATOR:
 		if msg.From != bus.ADMIN {
 			log.Debug().Msg("aggregator received message from non-admin")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": "non-admin"}}
 			return
 		}
 		log.Debug().Msg("activate aggregator msg received")
 		aggregatorId, err := bus.ParseInt64MsgParam(msg, "id")
 		if err != nil {
 			log.Error().Err(err).Msg("failed to parse aggregatorId")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
 			return
 		}
 
@@ -195,16 +197,22 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		err = a.startAggregatorById(ctx, aggregatorId)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start aggregator")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		log.Debug().Msg("sending success response for activate aggregator")
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.DEACTIVATE_AGGREGATOR:
 		if msg.From != bus.ADMIN {
 			log.Debug().Msg("aggregator received message from non-admin")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": "non-admin"}}
 			return
 		}
 		log.Debug().Msg("deactivate aggregator msg received")
 		aggregatorId, err := bus.ParseInt64MsgParam(msg, "id")
 		if err != nil {
 			log.Error().Err(err).Msg("failed to parse aggregatorId")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
 			return
 		}
 
@@ -212,7 +220,10 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		err = a.stopAggregatorById(ctx, aggregatorId)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop aggregator")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.REFRESH_AGGREGATOR_APP:
 		if msg.From != bus.ADMIN {
 			log.Debug().Msg("aggregator received message from non-admin")

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -233,35 +233,50 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		err := a.stopAllAggregators(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop all aggregators")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
 		err = a.setAggregators(ctx, a.Host, a.Pubsub)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to set aggregators")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
 		err = a.startAllAggregators(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start all aggregators")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.STOP_AGGREGATOR_APP:
 		if msg.From != bus.ADMIN {
 			log.Debug().Msg("aggregator received message from non-admin")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": "non-admin"}}
 			return
 		}
 		log.Debug().Msg("stop aggregator msg received")
 		err := a.stopAllAggregators(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop all aggregators")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.START_AGGREGATOR_APP:
 		if msg.From != bus.ADMIN {
 			log.Debug().Msg("aggregator received message from non-admin")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": "non-admin"}}
 			return
 		}
 		log.Debug().Msg("start aggregator msg received")
 		err := a.startAllAggregators(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start all aggregators")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.DEVIATION:
 		if msg.From != bus.FETCHER {
 			log.Debug().Msg("aggregator received deviation message from non-fetcher")

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -156,7 +155,7 @@ func aggregatorCleanup(ctx context.Context, admin *fiber.App, testItems *TestIte
 }
 
 func TestMain(m *testing.M) {
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	// zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	code := m.Run()
 	db.ClosePool()
 	db.CloseRedis()

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -155,7 +156,7 @@ func aggregatorCleanup(ctx context.Context, admin *fiber.App, testItems *TestIte
 }
 
 func TestMain(m *testing.M) {
-	// zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	code := m.Run()
 	db.ClosePool()
 	db.CloseRedis()

--- a/node/pkg/bus/bus.go
+++ b/node/pkg/bus/bus.go
@@ -8,13 +8,19 @@ import (
 // message bus will be passed as parameter to modules that need to communicate with each other
 
 type Message struct {
-	From    string
-	To      string
-	Content MessageContent
+	From     string
+	To       string
+	Content  MessageContent
+	Response chan MessageResponse
 }
 
 type MessageContent struct {
 	Command string
+	Args    map[string]any
+}
+
+type MessageResponse struct {
+	Success bool
 	Args    map[string]any
 }
 

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -79,6 +79,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		adapterId, err := bus.ParseInt64MsgParam(msg, "id")
 		if err != nil {
 			log.Error().Err(err).Msg("failed to parse adapterId")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
 			return
 		}
 
@@ -86,12 +87,16 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		err = a.startFetcherById(ctx, adapterId)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start fetcher")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.DEACTIVATE_FETCHER:
 		log.Debug().Msg("deactivate fetcher msg received")
 		adapterId, err := bus.ParseInt64MsgParam(msg, "id")
 		if err != nil {
 			log.Error().Err(err).Msg("failed to parse adapterId")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
 			return
 		}
 
@@ -99,36 +104,50 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		err = a.stopFetcherById(ctx, adapterId)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop fetcher")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.STOP_FETCHER_APP:
 		log.Debug().Msg("stopping all fetchers")
 		err := a.stopAllFetchers(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop all fetchers")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
-
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.START_FETCHER_APP:
 		log.Debug().Msg("starting all fetchers")
 		err := a.startAllFetchers(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start all fetchers")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
-
+		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.REFRESH_FETCHER_APP:
 		err := a.stopAllFetchers(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to stop all fetchers")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
 		err = a.initialize(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to initialize fetchers")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
 		err = a.startAllFetchers(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to start all fetchers")
+			msg.Response <- bus.MessageResponse{Success: false, Args: map[string]any{"error": err.Error()}}
+			return
 		}
 
 		log.Debug().Msg("refreshing fetcher")
+		msg.Response <- bus.MessageResponse{Success: true}
 	}
 }
 


### PR DESCRIPTION
# Description

Updates message bus package to use msg response channel. After sending message, sender can access response through `Response` channel element of message struct

it includes related implementation updates and test codes updates

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
