### PR TITLE
Implement reusable workflow for helm chart pr generation

### DIFF
--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -95,3 +95,14 @@ jobs:
         run: |
           docker tag orakl-api ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+
+  create-helmchart-pr:
+    needs: [prepare, build]
+    uses: ./.github/workflows/create-helmchart-pr.yaml
+    with:
+      project-name: "api"
+      version: ${{ needs.prepare.outputs.version }}
+      tag_date: ${{ needs.prepare.outputs.tag_date }}
+      tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -70,3 +70,14 @@ jobs:
         run: |
           docker tag orakl-cli ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+
+  create-helmchart-pr:
+    needs: [prepare, build]
+    uses: ./.github/workflows/create-helmchart-pr.yaml
+    with:
+      project-name: "cli"
+      version: ${{ needs.prepare.outputs.version }}
+      tag_date: ${{ needs.prepare.outputs.tag_date }}
+      tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -70,3 +70,14 @@ jobs:
         run: |
           docker tag orakl-core ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+
+  create-helmchart-pr:
+    needs: [prepare, build]
+    uses: ./.github/workflows/create-helmchart-pr.yaml
+    with:
+      project-name: "aggregator"
+      version: ${{ needs.prepare.outputs.version }}
+      tag_date: ${{ needs.prepare.outputs.tag_date }}
+      tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/create-helmchart-pr.yaml
+++ b/.github/workflows/create-helmchart-pr.yaml
@@ -1,0 +1,64 @@
+name: "create-helmchart-pr"
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      tag_date:
+        required: true
+        type: string
+      tag_git_hash:
+        required: true
+        type: string
+
+    secrets:
+      PAT:
+        required: true
+
+jobs:
+  create-helmchart-pr:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: ["baobab", "cypress"]
+        include:
+          - environment: "baobab"
+            base: "gcp-baobab-prod"
+          - environment: "cypress"
+            base: "gcp-cypress-prod"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.base }}
+          repository: "Bisonai/orakl-helm-charts"
+          token: ${{ secrets.PAT }}
+
+      - name: Install YQ
+        uses: dcarbone/install-yq-action@v1.1.1
+
+      - name: Create commits
+        run: |
+          set -e
+          git config --global user.email "orakl-bot@users.noreply.github.com"
+          git config --global user.name "orakl-bot"
+
+          yq eval '.global.image.tag = "v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"' -i ./${{ inputs.project-name }}/values.yaml
+          yq eval '.appVersion = "${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"' -i ./${{ inputs.project-name }}/Chart.yaml
+          git add .
+          git commit -m "feat: deploy v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"
+
+      - name: create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PAT }}
+          commit-message: "feat: deploy v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"
+          title: "deploy ${{ matrix.environment }}-${{ inputs.project-name }}-v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"
+          body: "${{ matrix.environment }}-${{ inputs.project-name }}-v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"
+          base: "${{ matrix.base }}"
+          branch: "deploy/${{ matrix.environment }}-${{ inputs.project-name }}-v${{ inputs.version }}.${{ inputs.tag_date }}.${{ inputs.tag_git_hash }}"

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -70,3 +70,14 @@ jobs:
         run: |
           docker tag orakl-fetcher ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+
+  create-helmchart-pr:
+    needs: [prepare, build]
+    uses: ./.github/workflows/create-helmchart-pr.yaml
+    with:
+      project-name: "fetcher"
+      version: ${{ needs.prepare.outputs.version }}
+      tag_date: ${{ needs.prepare.outputs.tag_date }}
+      tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/godelegator.image+upload.yaml
+++ b/.github/workflows/godelegator.image+upload.yaml
@@ -94,47 +94,12 @@ jobs:
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 
   create-helmchart-pr:
-    name: create-pr-helmchart
-    runs-on: ubuntu-latest
     needs: [prepare, build]
-
-    strategy:
-      matrix:
-        environment: ["baobab", "cypress"]
-        include:
-          - environment: "baobab"
-            base: "gcp-baobab-prod"
-          - environment: "cypress"
-            base: "gcp-cypress-prod"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.base }}
-          repository: "Bisonai/orakl-helm-charts"
-          token: ${{ secrets.PAT }} # Personal Access Token with repo scope, should be carefully handled
-
-      - name: Install YQ
-        uses: dcarbone/install-yq-action@v1.1.1
-
-      - name: Create commits
-        run: |
-          set -e
-          git config --global user.email "orakl-bot@users.noreply.github.com"
-          git config --global user.name "orakl-bot"
-
-          yq eval '.global.image.tag = "v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"' -i ./godelegator/values.yaml
-          yq eval '.appVersion = "${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"' -i ./godelegator/Chart.yaml
-          git add .
-          git commit -m "feat: deploy v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"
-
-      - name: create PR
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.PAT }}
-          commit-message: "feat: deploy v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"
-          title: "deploy ${{ matrix.environment }}-delegator-v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"
-          body: "${{ matrix.environment }}-delegator-v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"
-          base: "${{ matrix.base }}"
-          branch: "deploy/${{ matrix.environment }}-delegator-v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}"
+    uses: ./.github/workflows/create-helmchart-pr.yaml
+    with:
+      project-name: "godelegator"
+      version: ${{ needs.prepare.outputs.version }}
+      tag_date: ${{ needs.prepare.outputs.tag_date }}
+      tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
+    secrets:
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
# Description

separates `create-helmchart-pr` as reusable workflow to reference from multiple image build workflow

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a step to automatically create Helm chart pull requests in various project workflows, enhancing deployment processes.

- **Refactor**
	- Simplified the Helm chart pull request creation process in the workflow for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->