### PR TITLE
(OraklNode) Boot API, check entries before refreshing

### DIFF
--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -67,6 +67,16 @@ func Run(ctx context.Context) error {
 }
 
 func RefreshJob(ctx context.Context) error {
+	peers, err := db.QueryRows[peer.PeerModel](ctx, peer.GetPeer, nil)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get peers")
+		return err
+	}
+
+	if len(peers) == 0 {
+		return nil
+	}
+
 	bootPortStr := os.Getenv("BOOT_LISTEN_PORT")
 	if bootPortStr == "" {
 		log.Info().Msg("BOOT_PORT not set, defaulting to 10010")
@@ -82,12 +92,6 @@ func RefreshJob(ctx context.Context) error {
 	h, err := libp2p_setup.MakeHost(bootPort)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to make host")
-		return err
-	}
-
-	peers, err := db.QueryRows[peer.PeerModel](ctx, peer.GetPeer, nil)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get peers")
 		return err
 	}
 


### PR DESCRIPTION
# Description

Minor update that adds simple logic to skip refreshing if there's no entry in peers table

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized the logic in the boot process to skip certain operations when there are no peers, enhancing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->