### PR TITLE
Integrate ethereum mainnet for fetching dex prices

### DIFF
--- a/fetcher/src/job/job.utils.ts
+++ b/fetcher/src/job/job.utils.ts
@@ -3,12 +3,13 @@ import { Logger } from '@nestjs/common'
 import axios from 'axios'
 import { Contract, JsonRpcProvider } from 'ethers'
 import { abis as uniswapPoolAbis } from '../abis/pool'
-import { CYPRESS_PROVIDER_URL, FETCH_TIMEOUT } from '../settings'
+import { CYPRESS_PROVIDER_URL, ETHEREUM_PROVIDER_URL, FETCH_TIMEOUT } from '../settings'
 import { LOCAL_AGGREGATOR_FN } from './job.aggregator'
 import { FetcherError, FetcherErrorCode } from './job.errors'
 import { IAdapter, IFetchedData, IProxy } from './job.types'
 
 const CYPRESS_CHAIN_ID = 8217
+const ETHEREUM_CHAIN_ID = 1
 
 export function buildUrl(host: string, path: string) {
   const url = [host, path].join('/')
@@ -267,6 +268,8 @@ export async function extractUniswapPrice(adapter, decimals) {
 export async function providerByChain(chainId: number) {
   if (chainId == CYPRESS_CHAIN_ID) {
     return new JsonRpcProvider(CYPRESS_PROVIDER_URL)
+  } else if (chainId == ETHEREUM_CHAIN_ID) {
+    return new JsonRpcProvider(ETHEREUM_PROVIDER_URL)
   } else {
     throw new Error(`Invalid chain id`)
   }

--- a/fetcher/src/settings.ts
+++ b/fetcher/src/settings.ts
@@ -15,3 +15,6 @@ export const FETCHER_TYPE = process.env.FETCHER_TYPE || 0
 
 export const CYPRESS_PROVIDER_URL =
   process.env.CYPRESS_PROVIDER_URL || 'https://public-en-cypress.klaytn.net'
+
+export const ETHEREUM_PROVIDER_URL =
+  process.env.ETHEREUM_PROVIDER_URL || 'https://ethereum-mainnet-rpc.allthatnode.com'


### PR DESCRIPTION
# Description

Once deployed, we can try to fetch prices from uniswap.

* ETH/USDT (0.3%) https://info.uniswap.org/#/pools/0x4e68ccd3e89f51c3074ca5072bbac773960dfa36
* ETH/USDT (0.05%) https://info.uniswap.org/#/pools/0x11b815efb8f581194ae79006d24e0d814b7697f6
* WBTC/USDT (0.3%) https://info.uniswap.org/#/pools/0x9db9e0e53058c89e5b94e29621a205198648425b
* USDC/USDT (0.01%) https://info.uniswap.org/#/pools/0x3416cf6c708da44db2624d63ea0aaef7113527c6
* DAI/USDT (0.01%) https://info.uniswap.org/#/pools/0x48da0965ab2d2cbf1c17c09cfb5cbe67ad5b1406
* UNI/USDT (0.3%) https://info.uniswap.org/#/pools/0x3470447f3cecffac709d3e783a307790b0208d60

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded data fetching capabilities to include support for an additional Ethereum provider, enhancing the app's blockchain interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->