### PR TITLE
Remove submission by pair name (`SubmissionProxy`)

### DIFF
--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -15,22 +15,17 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
     uint256 public maxSubmission = 50;
     uint256 public expirationPeriod = 5 weeks;
     mapping(address oracle => uint256 expiration) oracles;
-    mapping(string => address) feeds;
     address[] public feedAddresses;
 
     event OracleAdded(address oracle);
     event MaxSubmissionSet(uint256 maxSubmission);
     event ExpirationPeriodSet(uint256 expirationPeriod);
-    event FeedAddressUpdated(string name, address indexed feed);
-    event FeedAddressBulkUpdated(string[] names, address[] feeds);
-    event FeedAddressRemoved(string name, address feed);
 
     error OnlyOracle();
     error InvalidOracle();
     error InvalidSubmissionLength();
     error InvalidExpirationPeriod();
     error InvalidMaxSubmission();
-    error InvalidFeed();
 
     modifier onlyOracle() {
         uint256 expiration_ = oracles[msg.sender];
@@ -42,34 +37,6 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
 
     function getFeeds() external view returns (address[] memory) {
 	return feedAddresses;
-    }
-
-    function removeFeed(string calldata _name) external onlyOwner {
-	if (feeds[_name] == address(0)) {
-	    revert InvalidFeed();
-	}
-
-	address feedToDelete_ = feeds[_name];
-	delete feeds[_name];
-	for (uint256 i = 0; i < feedAddresses.length; i++) {
-	    if (feedAddresses[i] == feedToDelete_) {
-		feedAddresses[i] = feedAddresses[feedAddresses.length - 1];
-		feedAddresses.pop();
-		break;
-	    }
-	}
-
-	emit FeedAddressRemoved(_name, feedToDelete_);
-    }
-
-    function updateFeedBulk(string[] calldata _names, address[] calldata _feeds) external onlyOwner {
-        require(_names.length > 0 && _names.length == _feeds.length, "invalid input");
-
-        for (uint256 i = 0; i < _names.length; i++) {
-	    updateFeed(_names[i], _feeds[i]);
-        }
-
-        emit FeedAddressBulkUpdated(_names, _feeds);
     }
 
     function setMaxSubmission(uint256 _maxSubmission) external onlyOwner {
@@ -97,7 +64,6 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
         emit OracleAdded(_oracle);
     }
 
-    // TODO compare with submitByPairName & remove
     function submit(address[] memory _feeds, int256[] memory _submissions) external onlyOracle {
         if (_feeds.length != _submissions.length || _feeds.length > maxSubmission) {
             revert InvalidSubmissionLength();
@@ -108,26 +74,7 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
         }
     }
 
-    function submitByPairName(string[] memory _feeds, int256[] memory _submissions) external onlyOracle {
-        if (_feeds.length != _submissions.length || _feeds.length > maxSubmission) {
-            revert InvalidSubmissionLength();
-        }
-
-        for (uint256 i = 0; i < _feeds.length; i++) {
-            IFeed(feeds[_feeds[i]]).submit(_submissions[i]);
-        }
-    }
-
     function typeAndVersion() external pure virtual override returns (string memory) {
         return "SubmissionProxy v0.2";
-    }
-
-    function updateFeed(string calldata _name, address _feed) public onlyOwner {
-	if (feeds[_name] == address(0)) {
-	    feedAddresses.push(_feed);
-	}
-
-        feeds[_name] = _feed;
-        emit FeedAddressUpdated(_name, _feed);
     }
 }

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -15,7 +15,6 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
     uint256 public maxSubmission = 50;
     uint256 public expirationPeriod = 5 weeks;
     mapping(address oracle => uint256 expiration) oracles;
-    address[] public feedAddresses;
 
     event OracleAdded(address oracle);
     event MaxSubmissionSet(uint256 maxSubmission);
@@ -34,10 +33,6 @@ contract SubmissionProxy is Ownable, ITypeAndVersion {
     }
 
     constructor() Ownable(msg.sender) {}
-
-    function getFeeds() external view returns (address[] memory) {
-	return feedAddresses;
-    }
 
     function setMaxSubmission(uint256 _maxSubmission) external onlyOwner {
 	if (_maxSubmission == MIN_SUBMISSION || _maxSubmission > MAX_SUBMISSION) {

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -21,55 +21,6 @@ contract SubmissionProxyTest is Test {
         submissionProxy = new SubmissionProxy();
     }
 
-    function test_UpdateFeedWithOwner() public {
-	address btcUsdtFeed = makeAddr("btc-usdt-feed");
-	submissionProxy.updateFeed("BTC-USDT", btcUsdtFeed);
-    }
-
-    function test_UpdateFeedMultipleTimesIsAllowed() public {
-	address btcUsdtFeed1 = makeAddr("btc-usdt-feed-1");
-	address btcUsdtFeed2 = makeAddr("btc-usdt-feed-2");
-	submissionProxy.updateFeed("BTC-USDT", btcUsdtFeed1);
-	submissionProxy.updateFeed("BTC-USDT", btcUsdtFeed2);
-    }
-
-    function test_UpdateFeedWithNonOwner() public {
-	address btcUsdtFeed = makeAddr("btc-usdt-feed");
-	address nonOwner = makeAddr("nonOwner");
-
-	vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, nonOwner));
-	vm.prank(nonOwner);
-	submissionProxy.updateFeed("BTC-USDT", btcUsdtFeed);
-    }
-
-    function test_UpdateFeedBulkWithOwner() public {
-	address btcUsdtFeed = makeAddr("btc-usdt-feed");
-	address ethUsdtFeed = makeAddr("eth-usdt-feed");
-
-	string[] memory names = new string[](2);
-	names[0] = "BTC-USDT";
-	names[1] = "ETH-USDT";
-
-	address[] memory feeds = new address[](2);
-	feeds[0] = btcUsdtFeed;
-	feeds[1] = ethUsdtFeed;
-
-	submissionProxy.updateFeedBulk(names, feeds);
-	feeds = submissionProxy.getFeeds();
-	assertEq(feeds.length, 2);
-    }
-
-    function test_RemoveFeed() public {
-	address btcUsdtFeed = makeAddr("btc-usdt-feed");
-	submissionProxy.updateFeed("BTC-USDT", btcUsdtFeed);
-	address[] memory feeds = submissionProxy.getFeeds();
-	assertEq(feeds.length, 1);
-
-	submissionProxy.removeFeed("BTC-USDT");
-	feeds = submissionProxy.getFeeds();
-	assertEq(feeds.length, 0);
-    }
-
     function test_AddOracleOnce() public {
 	address oracle_ = makeAddr("oracle");
         submissionProxy.addOracle(oracle_);


### PR DESCRIPTION
# Description

After comparison between different multi submission schemes, we decide to stay with submission by address due to the gas cost savings.

![image](https://github.com/Bisonai/orakl/assets/2312761/9c1adf28-ff36-42f2-bd78-7a0a12bb04c5)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Simplified feed management in smart contracts by removing the functionality for updating and removing feeds.
    - Streamlined submission process by consolidating feed management.
    - Removed unnecessary events and functions related to feed management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->