### PR TITLE
(OraklNode) Add reporter control, minor updates

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -74,7 +74,7 @@ func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) e
 	aggregator.nodeCancel = cancel
 	aggregator.isRunning = true
 
-	go aggregator.Run(ctx)
+	go aggregator.Run(nodeCtx)
 	return nil
 }
 
@@ -144,7 +144,7 @@ func (a *App) subscribe(ctx context.Context) {
 					Str("from", msg.From).
 					Str("to", msg.To).
 					Str("command", msg.Content.Command).
-					Msg("fetcher received message")
+					Msg("fetcher received bus message")
 				go a.handleMessage(ctx, msg)
 			case <-ctx.Done():
 				log.Debug().Msg("stopping aggregator subscription goroutine")

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -63,6 +63,10 @@ func (a *App) getAggregators(ctx context.Context) ([]Aggregator, error) {
 }
 
 func (a *App) startAggregator(ctx context.Context, aggregator *AggregatorNode) error {
+	if aggregator == nil {
+		return errors.New("aggregator not found")
+	}
+
 	log.Debug().Str("name", aggregator.Name).Msg("starting aggregator")
 	if aggregator.isRunning {
 		log.Debug().Str("name", aggregator.Name).Msg("aggregator already running")

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -18,11 +18,11 @@ import (
 const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
 
 type TestItems struct {
-	app        *App
-	reporter   *ReporterNode
-	admin      *fiber.App
-	messageBus *bus.MessageBus
-	tmpData    *TmpData
+	app          *App
+	reporterNode *ReporterNode
+	admin        *fiber.App
+	messageBus   *bus.MessageBus
+	tmpData      *TmpData
 }
 
 type TmpData struct {
@@ -68,7 +68,7 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 		return nil, nil, err
 	}
 
-	testItems.reporter = reporterNode
+	testItems.reporterNode = reporterNode
 
 	tmpData, err := insertSampleData(ctx)
 	if err != nil {

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"bisonai.com/orakl/node/pkg/admin/reporter"
 	"bisonai.com/orakl/node/pkg/admin/utils"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
@@ -17,7 +18,8 @@ import (
 const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
 
 type TestItems struct {
-	reporter   *Reporter
+	app        *App
+	reporter   *ReporterNode
 	admin      *fiber.App
 	messageBus *bus.MessageBus
 	tmpData    *TmpData
@@ -58,12 +60,15 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 		return nil, nil, err
 	}
 
-	reporter, err := New(ctx, *h, ps)
+	app := New(mb, *h, ps)
+	testItems.app = app
+
+	reporterNode, err := NewNode(ctx, *h, ps)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	testItems.reporter = reporter
+	testItems.reporter = reporterNode
 
 	tmpData, err := insertSampleData(ctx)
 	if err != nil {
@@ -71,9 +76,8 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	}
 	testItems.tmpData = tmpData
 
-	_ = admin.Group("/api/v1")
-	// TODO: add reporter admin test
-	// reporter.Routes(v1)
+	v1 := admin.Group("/api/v1")
+	reporter.Routes(v1)
 
 	return reporterCleanup(ctx, admin, testItems), testItems, nil
 

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 	}
 	defer cleanup()
 
-	_, err = NewNode(ctx, testItems.reporter.Raft.Host, testItems.reporter.Raft.Ps)
+	_, err = NewNode(ctx, testItems.reporterNode.Raft.Host, testItems.reporterNode.Raft.Ps)
 	if err != nil {
 		t.Fatal("error creating new reporter")
 	}
@@ -32,7 +32,7 @@ func TestLeaderJob(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.reporter.leaderJob()
+	err = testItems.reporterNode.leaderJob()
 	if err != nil {
 		t.Fatal("error running leader job")
 	}
@@ -46,8 +46,8 @@ func TestResignLeader(t *testing.T) {
 	}
 	defer cleanup()
 
-	testItems.reporter.resignLeader()
-	assert.Equal(t, testItems.reporter.Raft.GetRole(), raft.Follower)
+	testItems.reporterNode.resignLeader()
+	assert.Equal(t, testItems.reporterNode.Raft.GetRole(), raft.Follower)
 }
 
 func TestHandleCustomMessage(t *testing.T) {
@@ -58,7 +58,7 @@ func TestHandleCustomMessage(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = testItems.reporter.handleCustomMessage(raft.Message{})
+	err = testItems.reporterNode.handleCustomMessage(raft.Message{})
 	assert.Equal(t, err.Error(), "unknown message type")
 }
 
@@ -70,7 +70,7 @@ func TestGetLatestGlobalAggregates(t *testing.T) {
 	}
 	defer cleanup()
 
-	result, err := testItems.reporter.getLatestGlobalAggregates(ctx)
+	result, err := testItems.reporterNode.getLatestGlobalAggregates(ctx)
 	if err != nil {
 		t.Fatal("error getting latest global aggregates")
 	}
@@ -90,11 +90,11 @@ func TestFilterInvalidAggregates(t *testing.T) {
 		Value: 15,
 		Round: 1,
 	}}
-	result := testItems.reporter.filterInvalidAggregates(aggregates)
+	result := testItems.reporterNode.filterInvalidAggregates(aggregates)
 	assert.Equal(t, result, aggregates)
 
-	testItems.reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
-	result = testItems.reporter.filterInvalidAggregates(aggregates)
+	testItems.reporterNode.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	result = testItems.reporterNode.filterInvalidAggregates(aggregates)
 	assert.Equal(t, result, []GlobalAggregate{})
 }
 
@@ -111,11 +111,11 @@ func TestIsAggValid(t *testing.T) {
 		Value: 15,
 		Round: 1,
 	}
-	result := testItems.reporter.isAggValid(agg)
+	result := testItems.reporterNode.isAggValid(agg)
 	assert.Equal(t, result, true)
 
-	testItems.reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
-	result = testItems.reporter.isAggValid(agg)
+	testItems.reporterNode.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	result = testItems.reporterNode.isAggValid(agg)
 	assert.Equal(t, result, false)
 }
 
@@ -132,7 +132,7 @@ func TestMakeContractArgs(t *testing.T) {
 		Value: 15,
 		Round: 1,
 	}
-	pairs, values, err := testItems.reporter.makeContractArgs([]GlobalAggregate{agg})
+	pairs, values, err := testItems.reporterNode.makeContractArgs([]GlobalAggregate{agg})
 	if err != nil {
 		t.Fatal("error making contract args")
 	}

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 	}
 	defer cleanup()
 
-	_, err = New(ctx, testItems.reporter.Raft.Host, testItems.reporter.Raft.Ps)
+	_, err = NewNode(ctx, testItems.reporter.Raft.Host, testItems.reporter.Raft.Ps)
 	if err != nil {
 		t.Fatal("error creating new reporter")
 	}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -1,0 +1,111 @@
+package reporter
+
+import (
+	"context"
+	"errors"
+
+	"bisonai.com/orakl/node/pkg/bus"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/rs/zerolog/log"
+)
+
+func New(bus *bus.MessageBus, h host.Host, ps *pubsub.PubSub) *App {
+	return &App{
+		Reporter: &ReporterNode{},
+		Bus:      bus,
+		Host:     h,
+		Pubsub:   ps,
+	}
+}
+
+func (a *App) Run(ctx context.Context) error {
+	err := a.setReporter(ctx, a.Host, a.Pubsub)
+	if err != nil {
+		return err
+	}
+
+	a.subscribe(ctx)
+
+	return a.startReporter(ctx)
+}
+
+func (a *App) setReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
+	reporter, err := NewNode(ctx, h, ps)
+	if err != nil {
+		return err
+	}
+	a.Reporter = reporter
+	return nil
+}
+
+func (a *App) startReporter(ctx context.Context) error {
+	if a.Reporter.isRunning {
+		log.Debug().Msg("reporter already running")
+		return errors.New("reporter already running")
+	}
+
+	nodeCtx, cancel := context.WithCancel(ctx)
+	a.Reporter.nodeCtx = nodeCtx
+	a.Reporter.nodeCancel = cancel
+	a.Reporter.isRunning = true
+
+	go a.Reporter.Run(nodeCtx)
+	return nil
+}
+
+func (a *App) stopReporter() error {
+	if !a.Reporter.isRunning {
+		log.Debug().Msg("reporter not running")
+		return errors.New("reporter not running")
+	}
+
+	a.Reporter.nodeCancel()
+	a.Reporter.isRunning = false
+	return nil
+}
+
+func (a *App) subscribe(ctx context.Context) {
+	log.Debug().Msg("subscribing to reporter topic")
+	channel := a.Bus.Subscribe(bus.REPORTER)
+	go func() {
+		log.Debug().Msg("start reporter subscription goroutine")
+		for {
+			select {
+			case msg := <-channel:
+				log.Debug().Str("command", msg.Content.Command).Msg("received message from reporter topic")
+				go a.handleMessage(ctx, msg)
+			case <-ctx.Done():
+				log.Debug().Msg("stopping reporter subscription goroutine")
+				return
+			}
+		}
+	}()
+}
+
+func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
+	switch msg.Content.Command {
+	case bus.ACTIVATE_REPORTER:
+		if msg.From != bus.ADMIN {
+			bus.HandleMessageError(errors.New("non-admin"), msg, "reporter received message from non-admin")
+			return
+		}
+		err := a.startReporter(ctx)
+		if err != nil {
+			bus.HandleMessageError(err, msg, "failed to start reporter")
+			return
+		}
+		msg.Response <- bus.MessageResponse{Success: true}
+	case bus.DEACTIVATE_REPORTER:
+		if msg.From != bus.ADMIN {
+			bus.HandleMessageError(errors.New("non-admin"), msg, "reporter received message from non-admin")
+			return
+		}
+		err := a.stopReporter()
+		if err != nil {
+			bus.HandleMessageError(err, msg, "failed to stop reporter")
+			return
+		}
+		msg.Response <- bus.MessageResponse{Success: true}
+	}
+}

