### PR TITLE
(OraklNode) Reporter

### DIFF
--- a/.github/workflows/node.test.yaml
+++ b/.github/workflows/node.test.yaml
@@ -94,3 +94,4 @@ jobs:
           PROVIDER_URL: "https://api.baobab.klaytn.net:8651"
           REPORTER_PK: ${{ secrets.TEST_DELEGATOR_REPORTER_PK}}
           TEST_FEE_PAYER_PK: ${{ secrets.DELEGATOR_FEEPAYER_PK}}
+          SUBMISSION_PROXY_CONTRACT: "0x8fb610c0Cc27Ca7726fad4c8696d09ca0E8eAee1"

--- a/node/.env.example
+++ b/node/.env.example
@@ -10,5 +10,7 @@ PROVIDER_URL=
 #not required if wallets table is not empty
 REPORTER_PK=
 
+SUBMISSION_PROXY_CONTRACT=
+
 #required to run klaytn_helper test
 #TEST_FEE_PAYER_PK=

--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 
 	"time"
@@ -71,8 +72,9 @@ func (n *AggregatorNode) HandleCustomMessage(message raft.Message) error {
 		return n.HandleRoundSyncMessage(message)
 	case PriceData:
 		return n.HandlePriceDataMessage(message)
+	default:
+		return errors.New("unknown message type")
 	}
