### PR TITLE
(API) Fix panic on hash failure

### DIFF
--- a/api/adapter/controller.go
+++ b/api/adapter/controller.go
@@ -1,11 +1,12 @@
 package adapter
 
 import (
-	"bisonai.com/orakl/api/feed"
-	"bisonai.com/orakl/api/utils"
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"bisonai.com/orakl/api/feed"
+	"bisonai.com/orakl/api/utils"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
@@ -58,7 +59,7 @@ func insert(c *fiber.Ctx) error {
 
 	err := computeAdapterHash(payload, true)
 	if err != nil {
-		panic(err)
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to compute adapter hash: " + err.Error())
 	}
 
 	row, err := utils.QueryRow[AdapterIdModel](c, InsertAdapter, map[string]any{
@@ -105,7 +106,7 @@ func hash(c *fiber.Ctx) error {
 
 	err = computeAdapterHash(&payload, verify)
 	if err != nil {
-		panic(err)
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to compute adapter hash: " + err.Error())
 	}
 	return c.JSON(payload)
 }
@@ -152,7 +153,7 @@ func computeAdapterHash(data *AdapterInsertModel, verify bool) error {
 
 	out, err := json.Marshal(input)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	hash := crypto.Keccak256Hash([]byte(out))

--- a/api/adapter/controller.go
+++ b/api/adapter/controller.go
@@ -117,10 +117,6 @@ func get(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	if results == nil {
-		results = []AdapterModel{}
-	}
-
 	return c.JSON(results)
 }
 

--- a/api/adapter/controller.go
+++ b/api/adapter/controller.go
@@ -117,6 +117,10 @@ func get(c *fiber.Ctx) error {
 		panic(err)
 	}
 
+	if results == nil {
+		results = []AdapterModel{}
+	}
+
 	return c.JSON(results)
 }
 

--- a/api/aggregator/controller.go
+++ b/api/aggregator/controller.go
@@ -231,10 +231,6 @@ func get(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	if results == nil {
-		results = []AggregatorResultModel{}
-	}
-
 	return c.JSON(results)
 }
 

--- a/api/aggregator/controller.go
+++ b/api/aggregator/controller.go
@@ -1,13 +1,14 @@
 package aggregator
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
 	"bisonai.com/orakl/api/adapter"
 	"bisonai.com/orakl/api/chain"
 	"bisonai.com/orakl/api/feed"
 	"bisonai.com/orakl/api/utils"
-	"encoding/json"
-	"fmt"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
@@ -118,7 +119,7 @@ func insert(c *fiber.Ctx) error {
 	}
 	err = computeAggregatorHash(&hashComputeParam, true)
 	if err != nil {
-		panic(err)
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to compute aggregator hash: " + err.Error())
 	}
 
 	insertParam := _AggregatorInsertModel{
@@ -207,7 +208,7 @@ func hash(c *fiber.Ctx) error {
 
 	err = computeAggregatorHash(&hashComputeParam, verify)
 	if err != nil {
-		panic(err)
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to compute aggregator hash: " + err.Error())
 	}
 
 	return c.JSON(hashComputeParam)
@@ -313,13 +314,13 @@ func computeAggregatorHash(data *AggregatorHashComputeInputModel, verify bool) e
 	processData := input.AggregatorHashComputeProcessModel
 	out, err := json.Marshal(processData)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	hash := crypto.Keccak256Hash([]byte(out))
 	hashString := fmt.Sprintf("0x%x", hash)
 	if verify && data.AggregatorHash != hashString {
-		panic(err)
+		return fmt.Errorf("hashes do not match!\nexpected %s, received %s", hashString, data.AdapterHash)
 	}
 
 	data.AggregatorHash = hashString

--- a/api/aggregator/controller.go
+++ b/api/aggregator/controller.go
@@ -231,6 +231,10 @@ func get(c *fiber.Ctx) error {
 		panic(err)
 	}
 
+	if results == nil {
+		results = []AggregatorResultModel{}
+	}
+
 	return c.JSON(results)
 }
 

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -123,8 +123,8 @@ func QueryRows[T any](c *fiber.Ctx, query string, args map[string]any) ([]T, err
 	}
 
 	results, err = pgx.CollectRows(rows, pgx.RowToStructByName[T])
-	if errors.Is(err, pgx.ErrNoRows) {
-		return results, nil
+	if errors.Is(err, pgx.ErrNoRows) || (results == nil && err == nil) {
+		return []T{}, nil
 	}
 	return results, err
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,7 +23,7 @@
     "build": "yarn clean && tsc",
     "cli": "node --no-warnings --import=specifier-resolution-node/register --experimental-json-modules dist/index.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
-    "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest.js --testPathIgnorePatterns mockData.ts --silent"
+    "test": "node --no-warnings --experimental-vm-modules node_modules/.bin/jest --testPathIgnorePatterns mockData.ts --silent"
   },
   "bin": {
     "cli": "dist/index.js"

--- a/cli/src/adapter.ts
+++ b/cli/src/adapter.ts
@@ -119,9 +119,9 @@ export function hashHandler() {
       return adapterWithCorrectHash
     } catch (e) {
       console.error('Adapter hash could not be computed. Reason:')
-      const errMsg = e?.response?.data?.message ? e.response.data.message : e.message
+      const errMsg = e?.response?.data ? e.response.data : e.message
 
-      console.error(errMsg)
+      console.error(e.response.data)
       return errMsg
     }
   }

--- a/cli/src/adapter.ts
+++ b/cli/src/adapter.ts
@@ -121,7 +121,7 @@ export function hashHandler() {
       console.error('Adapter hash could not be computed. Reason:')
       const errMsg = e?.response?.data ? e.response.data : e.message
 
-      console.error(e.response.data)
+      console.error(errMsg)
       return errMsg
     }
   }

--- a/cli/src/aggregator.ts
+++ b/cli/src/aggregator.ts
@@ -234,7 +234,7 @@ export function hashHandler() {
       console.error('Aggregator hash could not be computed. Reason:')
       const errMsg = e?.response?.data ? e.response.data : e.message
 
-      console.error(e.response.data)
+      console.error(errMsg)
       return errMsg
     }
   }

--- a/cli/src/aggregator.ts
+++ b/cli/src/aggregator.ts
@@ -232,8 +232,9 @@ export function hashHandler() {
       return aggregatorWithCorrectHash
     } catch (e) {
       console.error('Aggregator hash could not be computed. Reason:')
-      const errMsg = e?.response?.data?.message ? e.response.data.message : e.message
-      console.error(errMsg)
+      const errMsg = e?.response?.data ? e.response.data : e.message
+
+      console.error(e.response.data)
       return errMsg
     }
   }

--- a/cli/test/mockData.ts
+++ b/cli/test/mockData.ts
@@ -117,24 +117,24 @@ export const DATAFEED_BULK_1 = {
   eventName: 'NewRoundV2',
   bulk: [
     {
-      adapterSource: 'https://config.orakl.network/adapter/baobab/bnb-usdt.adapter.json',
-      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/bnb-usdt.aggregator.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/btc-usdt.adapter.json',
+      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/btc-usdt.aggregator.json',
       reporter: {
         walletAddress: '0x0',
         walletPrivateKey: '0x1'
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/baobab/bora-krw.adapter.json',
-      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/bora-krw.aggregator.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/ltc-usdt.adapter.json',
+      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/ltc-usdt.aggregator.json',
       reporter: {
         walletAddress: '0x2',
         walletPrivateKey: '0x3'
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/baobab/eth-usdt.adapter.json',
-      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/eth-usdt.aggregator.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/klay-usdt.adapter.json',
+      aggregatorSource: 'https://config.orakl.network/aggregator/baobab/klay-usdt.aggregator.json',
       reporter: {
         walletAddress: '0x4',
         walletPrivateKey: '0x5'

--- a/cli/test/mockData.ts
+++ b/cli/test/mockData.ts
@@ -83,7 +83,7 @@ export const VRF_1 = {
 export const DATAFEED_BULK_0 = {
   bulk: [
     {
-      adapterSource: 'https://config.orakl.network/adapter/ada-usdt.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/ada-usdt.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/ada-usdt.aggregator.json',
       reporter: {
         walletAddress: '0xa',
@@ -91,7 +91,7 @@ export const DATAFEED_BULK_0 = {
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/atom-usdt.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/atom-usdt.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/atom-usdt.aggregator.json',
       reporter: {
         walletAddress: '0xc',
@@ -99,7 +99,7 @@ export const DATAFEED_BULK_0 = {
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/avax-usdt.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/avax-usdt.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/avax-usdt.aggregator.json',
       reporter: {
         walletAddress: '0xe',
@@ -117,7 +117,7 @@ export const DATAFEED_BULK_1 = {
   eventName: 'NewRoundV2',
   bulk: [
     {
-      adapterSource: 'https://config.orakl.network/adapter/bnb-usdt.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/bnb-usdt.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/bnb-usdt.aggregator.json',
       reporter: {
         walletAddress: '0x0',
@@ -125,7 +125,7 @@ export const DATAFEED_BULK_1 = {
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/bora-krw.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/bora-krw.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/bora-krw.aggregator.json',
       reporter: {
         walletAddress: '0x2',
@@ -133,7 +133,7 @@ export const DATAFEED_BULK_1 = {
       }
     },
     {
-      adapterSource: 'https://config.orakl.network/adapter/eth-usdt.adapter.json',
+      adapterSource: 'https://config.orakl.network/adapter/baobab/eth-usdt.adapter.json',
       aggregatorSource: 'https://config.orakl.network/aggregator/baobab/eth-usdt.aggregator.json',
       reporter: {
         walletAddress: '0x4',


### PR DESCRIPTION
# Description

fix panic failure on hash error for adapter and aggregator
### AS-IS
```
goroutine 29 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/debug/stack.go:24 +0x64
bisonai.com/orakl/api/utils.CustomStackTraceHandler(0x14000442cc0?, {0x104da9fe0?, 0x1052f2fa0})
        /Users/kersner/git/orakl/api/utils/utils.go:301 +0x1d8
bisonai.com/orakl/api/utils.Setup.New.func2.1()
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/recover/recover.go:31 +0x70
panic({0x0?, 0x0?})
        /opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/panic.go:914 +0x218
bisonai.com/orakl/api/aggregator.computeAggregatorHash(0x140000af748, 0x1)
        /Users/kersner/git/orakl/api/aggregator/controller.go:322 +0x190
bisonai.com/orakl/api/aggregator.hash(0x104d9c820?)
        /Users/kersner/git/orakl/api/aggregator/controller.go:208 +0x338
github.com/gofiber/fiber/v2.(*App).next(0x14000483400, 0x14000478c00)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:145 +0x188
github.com/gofiber/fiber/v2.(*Ctx).Next(0x104e5bb00?)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1030 +0x5c
bisonai.com/orakl/api/utils.Setup.func1(0x100?)
        /Users/kersner/git/orakl/api/utils/utils.go:180 +0x104
github.com/gofiber/fiber/v2.(*Ctx).Next(0x1400001c330?)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1027 +0x48
github.com/gofiber/fiber/v2/middleware/cors.New.func1(0x14000478c00)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/cors/cors.go:166 +0x318
github.com/gofiber/fiber/v2.(*Ctx).Next(0x140000afaf8?)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/ctx.go:1027 +0x48
bisonai.com/orakl/api/utils.Setup.New.func2(0x104d9c820?)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/middleware/recover/recover.go:43 +0xa4
github.com/gofiber/fiber/v2.(*App).next(0x14000483400, 0x14000478c00)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:145 +0x188
github.com/gofiber/fiber/v2.(*App).handler(0x14000483400, 0x1049f6e88?)
        /Users/kersner/.go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.0/router.go:172 +0x74
github.com/valyala/fasthttp.(*Server).serveConn(0x14000480fc0, {0x104e73b28?, 0x140005060b0})
        /Users/kersner/.go/pkg/mod/github.com/valyala/fasthttp@v1.52.0/server.go:2374 +0xdd0
github.com/valyala/fasthttp.(*workerPool).workerFunc(0x140004900a0, 0x1400028c040)
        /Users/kersner/.go/pkg/mod/github.com/valyala/fasthttp@v1.52.0/workerpool.go:224 +0x70
github.com/valyala/fasthttp.(*workerPool).getCh.func1()
        /Users/kersner/.go/pkg/mod/github.com/valyala/fasthttp@v1.52.0/workerpool.go:196 +0x38
created by github.com/valyala/fasthttp.(*workerPool).getCh in goroutine 1
        /Users/kersner/.go/pkg/mod/github.com/valyala/fasthttp@v1.52.0/workerpool.go:195 +0x208

2024/03/13 20:07:12 | 500 | 127.0.0.1 | POST | /api/v1/aggregator/hash | panic called with nil argument
```

### TO-BE
<img width="1228" alt="Screenshot 2024-03-15 at 1 33 30 PM" src="https://github.com/Bisonai/orakl/assets/148735107/c9a70d8e-412b-4306-8652-dcec6f74a954">
<img width="1185" alt="Screenshot 2024-03-15 at 1 33 22 PM" src="https://github.com/Bisonai/orakl/assets/148735107/f57bd2bf-3383-4b6d-b2c8-0d6369e86fe4">



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Adjusted URLs for assets to include the path `/baobab/` and modified wallet information for different assets.
- **Refactor**
	- Improved error handling in API components to enhance stability and provide clearer error messages.
- **Refactor**
	- Enhanced error message handling in CLI scripts for improved readability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->