--- a/node/pkg/reporter/reporter_test.go
+++ b/node/pkg/reporter/reporter_test.go
@@ -1,0 +1,89 @@
+//nolint:all
+package reporter
+
+import (
+	"context"
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/admin/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	err = testItems.app.Run(ctx)
+	if err != nil {
+		t.Fatal("error running reporter")
+	}
+
+	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+}
+
+func TestStopReporter(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	err = testItems.app.Run(ctx)
+	if err != nil {
+		t.Fatal("error running reporter")
+	}
+
+	err = testItems.app.stopReporter()
+	if err != nil {
+		t.Fatal("error stopping reporter")
+	}
+
+	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+}
+
+func TestStopReporterByAdmin(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	testItems.app.subscribe(ctx)
+
+	err = testItems.app.Run(ctx)
+	if err != nil {
+		t.Fatal("error running reporter")
+	}
+
+	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/deactivate", nil)
+	if err != nil {
+		t.Fatalf("error activating reporter: %v", err)
+	}
+
+	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+}
+
+func TestStartReporterByAdmin(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	testItems.app.subscribe(ctx)
+	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+
+	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
+	if err != nil {
+		t.Fatalf("error activating reporter: %v", err)
+	}
+
+	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+}

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -1,0 +1,57 @@
+package reporter
+
+import (
+	"context"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/raft"
+	"bisonai.com/orakl/node/pkg/utils"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+)
+
+const (
+	TOPIC_STRING            = "orakl-offchain-aggregation-reporter"
+	MESSAGE_BUFFER          = 100
+	LEADER_TIMEOUT          = 5 * time.Second
+	INITIAL_FAILURE_TIMEOUT = 50 * time.Millisecond
+	MAX_RETRY               = 3
+	MAX_RETRY_DELAY         = 500 * time.Millisecond
+	FUNCTION_STRING         = "batchSubmit(string[] memory _pairs, int256[] memory _prices)"
+
+	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
+		SELECT ga.name, ga.value, ga.round, ga.timestamp
+		FROM global_aggregates ga
+		JOIN (
+			SELECT name, MAX(round) as max_round
+			FROM global_aggregates
+			GROUP BY name
+		) subq ON ga.name = subq.name AND ga.round = subq.max_round;`
+)
+
+type App struct {
+	Reporter *ReporterNode
+	Bus      *bus.MessageBus
+	Host     host.Host
+	Pubsub   *pubsub.PubSub
+}
+
+type ReporterNode struct {
+	Raft     *raft.Raft
+	TxHelper *utils.TxHelper
+
+	lastSubmissions map[string]int64
+	contractAddress string
+
+	nodeCtx    context.Context
+	nodeCancel context.CancelFunc
+	isRunning  bool
+}
+
+type GlobalAggregate struct {
+	Name      string    `db:"name"`
+	Value     int64     `db:"value"`
+	Round     int64     `db:"round"`
+	Timestamp time.Time `db:"timestamp"`
+}

--- a/node/pkg/utils/klaytn_helper.go
+++ b/node/pkg/utils/klaytn_helper.go
@@ -42,16 +42,6 @@ type TxHelper struct {
 }
 
 func NewTxHelper(ctx context.Context) (*TxHelper, error) {
-	client, err := client.Dial(os.Getenv("PROVIDER_URL"))
-	if err != nil {
-		return nil, err
-	}
-
-	chainID, err := getChainID(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-
 	wallets, err := getWallets(ctx)
 	if err != nil {
 		return nil, err
@@ -66,9 +56,27 @@ func NewTxHelper(ctx context.Context) (*TxHelper, error) {
 		return nil, errors.New("no wallets found")
 	}
 
+	return newTxHelper(ctx, os.Getenv("PROVIDER_URL"), wallets)
+}
+
+func newTxHelper(ctx context.Context, providerUrl string, reporterPKs []string) (*TxHelper, error) {
+	client, err := client.Dial(providerUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	chainID, err := getChainID(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(reporterPKs) == 0 {
+		return nil, errors.New("no wallets found")
+	}
+
 	return &TxHelper{
 		client:  client,
-		wallets: wallets,
+		wallets: reporterPKs,
 		chainID: chainID,
 	}, nil
 }

--- a/node/pkg/utils/klaytn_helper.go
+++ b/node/pkg/utils/klaytn_helper.go
@@ -60,6 +60,10 @@ func NewTxHelper(ctx context.Context) (*TxHelper, error) {
 }
 
 func newTxHelper(ctx context.Context, providerUrl string, reporterPKs []string) (*TxHelper, error) {
+	if providerUrl == "" {
+		return nil, errors.New("provider url not set")
+	}
+
 	client, err := client.Dial(providerUrl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

### Reporter control functionality

- Adds App structure which contains single reporter for batch submission and contains msg bus to control it.
- Start & stop reporter from admin through message bus
- Test codes included

### Declare type and const in separate file

### Minor code updates
- `aggregator` context reference update
- Add private function  in `klaytn_helper` to be utilized later

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a comprehensive reporting functionality for managing reporter nodes, including subscription to topics and handling activation/deactivation messages.
- **Enhancements**
	- Improved the aggregator's context management for enhanced performance and reliability.
	- Enhanced log messages for clearer communication regarding message reception.
- **Refactor**
	- Refactored and renamed key components in the reporter package for better clarity and consistency.
	- Separated logic in `NewTxHelper` for improved code maintainability and readability in transaction handling.
- **Bug Fixes**
	- Fixed a potential issue in the `startAggregator` function by adding a check for a nil `aggregator` before proceeding.
- **Documentation**
	- Updated log message in the aggregator for better understanding from "fetcher received message" to "fetcher received bus message."
	- Improved documentation by using `nodeCtx` instead of `ctx` when calling `aggregator.Run`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->