-	return nil
 }
 
 func (n *AggregatorNode) HandleRoundSyncMessage(msg raft.Message) error {

--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -15,16 +15,16 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const LEADER_TIMEOUT = 5 * time.Second
+
 func NewNode(h host.Host, ps *pubsub.PubSub, topicString string) (*AggregatorNode, error) {
 	topic, err := ps.Join(topicString)
 	if err != nil {
 		return nil, err
 	}
 
-	leaderTimeout := 5 * time.Second
-
 	aggregator := AggregatorNode{
-		Raft:            raft.NewRaftNode(h, ps, topic, 100, leaderTimeout),
+		Raft:            raft.NewRaftNode(h, ps, topic, 100, LEADER_TIMEOUT),
 		CollectedPrices: map[int64][]int64{},
 		AggregatorMutex: sync.Mutex{},
 	}

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -1,0 +1,101 @@
+//nolint:all
+package reporter
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/admin/utils"
+	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/db"
+	"bisonai.com/orakl/node/pkg/libp2p"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
+
+type TestItems struct {
+	reporter   *Reporter
+	admin      *fiber.App
+	messageBus *bus.MessageBus
+	tmpData    *TmpData
+}
+
+type TmpData struct {
+	globalAggregate GlobalAggregate
+}
+
+func insertSampleData(ctx context.Context) (*TmpData, error) {
+	var tmpData = new(TmpData)
+	tmpGlobalAggregate, err := db.QueryRow[GlobalAggregate](ctx, InsertGlobalAggregateQuery, map[string]any{"name": "test-aggregate", "value": int64(15), "round": int64(1)})
+	if err != nil {
+		return nil, err
+	}
+	tmpData.globalAggregate = tmpGlobalAggregate
+	return tmpData, nil
+}
+
+func setup(ctx context.Context) (func() error, *TestItems, error) {
+	var testItems = new(TestItems)
+
+	mb := bus.New(10)
+	testItems.messageBus = mb
+
+	admin, err := utils.Setup(utils.SetupInfo{
+		Version: "",
+		Bus:     mb,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	testItems.admin = admin
+
+	h, ps, err := libp2p.Setup(ctx, "", 10001)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reporter, err := New(ctx, *h, ps)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	testItems.reporter = reporter
+
+	tmpData, err := insertSampleData(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	testItems.tmpData = tmpData
+
+	_ = admin.Group("/api/v1")
+	// reporter.Routes(v1)
+
+	return reporterCleanup(ctx, admin, testItems), testItems, nil
+
+}
+
+func reporterCleanup(ctx context.Context, admin *fiber.App, testItems *TestItems) func() error {
+	return func() error {
+		err := db.QueryWithoutResult(ctx, "DELETE FROM global_aggregates;", nil)
+		if err != nil {
+			return err
+		}
+		err = admin.Shutdown()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	code := m.Run()
+	db.ClosePool()
+	db.CloseRedis()
+	os.Exit(code)
+}

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -72,6 +72,7 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	testItems.tmpData = tmpData
 
 	_ = admin.Group("/api/v1")
+	// TODO: add reporter admin test
 	// reporter.Routes(v1)
 
 	return reporterCleanup(ctx, admin, testItems), testItems, nil

--- a/node/pkg/reporter/node.go
+++ b/node/pkg/reporter/node.go
@@ -1,0 +1,160 @@
+package reporter
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/db"
+	"bisonai.com/orakl/node/pkg/raft"
+	"bisonai.com/orakl/node/pkg/utils"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	TOPIC_STRING    = "orakl-offchain-aggregation-reporter"
+	LEADER_TIMEOUT  = 5 * time.Second
+	MAX_RETRY       = 3
+	FUNCTION_STRING = "batchSubmit(string[] memory _pairs, int256[] memory _prices)"
+
+	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
+		SELECT ga.name, ga.value, ga.round, ga.timestamp
+		FROM global_aggregates ga
+		JOIN (
+			SELECT name, MAX(round) as max_round
+			FROM global_aggregates
+			GROUP BY name
+		) subq ON ga.name = subq.name AND ga.round = subq.max_round;`
+)
+
+type Reporter struct {
+	Raft     *raft.Raft
+	TxHelper *utils.TxHelper
+
+	lastSubmissions map[string]int64
+	contractAddress string
+}
+
+type GlobalAggregate struct {
+	Name      string    `db:"name"`
+	Value     int64     `db:"value"`
+	Round     int64     `db:"round"`
+	Timestamp time.Time `db:"timestamp"`
+}
+
+func New(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*Reporter, error) {
+	encryptedTopic, err := utils.EncryptText(TOPIC_STRING)
+	if err != nil {
+		return nil, err
+	}
+
+	topic, err := ps.Join(encryptedTopic)
+	if err != nil {
+		return nil, err
+	}
+
+	raft := raft.NewRaftNode(h, ps, topic, 100, LEADER_TIMEOUT)
+	txHelper, err := utils.NewTxHelper(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reporter := &Reporter{
+		Raft:            raft,
+		TxHelper:        txHelper,
+		contractAddress: os.Getenv("SUBMISSION_PROXY_CONTRACT"),
+	}
+	reporter.Raft.LeaderJob = reporter.LeaderJob
+	reporter.Raft.HandleCustomMessage = reporter.HandleCustomMessage
+
+	return reporter, nil
+}
+
+func (r *Reporter) Run(ctx context.Context) {
+	r.Raft.Run(ctx)
+}
+
+func (r *Reporter) LeaderJob() error {
+	aggregates, err := r.GetLatestGlobalAggregates(context.Background())
+	if err != nil {
+		return err
+	}
+
+	validAggregates := r.filterInvalidAggregates(aggregates)
+	if len(validAggregates) == 0 {
+		return nil
+	}
+
+	if err := r.Report(context.Background(), validAggregates); err != nil {
+		r.Raft.StopHeartbeatTicker()
+		r.Raft.UpdateRole(raft.Follower)
+		return err
+	}
+
+	for _, agg := range validAggregates {
+		r.lastSubmissions[agg.Name] = agg.Round
+	}
+	return nil
+}
+
+func (r *Reporter) HandleCustomMessage(msg raft.Message) error {
+	return errors.New("unknown message type")
+}
+
+func (r *Reporter) GetLatestGlobalAggregates(ctx context.Context) ([]GlobalAggregate, error) {
+	return db.QueryRows[GlobalAggregate](ctx, GET_LATEST_GLOBAL_AGGREGATES_QUERY, nil)
+}
+
+func (r *Reporter) Report(ctx context.Context, aggregates []GlobalAggregate) error {
+	for i := 0; i < MAX_RETRY; i++ {
+		log.Debug().Int("retry", i).Msg("reporting global aggregates")
+		if err := r.report(ctx, aggregates); err == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return errors.New("failed to report global aggregates")
+}
+
+func (r *Reporter) filterInvalidAggregates(aggregates []GlobalAggregate) []GlobalAggregate {
+	validAggregates := make([]GlobalAggregate, 0, len(aggregates))
+	for _, agg := range aggregates {
+		if r.isAggValid(agg) {
+			validAggregates = append(validAggregates, agg)
+		}
+	}
+	return validAggregates
+}
+
+func (r *Reporter) isAggValid(aggregate GlobalAggregate) bool {
+	lastSubmission, ok := r.lastSubmissions[aggregate.Name]
+	if !ok {
+		return true
+	}
+	return aggregate.Round > lastSubmission
+}
+
+func (r *Reporter) report(ctx context.Context, aggregates []GlobalAggregate) error {
+	pairs, values := r.makeContractArgs(aggregates)
+	rawTx, err := r.TxHelper.MakeDirectTx(ctx, r.contractAddress, FUNCTION_STRING, pairs, values)
+	if err != nil {
+		log.Error().Err(err).Msg("MakeDirectTx")
+		return err
+	}
+	return r.TxHelper.SubmitRawTx(ctx, rawTx)
+}
+
+func (r *Reporter) makeContractArgs(aggregates []GlobalAggregate) ([]string, []*big.Int) {
+	args := make([]string, len(aggregates))
+	values := make([]*big.Int, len(aggregates))
+	for i, agg := range aggregates {
+		args[i] = agg.Name
+		values[i] = big.NewInt(agg.Value)
+	}
+	return args, values
+}

--- a/node/pkg/reporter/node.go
+++ b/node/pkg/reporter/node.go
@@ -191,7 +191,7 @@ func (r *Reporter) makeContractArgs(aggregates []GlobalAggregate) ([]string, []*
 		values[i] = big.NewInt(agg.Value)
 	}
 
-	if len(pairs) == 0 || len(values) < 0 {
+	if len(pairs) == 0 || len(values) == 0 {
 		return nil, nil, errors.New("no valid aggregates")
 	}
 

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -1,0 +1,140 @@
+//nolint:all
+package reporter
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/raft"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	_, err = New(ctx, testItems.reporter.Raft.Host, testItems.reporter.Raft.Ps)
+	if err != nil {
+		t.Fatal("error creating new reporter")
+	}
+}
+
+func TestLeaderJob(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	err = testItems.reporter.leaderJob()
+	if err != nil {
+		t.Fatal("error running leader job")
+	}
+}
+
+func TestResignLeader(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+	time.Sleep(1 * time.Second)
+
+	testItems.reporter.resignLeader()
+	assert.Equal(t, testItems.reporter.Raft.GetRole(), raft.Follower)
+}
+
+func TestHandleCustomMessage(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	err = testItems.reporter.handleCustomMessage(raft.Message{})
+	assert.Equal(t, err.Error(), "unknown message type")
+}
+
+func TestGetLatestGlobalAggregates(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	result, err := testItems.reporter.getLatestGlobalAggregates(ctx)
+	if err != nil {
+		t.Fatal("error getting latest global aggregates")
+	}
+	assert.Equal(t, result[0], testItems.tmpData.globalAggregate)
+}
+
+func TestFilterInvalidAggregates(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	aggregates := []GlobalAggregate{{
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
+	}}
+	result := testItems.reporter.filterInvalidAggregates(aggregates)
+	assert.Equal(t, result, aggregates)
+
+	testItems.reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	result = testItems.reporter.filterInvalidAggregates(aggregates)
+	assert.Equal(t, result, []GlobalAggregate{})
+}
+
+func TestIsAggValid(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	agg := GlobalAggregate{
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
+	}
+	result := testItems.reporter.isAggValid(agg)
+	assert.Equal(t, result, true)
+
+	testItems.reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	result = testItems.reporter.isAggValid(agg)
+	assert.Equal(t, result, false)
+}
+
+func TestMakeContractArgs(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	agg := GlobalAggregate{
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
+	}
+	pairs, values := testItems.reporter.makeContractArgs([]GlobalAggregate{agg})
+	assert.Equal(t, pairs[0], "test-aggregate")
+	assert.Equal(t, values[0], big.NewInt(15))
+}

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -132,7 +132,11 @@ func TestMakeContractArgs(t *testing.T) {
 		Value: 15,
 		Round: 1,
 	}
-	pairs, values := testItems.reporter.makeContractArgs([]GlobalAggregate{agg})
+	pairs, values, err := testItems.reporter.makeContractArgs([]GlobalAggregate{agg})
+	if err != nil {
+		t.Fatal("error making contract args")
+	}
+
 	assert.Equal(t, pairs[0], "test-aggregate")
 	assert.Equal(t, values[0], big.NewInt(15))
 }

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"bisonai.com/orakl/node/pkg/raft"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,6 @@ func TestResignLeader(t *testing.T) {
 		t.Fatalf("error setting up test: %v", err)
 	}
 	defer cleanup()
-	time.Sleep(1 * time.Second)
 
 	testItems.reporter.resignLeader()
 	assert.Equal(t, testItems.reporter.Raft.GetRole(), raft.Follower)

--- a/node/pkg/utils/klaytn_helper.go
+++ b/node/pkg/utils/klaytn_helper.go
@@ -239,8 +239,6 @@ func makeFeeDelegatedTx(ctx context.Context, client *client.Client, contractAddr
 		return nil, err
 	}
 
-	fmt.Println(len(args))
-
 	functionName := strings.Split(functionString, "(")[0]
 	packed, err := abi.Pack(functionName, args...)
 	if err != nil {

--- a/node/pkg/utils/klaytn_helper.go
+++ b/node/pkg/utils/klaytn_helper.go
@@ -13,6 +13,7 @@ import (
 	"bisonai.com/orakl/node/pkg/db"
 
 	"github.com/klaytn/klaytn/accounts/abi"
+	"github.com/klaytn/klaytn/accounts/abi/bind"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/client"
 	"github.com/klaytn/klaytn/common"
@@ -318,7 +319,11 @@ func submitRawTx(ctx context.Context, client *client.Client, tx *types.Transacti
 		return err
 	}
 
-	log.Debug().Str("txHash", tx.Hash().Hex()).Msg("submitted")
+	receipt, err := bind.WaitMined(ctx, client, tx)
+	if err != nil {
+		return err
+	}
+	log.Debug().Any("receipt", receipt).Msg("mined")
 	return nil
 }
 

--- a/node/pkg/utils/tests/crypt_test.go
+++ b/node/pkg/utils/tests/crypt_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"bisonai.com/orakl/node/pkg/utils"
-	"github.com/go-playground/assert/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncryptDecrypt(t *testing.T) {

--- a/node/pkg/utils/tests/klaytn_helper_test.go
+++ b/node/pkg/utils/tests/klaytn_helper_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"bisonai.com/orakl/node/pkg/utils"
-	"github.com/go-playground/assert/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTxHelper(t *testing.T) {

--- a/node/taskfiles/taskfile.local.yml
+++ b/node/taskfiles/taskfile.local.yml
@@ -46,6 +46,10 @@ tasks:
   test-libp2p:
     cmds:
       - go test ./pkg/libp2p -v
+  test-reporter:
+    dotenv: [".env"]
+    cmds:
+      - go test ./pkg/reporter -v
   test:
     cmds:
       - task: test-db
@@ -55,3 +59,4 @@ tasks:
       - task: test-fetcher
       - task: test-utils
       - task: test-aggregator
+      - task: test-reporter


### PR DESCRIPTION
# Description

### Reporter

Single raft node which leader submits global aggregates using batch submission every 5 seconds

- Environment variable added

`SUBMISSION_PROXY_CONTRACT`: contract address which contains `batchSubmit(string[] memory _pairs, int256[] memory _prices)` function interface

- Includes test codes
- Loads most recent global aggregates and filters out if `round` didn't increase from 5 seconds ago before submitting to the contract


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `Reporter` component for reporting global aggregates to a contract, enhancing the application's reporting capabilities.
- **Refactor**
	- Updated `leaderTimeout` to be globally defined, improving configuration management.
- **Tests**
	- Added comprehensive test setups and functions for the new `Reporter` module and other utilities, ensuring robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->