### PR TITLE
(OraklNode) Remove unnecessary duplicate declaration

### DIFF
--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -21,15 +21,10 @@ func NewNode(h host.Host, ps *pubsub.PubSub, topicString string) (*AggregatorNod
 		return nil, err
 	}
 
-	sub, err := topic.Subscribe()
-	if err != nil {
-		return nil, err
-	}
-
 	leaderTimeout := 5 * time.Second
 
 	aggregator := AggregatorNode{
-		Raft: raft.NewRaftNode(h, ps, topic, sub, 100), // consider updating after testing
+		Raft: raft.NewRaftNode(h, ps, topic, 100), // consider updating after testing
 
 		LeaderJobTimeout: &leaderTimeout,
 

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -16,12 +16,11 @@ import (
 
 const HEARTBEAT_TIMEOUT = 100 * time.Millisecond
 
-func NewRaftNode(h host.Host, ps *pubsub.PubSub, topic *pubsub.Topic, sub *pubsub.Subscription, messageBuffer int) *Raft {
+func NewRaftNode(h host.Host, ps *pubsub.PubSub, topic *pubsub.Topic, messageBuffer int) *Raft {
 	r := &Raft{
 		Host:  h,
 		Ps:    ps,
 		Topic: topic,
-		Sub:   sub,
 
 		Role:             "follower",
 		VotedFor:         "",

--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -49,7 +49,6 @@ type Raft struct {
 	Host  host.Host
 	Ps    *pubsub.PubSub
 	Topic *pubsub.Topic
-	Sub   *pubsub.Subscription
 
 	Role          RoleType
 	VotedFor      string


### PR DESCRIPTION
# Description

`Sub` declared from aggregator node, yet not used inside raft package. rather redeclared inside raft package and not being referenced, therefore removing structure element

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the node initialization process by removing the subscription parameter from the `NewNode` and `NewRaftNode` functions.
	- Updated the `Raft` struct by removing the `Sub` field to reflect changes in subscription handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->