### PR TITLE
(OraklNode) Prepare run test

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -6,6 +6,7 @@ ENCRYPT_PASSWORD=
 BOOT_NODE=
 LISTEN_PORT=
 PROVIDER_URL=
+CONFIG_URL=
 
 #not required if wallets table is not empty
 REPORTER_PK=

--- a/node/cmd/test_all/main.go
+++ b/node/cmd/test_all/main.go
@@ -44,9 +44,9 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := admin.Run(mb)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to start admin server")
+		adminErr := admin.Run(mb)
+		if adminErr != nil {
+			log.Error().Err(adminErr).Msg("Failed to start admin server")
 			return
 		}
 	}()
@@ -55,9 +55,9 @@ func main() {
 	go func() {
 		defer wg.Done()
 		f := fetcher.New(mb)
-		err := f.Run(ctx)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to start fetcher")
+		fetcherErr := f.Run(ctx)
+		if fetcherErr != nil {
+			log.Error().Err(fetcherErr).Msg("Failed to start fetcher")
 			return
 		}
 	}()
@@ -67,9 +67,9 @@ func main() {
 		defer wg.Done()
 
 		a := aggregator.New(mb, *host, ps)
-		err = a.Run(ctx)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to start aggregator")
+		aaggreegatorErr := a.Run(ctx)
+		if aaggreegatorErr != nil {
+			log.Error().Err(aaggreegatorErr).Msg("Failed to start aggregator")
 			return
 		}
 	}()
@@ -79,9 +79,9 @@ func main() {
 		defer wg.Done()
 
 		r := reporter.New(mb, *host, ps)
-		err = r.Run(ctx)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to start reporter")
+		reporterErr := r.Run(ctx)
+		if reporterErr != nil {
+			log.Error().Err(reporterErr).Msg("Failed to start reporter")
 			return
 		}
 	}()

--- a/node/cmd/test_all/main.go
+++ b/node/cmd/test_all/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+
+	"bisonai.com/orakl/node/pkg/admin"
+	"bisonai.com/orakl/node/pkg/aggregator"
+	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/fetcher"
+	"bisonai.com/orakl/node/pkg/libp2p"
+	"bisonai.com/orakl/node/pkg/reporter"
+	"github.com/rs/zerolog/log"
+)
+
+/*
+following script does not include initialization of adapters and aggregators
+add 1 adapter and then sync aggregator before running the script
+*/
+
+func main() {
+	ctx := context.Background()
+	mb := bus.New(10)
+	var wg sync.WaitGroup
+
+	bootnode := os.Getenv("BOOT_NODE")
+	if bootnode == "" {
+		log.Debug().Msg("No bootnode specified")
+	}
+	listenPort, err := strconv.Atoi(os.Getenv("LISTEN_PORT"))
+	if err != nil {
+		log.Error().Err(err).Msg("Error parsing LISTEN_PORT")
+		return
+	}
+
+	host, ps, err := libp2p.Setup(ctx, bootnode, listenPort)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to setup libp2p")
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := admin.Run(mb)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to start admin server")
+			return
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f := fetcher.New(mb)
+		err := f.Run(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to start fetcher")
+			return
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		a := aggregator.New(mb, *host, ps)
+		err = a.Run(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to start aggregator")
+			return
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		r := reporter.New(mb, *host, ps)
+		err = r.Run(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to start reporter")
+			return
+		}
+	}()
+
+	wg.Wait()
+}

--- a/node/pkg/admin/adapter/controller.go
+++ b/node/pkg/admin/adapter/controller.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"encoding/json"
+	"os"
 	"sync"
 
 	"bisonai.com/orakl/node/pkg/admin/utils"
@@ -47,8 +48,14 @@ type AdapterDetailModel struct {
 }
 
 func syncFromOraklConfig(c *fiber.Ctx) error {
+	configUrl := os.Getenv("CONFIG_URL")
+	if configUrl == "" {
+		//defaults to baobab_adapters
+		configUrl = "https://config.orakl.network/baobab_adapters.json"
+	}
+
 	var adapters BulkAdapters
-	adapters, err := oraklUtil.GetRequest[BulkAdapters]("https://config.orakl.network/adapters.json", nil, map[string]string{"Content-Type": "application/json"})
+	adapters, err := oraklUtil.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to get orakl config: " + err.Error())
 	}

--- a/node/pkg/admin/adapter/controller.go
+++ b/node/pkg/admin/adapter/controller.go
@@ -48,11 +48,7 @@ type AdapterDetailModel struct {
 }
 
 func syncFromOraklConfig(c *fiber.Ctx) error {
-	configUrl := os.Getenv("CONFIG_URL")
-	if configUrl == "" {
-		//defaults to baobab_adapters
-		configUrl = "https://config.orakl.network/baobab_adapters.json"
-	}
+	configUrl := getConfigUrl()
 
 	var adapters BulkAdapters
 	adapters, err := oraklUtil.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
@@ -120,6 +116,7 @@ func syncFromOraklConfig(c *fiber.Ctx) error {
 }
 
 func addFromOraklConfig(c *fiber.Ctx) error {
+	configUrl := getConfigUrl()
 	name := c.Params("name")
 
 	if name == "" {
@@ -127,7 +124,7 @@ func addFromOraklConfig(c *fiber.Ctx) error {
 	}
 
 	var adapters BulkAdapters
-	adapters, err := oraklUtil.GetRequest[BulkAdapters]("https://config.orakl.network/adapters.json", nil, map[string]string{"Content-Type": "application/json"})
+	adapters, err := oraklUtil.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to get orakl config: " + err.Error())
 	}
@@ -282,4 +279,13 @@ func deactivate(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(result)
+}
+
+func getConfigUrl() string {
+	configUrl := os.Getenv("CONFIG_URL")
+	if configUrl == "" {
+		//defaults to baobab_adapters
+		configUrl = "https://config.orakl.network/baobab_adapters.json"
+	}
+	return configUrl
 }

--- a/node/pkg/admin/adapter/route.go
+++ b/node/pkg/admin/adapter/route.go
@@ -10,6 +10,7 @@ func Routes(router fiber.Router) {
 	adapter.Post("", insert)
 	adapter.Get("", get)
 	adapter.Post("/sync", syncFromOraklConfig)
+	adapter.Post("/sync/:name", addFromOraklConfig)
 	adapter.Get("/detail/:id", getDetailById)
 	adapter.Get("/:id", getById)
 	adapter.Delete("/:id", deleteById)

--- a/node/pkg/admin/admin.go
+++ b/node/pkg/admin/admin.go
@@ -9,7 +9,9 @@ import (
 	"bisonai.com/orakl/node/pkg/admin/feed"
 	"bisonai.com/orakl/node/pkg/admin/fetcher"
 	"bisonai.com/orakl/node/pkg/admin/proxy"
+	"bisonai.com/orakl/node/pkg/admin/reporter"
 	"bisonai.com/orakl/node/pkg/admin/utils"
+	"bisonai.com/orakl/node/pkg/admin/wallet"
 	"bisonai.com/orakl/node/pkg/bus"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
@@ -35,6 +37,8 @@ func Run(bus *bus.MessageBus) error {
 	proxy.Routes(v1)
 	fetcher.Routes(v1)
 	aggregator.Routes(v1)
+	reporter.Routes(v1)
+	wallet.Routes(v1)
 
 	port := os.Getenv("APP_PORT")
 	if port == "" {

--- a/node/pkg/reporter/node.go
+++ b/node/pkg/reporter/node.go
@@ -52,11 +52,6 @@ func NewNode(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*ReporterNode
 }
 
 func (r *ReporterNode) Run(ctx context.Context) {
-	if r.isRunning {
-		log.Debug().Msg("reporter already running")
-		return
-	}
-
 	r.Raft.Run(ctx)
 }
 
@@ -97,7 +92,7 @@ func (r *ReporterNode) leaderJob() error {
 		validAggregates := r.filterInvalidAggregates(aggregates)
 		if len(validAggregates) == 0 {
 			log.Error().Msg("no valid aggregates to report")
-			return errors.New("no valid aggregates to report")
+			return nil
 		}
 
 		err = r.report(ctx, validAggregates)
@@ -115,6 +110,7 @@ func (r *ReporterNode) leaderJob() error {
 	err := r.retry(job)
 	if err != nil {
 		r.resignLeader()
+		log.Error().Err(err).Msg("failed to report")
 		return errors.New("failed to report")
 	}
 

--- a/node/taskfiles/taskfile.local.yml
+++ b/node/taskfiles/taskfile.local.yml
@@ -17,6 +17,10 @@ tasks:
     dotenv: [".env"]
     cmds:
       - go run ./cmd/test_fetcher_and_aggregator/main.go
+  local-test-all:
+    dotenv: [".env"]
+    cmds:
+      - go run ./cmd/test_all/main.go
   boot-node:
     cmds:
       - go run ./cmd/boot/main.go


### PR DESCRIPTION
# Description

This PR contains multiple code updates preparing 12hrs run test including fetcher, aggregator, and reporter

### Adds `test_all.main.go` script

It runs all fetcher, aggregator, and reporter. unlike previous test, it doesn't inlcude step which automatically syncs from orakl-config. adapter and aggregator should be added before running the script

### Admin update, `addFromOraklConfig()`

Takes pair name as param and syncs single adapter with same name. endpoint is `/sync/:name`

### Raft code minor update

Signal resign before stopping heartbeat, prevent nil pointer error from becomeLeader function by closing go routine first before referencing heartbeat ticker

### Taskfile

Adds taskfile to execute new script


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a comprehensive system to run various components concurrently.
    - Added functionality to retrieve and validate adapter information from a remote source.
    - Introduced new routes for syncing adapter information and handling reporting and wallet operations.
- **Enhancements**
    - Improved the `Raft` struct's operations for better reliability in leader election and heartbeat management.
    - Optimized the `ReporterNode` struct's execution flow and error handling for more robust reporting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->