### PR TITLE
(OraklNode) Separate utils inner paths

### DIFF
--- a/node/pkg/admin/adapter/controller.go
+++ b/node/pkg/admin/adapter/controller.go
@@ -8,7 +8,7 @@ import (
 	"bisonai.com/orakl/node/pkg/admin/utils"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
-	oraklUtil "bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/request"
 	"github.com/go-playground/validator"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
@@ -51,7 +51,7 @@ func syncFromOraklConfig(c *fiber.Ctx) error {
 	configUrl := getConfigUrl()
 
 	var adapters BulkAdapters
-	adapters, err := oraklUtil.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
+	adapters, err := request.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to get orakl config: " + err.Error())
 	}
@@ -124,7 +124,7 @@ func addFromOraklConfig(c *fiber.Ctx) error {
 	}
 
 	var adapters BulkAdapters
-	adapters, err := oraklUtil.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
+	adapters, err := request.GetRequest[BulkAdapters](configUrl, nil, map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to get orakl config: " + err.Error())
 	}

--- a/node/pkg/aggregator/node.go
+++ b/node/pkg/aggregator/node.go
@@ -10,7 +10,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/raft"
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/calculator"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
@@ -131,7 +131,7 @@ func (n *AggregatorNode) HandlePriceDataMessage(msg raft.Message) error {
 		defer delete(n.CollectedPrices, priceDataMessage.RoundID)
 		filteredCollectedPrices := FilterNegative(n.CollectedPrices[priceDataMessage.RoundID])
 
-		median, err := utils.GetInt64Med(filteredCollectedPrices)
+		median, err := calculator.GetInt64Med(filteredCollectedPrices)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to get median")
 			return err

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -12,6 +12,8 @@ import (
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/reducer"
+	"bisonai.com/orakl/node/pkg/utils/request"
 	"github.com/rs/zerolog/log"
 )
 
@@ -294,7 +296,7 @@ func (a *App) fetch(fetcher Fetcher) ([]float64, error) {
 				return
 			}
 
-			result, err := utils.Reduce(res, definition.Reducers)
+			result, err := reducer.Reduce(res, definition.Reducers)
 			if err != nil {
 				errChan <- err
 				return
@@ -338,11 +340,11 @@ func (a *App) requestFeed(definition Definition) (interface{}, error) {
 }
 
 func (a *App) requestWithoutProxy(definition Definition) (interface{}, error) {
-	return utils.GetRequest[interface{}](definition.Url, nil, definition.Headers)
+	return request.GetRequest[interface{}](definition.Url, nil, definition.Headers)
 }
 
 func (a *App) requestWithProxy(definition Definition, proxyUrl string) (interface{}, error) {
-	return utils.GetRequestProxy[interface{}](definition.Url, nil, definition.Headers, proxyUrl)
+	return request.GetRequestProxy[interface{}](definition.Url, nil, definition.Headers, proxyUrl)
 }
 
 func (a *App) filterProxyByLocation(location string) []Proxy {

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -11,7 +11,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/calculator"
 	"bisonai.com/orakl/node/pkg/utils/reducer"
 	"bisonai.com/orakl/node/pkg/utils/request"
 	"github.com/rs/zerolog/log"
@@ -238,7 +238,7 @@ func (a *App) fetchAndInsert(ctx context.Context, fetcher Fetcher) error {
 	}
 	log.Debug().Str("fetcher", fetcher.Name).Msg("fetch complete")
 
-	aggregated, err := utils.GetFloatAvg(results)
+	aggregated, err := calculator.GetFloatAvg(results)
 	if err != nil {
 		return err
 	}

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/reducer"
 )
 
 const (
@@ -56,7 +56,7 @@ type Definition struct {
 	Url      string            `json:"url"`
 	Headers  map[string]string `json:"headers"`
 	Method   string            `json:"method"`
-	Reducers []utils.Reducer   `json:"reducers"`
+	Reducers []reducer.Reducer `json:"reducers"`
 	Location *string           `json:"location"`
 }
 

--- a/node/pkg/reporter/node.go
+++ b/node/pkg/reporter/node.go
@@ -10,7 +10,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/raft"
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -26,7 +26,7 @@ func NewNode(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*ReporterNode
 	}
 
 	raft := raft.NewRaftNode(h, ps, topic, MESSAGE_BUFFER, LEADER_TIMEOUT)
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -6,7 +6,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/raft"
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 )
@@ -39,7 +39,7 @@ type App struct {
 
 type ReporterNode struct {
 	Raft     *raft.Raft
-	TxHelper *utils.TxHelper
+	TxHelper *klaytn_helper.TxHelper
 
 	lastSubmissions map[string]int64
 	contractAddress string

--- a/node/pkg/utils/calculator/calculator.go
+++ b/node/pkg/utils/calculator/calculator.go
@@ -1,4 +1,4 @@
-package utils
+package calculator
 
 import (
 	"errors"

--- a/node/pkg/utils/klaytn_helper/klaytn_helper.go
+++ b/node/pkg/utils/klaytn_helper/klaytn_helper.go
@@ -1,4 +1,4 @@
-package utils
+package klaytn_helper
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/db"
+	"bisonai.com/orakl/node/pkg/utils/request"
 
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi"
@@ -142,7 +143,7 @@ func (t *TxHelper) GetSignedFromDelegator(tx *types.Transaction) (*types.Transac
 		return nil, err
 	}
 
-	result, err := UrlRequest[SignModel](t.delegatorUrl+"/api/v1/sign/volatile", "POST", payload, nil, "")
+	result, err := request.UrlRequest[SignModel](t.delegatorUrl+"/api/v1/sign/volatile", "POST", payload, nil, "")
 	if err != nil {
 		log.Error().Err(err).Msg("failed to request sign from delegator")
 		return nil, err

--- a/node/pkg/utils/reducer/reducer.go
+++ b/node/pkg/utils/reducer/reducer.go
@@ -1,4 +1,4 @@
-package utils
+package reducer
 
 import (
 	"fmt"

--- a/node/pkg/utils/request/request.go
+++ b/node/pkg/utils/request/request.go
@@ -1,4 +1,4 @@
-package utils
+package request
 
 import (
 	"bytes"

--- a/node/pkg/utils/tests/calculator_test.go
+++ b/node/pkg/utils/tests/calculator_test.go
@@ -3,13 +3,13 @@ package tests
 import (
 	"testing"
 
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/calculator"
 )
 
 func TestFloatAvgOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []float64{1, 2, 3, 4, 5}
-	avg1, err := utils.GetFloatAvg(data1)
+	avg1, err := calculator.GetFloatAvg(data1)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestFloatAvgOddLength(t *testing.T) {
 func TestFloatAvgEvnLength(t *testing.T) {
 	// Test with even length array
 	data2 := []float64{1, 2, 3, 4}
-	avg2, err := utils.GetFloatAvg(data2)
+	avg2, err := calculator.GetFloatAvg(data2)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestFloatAvgEvnLength(t *testing.T) {
 func TestFloatAvgUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data3 := []float64{5, 3, 1, 4, 2}
-	avg3, err := utils.GetFloatAvg(data3)
+	avg3, err := calculator.GetFloatAvg(data3)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestFloatAvgUnsorted(t *testing.T) {
 func TestFloatAvgZeroLength(t *testing.T) {
 	// Test with zero length array
 	data4 := []float64{}
-	avg4, err := utils.GetFloatAvg(data4)
+	avg4, err := calculator.GetFloatAvg(data4)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -57,7 +57,7 @@ func TestFloatAvgZeroLength(t *testing.T) {
 func TestFloatMedOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []float64{1, 2, 3, 4, 5}
-	med1, err := utils.GetFloatMed(data1)
+	med1, err := calculator.GetFloatMed(data1)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestFloatMedOddLength(t *testing.T) {
 func TestFloatMedEvenLength(t *testing.T) {
 	// Test with even length array
 	data2 := []float64{1, 2, 3, 4}
-	med2, err := utils.GetFloatMed(data2)
+	med2, err := calculator.GetFloatMed(data2)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestFloatMedEvenLength(t *testing.T) {
 func TestFloatMedUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data3 := []float64{5, 3, 1, 4, 2}
-	med3, err := utils.GetFloatMed(data3)
+	med3, err := calculator.GetFloatMed(data3)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestFloatMedUnsorted(t *testing.T) {
 func TestFloatMedZeroLength(t *testing.T) {
 	// Test with zero length array
 	data4 := []float64{}
-	med4, err := utils.GetFloatMed(data4)
+	med4, err := calculator.GetFloatMed(data4)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -105,7 +105,7 @@ func TestFloatMedZeroLength(t *testing.T) {
 func TestIntAvgOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []int{1, 2, 3, 4, 5}
-	avg1, err := utils.GetIntAvg(data1)
+	avg1, err := calculator.GetIntAvg(data1)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestIntAvgOddLength(t *testing.T) {
 func TestIntAvgEvnLength(t *testing.T) {
 	// Test with even length array
 	data2 := []int{1, 2, 3, 4}
-	avg2, err := utils.GetIntAvg(data2)
+	avg2, err := calculator.GetIntAvg(data2)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestIntAvgEvnLength(t *testing.T) {
 func TestIntAvgZeroLength(t *testing.T) {
 	// Test with zero length array
 	data3 := []int{}
-	avg3, err := utils.GetIntAvg(data3)
+	avg3, err := calculator.GetIntAvg(data3)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -141,7 +141,7 @@ func TestIntAvgZeroLength(t *testing.T) {
 func TestIntAvgUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data4 := []int{5, 3, 1, 4, 2}
-	avg4, err := utils.GetIntAvg(data4)
+	avg4, err := calculator.GetIntAvg(data4)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestIntAvgUnsorted(t *testing.T) {
 func TestIntMedOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []int{1, 2, 3, 4, 5}
-	med1, err := utils.GetIntMed(data1)
+	med1, err := calculator.GetIntMed(data1)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestIntMedOddLength(t *testing.T) {
 func TestIntMedEvnLength(t *testing.T) {
 	// Test with even length array
 	data2 := []int{1, 2, 3, 4}
-	med2, err := utils.GetIntMed(data2)
+	med2, err := calculator.GetIntMed(data2)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestIntMedEvnLength(t *testing.T) {
 func TestIntMedUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data3 := []int{5, 3, 1, 4, 2}
-	med3, err := utils.GetIntMed(data3)
+	med3, err := calculator.GetIntMed(data3)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestIntMedUnsorted(t *testing.T) {
 func TestIntMedZeroLength(t *testing.T) {
 	// Test with zero length array
 	data4 := []int{}
-	med4, err := utils.GetIntMed(data4)
+	med4, err := calculator.GetIntMed(data4)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -201,7 +201,7 @@ func TestIntMedZeroLength(t *testing.T) {
 func TestInt64AvgOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []int64{1, 2, 3, 4, 5}
-	avg1, err := utils.GetInt64Avg(data1)
+	avg1, err := calculator.GetInt64Avg(data1)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestInt64AvgOddLength(t *testing.T) {
 func TestInt64AvgEvnLength(t *testing.T) {
 	// Test with even length array
 	data2 := []int64{1, 2, 3, 4}
-	avg2, err := utils.GetInt64Avg(data2)
+	avg2, err := calculator.GetInt64Avg(data2)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestInt64AvgEvnLength(t *testing.T) {
 func TestInt64AvgUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data3 := []int64{5, 3, 1, 4, 2}
-	avg3, err := utils.GetInt64Avg(data3)
+	avg3, err := calculator.GetInt64Avg(data3)
 	if err != nil {
 		t.Errorf("Error calculating average: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestInt64AvgUnsorted(t *testing.T) {
 func TestInt64AvgZeroLength(t *testing.T) {
 	// Test with zero length array
 	data4 := []int64{}
-	avg4, err := utils.GetInt64Avg(data4)
+	avg4, err := calculator.GetInt64Avg(data4)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -249,7 +249,7 @@ func TestInt64AvgZeroLength(t *testing.T) {
 func TestInt64MedOddLength(t *testing.T) {
 	// Test with odd length array
 	data1 := []int64{1, 2, 3, 4, 5}
-	med1, err := utils.GetInt64Med(data1)
+	med1, err := calculator.GetInt64Med(data1)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestInt64MedOddLength(t *testing.T) {
 func TestInt64MedEvnLength(t *testing.T) {
 	// Test with even length array
 	data2 := []int64{1, 2, 3, 4}
-	med2, err := utils.GetInt64Med(data2)
+	med2, err := calculator.GetInt64Med(data2)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestInt64MedEvnLength(t *testing.T) {
 func TestInt64MedUnsorted(t *testing.T) {
 	// Test with unsorted list
 	data3 := []int64{5, 3, 1, 4, 2}
-	med3, err := utils.GetInt64Med(data3)
+	med3, err := calculator.GetInt64Med(data3)
 	if err != nil {
 		t.Errorf("Error calculating median: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestInt64MedUnsorted(t *testing.T) {
 func TestInt64MedZeroLength(t *testing.T) {
 	// Test with zero length array
 	data4 := []int64{}
-	med4, err := utils.GetInt64Med(data4)
+	med4, err := calculator.GetInt64Med(data4)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}

--- a/node/pkg/utils/tests/klaytn_helper_test.go
+++ b/node/pkg/utils/tests/klaytn_helper_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTxHelper(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -19,7 +19,7 @@ func TestNewTxHelper(t *testing.T) {
 
 func TestNextReporter(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestNextReporter(t *testing.T) {
 
 func TestMakeDirectTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestMakeDirectTx(t *testing.T) {
 
 func TestMakeFeeDelegatedTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestMakeFeeDelegatedTx(t *testing.T) {
 
 func TestTxToHashToTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -72,10 +72,10 @@ func TestTxToHashToTx(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	hash := utils.TxToHash(rawTx)
+	hash := klaytn_helper.TxToHash(rawTx)
 	assert.NotEqual(t, hash, "")
 
-	tx, err := utils.HashToTx(hash)
+	tx, err := klaytn_helper.HashToTx(hash)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -85,13 +85,13 @@ func TestTxToHashToTx(t *testing.T) {
 
 func TestGenerateABI(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	defer txHelper.Close()
 
-	abi, err := utils.GenerateABI("increment()")
+	abi, err := klaytn_helper.GenerateABI("increment()")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestGenerateABI(t *testing.T) {
 
 func TestSubmitRawTxString(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestSubmitRawTxString(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	rawTxString := utils.TxToHash(signedTx)
+	rawTxString := klaytn_helper.TxToHash(signedTx)
 	err = txHelper.SubmitRawTxString(ctx, rawTxString)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/node/pkg/utils/tests/reducer_test.go
+++ b/node/pkg/utils/tests/reducer_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/reducer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,7 +72,7 @@ var sampleResult = `[
   ]`
 
 func TestReduceAll(t *testing.T) {
-	var red []utils.Reducer
+	var red []reducer.Reducer
 	err := json.Unmarshal([]byte(reducers), &red)
 	if err != nil {
 		t.Fatalf("error unmarshalling sample def: %v", err)
@@ -84,7 +84,7 @@ func TestReduceAll(t *testing.T) {
 		t.Fatalf("error unmarshalling sample result: %v", err)
 	}
 
-	result, err := utils.Reduce(res, red)
+	result, err := reducer.Reduce(res, red)
 	if err != nil {
 		t.Fatalf("error reducing: %v", err)
 	}

--- a/node/pkg/utils/tests/request_test.go
+++ b/node/pkg/utils/tests/request_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/request"
 )
 
 type TestResponse struct {
@@ -98,7 +98,7 @@ func TestGetRequest(t *testing.T) {
 		Test: "value",
 	}
 
-	testResponse, err := utils.GetRequest[TestResponse](server.URL, requestBody, headers)
+	testResponse, err := request.GetRequest[TestResponse](server.URL, requestBody, headers)
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestGetRequestRaw(t *testing.T) {
 		Test: "value",
 	}
 
-	res, err := utils.GetRequestRaw(server.URL, requestBody, headers)
+	res, err := request.GetRequestRaw(server.URL, requestBody, headers)
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestUrlRequest(t *testing.T) {
 		Test: "value",
 	}
 
-	testResponse, err := utils.UrlRequest[TestResponse](server.URL, "GET", requestBody, headers, "")
+	testResponse, err := request.UrlRequest[TestResponse](server.URL, "GET", requestBody, headers, "")
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestUrlRequestRaw(t *testing.T) {
 		Test: "value",
 	}
 
-	res, err := utils.UrlRequestRaw(server.URL, "GET", requestBody, headers, "")
+	res, err := request.UrlRequestRaw(server.URL, "GET", requestBody, headers, "")
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestGetRequestProxy(t *testing.T) {
 		Test: "value",
 	}
 
-	testResponse, err := utils.GetRequestProxy[TestResponse](server.URL, requestBody, headers, proxy.URL)
+	testResponse, err := request.GetRequestProxy[TestResponse](server.URL, requestBody, headers, proxy.URL)
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestUrlRequestProxy(t *testing.T) {
 		"Test-Header": "test-value",
 	}
 
-	testResponse, err := utils.UrlRequest[TestResponse](server.URL, "GET", requestBody, headers, proxy.URL)
+	testResponse, err := request.UrlRequest[TestResponse](server.URL, "GET", requestBody, headers, proxy.URL)
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestUrlRequestRawProxy(t *testing.T) {
 		"Test-Header": "test-value",
 	}
 
-	res, err := utils.UrlRequestRaw(server.URL, "GET", requestBody, headers, proxy.URL)
+	res, err := request.UrlRequestRaw(server.URL, "GET", requestBody, headers, proxy.URL)
 	if err != nil {
 		t.Errorf("Error making request: %v", err)
 	}

--- a/node/script/test_submission/main.go
+++ b/node/script/test_submission/main.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"math/big"
 
-	"bisonai.com/orakl/node/pkg/utils"
+	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 	"github.com/rs/zerolog/log"
 )
 
 // send single submission through this script
 
 func testContractDelegatedCall(ctx context.Context, contractAddress string, contractFunction string, args ...interface{}) error {
-	txHelper, err := utils.NewTxHelper(ctx)
+	txHelper, err := klaytn_helper.NewTxHelper(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("NewTxHelper")
 		return err


### PR DESCRIPTION
# Description

It is a refactoring pr
It's to prevent circular reference among packages in advance

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved HTTP request handling by transitioning from `oraklUtil` to a more standardized approach using `request`.
	- Consolidated utility functions into separate packages (`reducer`, `request`, `klaytn_helper`) for streamlined data processing and code organization.
	- Restructured the import paths and method calls for better code organization and clarity.
- **Tests**
	- Updated tests to reflect changes in utility packages (`reducer`, `request`, `klaytn_helper`) for consistent and reliable functionality testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->