### PR TITLE
(OraklNode) Support fixed address for bootnode

### DIFF
--- a/node/cmd/boot/main.go
+++ b/node/cmd/boot/main.go
@@ -1,18 +1,21 @@
 package main
 
 import (
+	"context"
+
 	"bisonai.com/orakl/node/pkg/libp2p"
 	"bisonai.com/orakl/node/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	ctx := context.Background()
 	seed, err := utils.EncryptText("orakl-bootnode-test")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to encrypt seed")
 	}
 
-	bootnode, err := libp2p.SetBootNode(10010, seed)
+	bootnode, _, err := libp2p.SetBootNode(ctx, 10010, seed)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to set bootnode")
 	}

--- a/node/cmd/boot/main.go
+++ b/node/cmd/boot/main.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"bisonai.com/orakl/node/pkg/libp2p"
+	"bisonai.com/orakl/node/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
-	bootnode, err := libp2p.SetBootNode(10010)
+	seed, err := utils.EncryptText("orakl-bootnode-test")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to encrypt seed")
+	}
+
+	bootnode, err := libp2p.SetBootNode(10010, seed)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to set bootnode")
 	}

--- a/node/pkg/libp2p/libp2p.go
+++ b/node/pkg/libp2p/libp2p.go
@@ -26,14 +26,14 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-func SetBootNode(listenPort int, seed string) (*host.Host, error) {
+func SetBootNode(ctx context.Context, listenPort int, seed string) (*host.Host, *dht.IpfsDHT, error) {
 	var priv crypto.PrivKey
 	var err error
 	if seed == "" {
 		priv, _, err = crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
 		if err != nil {
 			log.Error().Err(err).Msg("Error generating key pair")
-			return nil, err
+			return nil, nil, err
 		}
 	} else {
 		hash := sha256.Sum256([]byte(seed))
@@ -41,20 +41,20 @@ func SetBootNode(listenPort int, seed string) (*host.Host, error) {
 		priv, err = crypto.UnmarshalEd25519PrivateKey(rawKey)
 		if err != nil {
 			log.Error().Err(err).Msg("Error unmarshalling private key")
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/"+strconv.Itoa(listenPort)), libp2p.Identity(priv))
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating libp2p host")
-		return nil, err
+		return nil, nil, err
 	}
 
-	_, err = dht.New(context.Background(), h)
+	dht, err := dht.New(ctx, h)
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating DHT")
-		return nil, err
+		return nil, nil, err
 	}
 
 	pi := peer.AddrInfo{
@@ -66,7 +66,7 @@ func SetBootNode(listenPort int, seed string) (*host.Host, error) {
 		fmt.Println(addr.String() + "/p2p/" + h.ID().String())
 	}
 
-	return &h, nil
+	return &h, dht, nil
 }
 
 func Setup(ctx context.Context, bootnodeStr string, port int) (*host.Host, *pubsub.PubSub, error) {

--- a/node/pkg/libp2p/libp2p_test.go
+++ b/node/pkg/libp2p/libp2p_test.go
@@ -39,7 +39,7 @@ func TestInitDHT(t *testing.T) {
 func TestDiscoverPeers(t *testing.T) {
 	ctx := context.Background()
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	b, _ := SetBootNode(10003)
+	b, _ := SetBootNode(10003, "")
 	h1, _ := MakeHost(10001)
 	h2, _ := MakeHost(10002)
 

--- a/node/pkg/libp2p/libp2p_test.go
+++ b/node/pkg/libp2p/libp2p_test.go
@@ -39,7 +39,7 @@ func TestInitDHT(t *testing.T) {
 func TestDiscoverPeers(t *testing.T) {
 	ctx := context.Background()
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	b, _ := SetBootNode(10003, "")
+	b, _, _ := SetBootNode(ctx, 10003, "")
 	h1, _ := MakeHost(10001)
 	h2, _ := MakeHost(10002)
 


### PR DESCRIPTION
# Description

- Improves bootnode implementation
- Set fixed id for bootnode host
- Receive context as parameter
- Return DHT so that it won't be collected by garbage collector inside setBootNode function

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced boot node initialization with context support and encryption for seed text.
	- Improved peer discovery with the introduction of a DHT instance in the boot node setup.

- **Refactor**
	- Updated the `SetBootNode` function to accept new parameters and return a DHT instance.

- **Tests**
	- Adjusted peer discovery tests to accommodate changes in the `SetBootNode` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->