### PR TITLE
(OraklNode) Store global aggregates in Redis

### DIFF
--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -91,7 +91,7 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 
 	localAggregateInsertTime := time.Now()
 
-	key := "latestAggregate:test-aggregate"
+	key := "localAggregate:test-aggregate"
 	data, err := json.Marshal(redisLocalAggregate{Value: int64(10), Timestamp: localAggregateInsertTime})
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func aggregatorCleanup(ctx context.Context, admin *fiber.App, testItems *TestIte
 			return err
 		}
 
-		err = db.Del(ctx, "latestAggregate:test-aggregate")
+		err = db.Del(ctx, "localAggregate:test-aggregate")
 		if err != nil {
 			return err
 		}

--- a/node/pkg/aggregator/node_test.go
+++ b/node/pkg/aggregator/node_test.go
@@ -118,5 +118,12 @@ func TestInsertGlobalAggregate(t *testing.T) {
 		t.Fatal("error getting latest round id")
 	}
 
+	redisResult, err := GetLatestGlobalAggregateFromRdb(ctx, "test-aggregate")
+	if err != nil {
+		t.Fatal("error getting latest global aggregate from rdb")
+	}
+	assert.Equal(t, redisResult.Value, int64(20))
+	assert.Equal(t, redisResult.Round, int64(2))
+
 	assert.Equal(t, roundId, int64(2))
 }

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -25,6 +25,11 @@ type redisLocalAggregate struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+type redisGlobalAggregate struct {
+	Value int64 `json:"value"`
+	Round int64 `json:"round"`
+}
+
 type pgsLocalAggregate struct {
 	Name      string    `db:"name"`
 	Value     int64     `db:"value"`

--- a/node/pkg/aggregator/utils.go
+++ b/node/pkg/aggregator/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GetLatestLocalAggregateFromRdb(ctx context.Context, name string) (redisLocalAggregate, error) {
-	key := "latestAggregate:" + name
+	key := "localAggregate:" + name
 	var aggregate redisLocalAggregate
 	data, err := db.Get(ctx, key)
 	if err != nil {
@@ -24,6 +24,21 @@ func GetLatestLocalAggregateFromRdb(ctx context.Context, name string) (redisLoca
 
 func GetLatestLocalAggregateFromPgs(ctx context.Context, name string) (pgsLocalAggregate, error) {
 	return db.QueryRow[pgsLocalAggregate](ctx, SelectLatestLocalAggregateQuery, map[string]any{"name": name})
+}
+
+func GetLatestGlobalAggregateFromRdb(ctx context.Context, name string) (redisGlobalAggregate, error) {
+	key := "globalAggregate:" + name
+	var aggregate redisGlobalAggregate
+	data, err := db.Get(ctx, key)
+	if err != nil {
+		return aggregate, err
+	}
+
+	err = json.Unmarshal([]byte(data), &aggregate)
+	if err != nil {
+		return aggregate, err
+	}
+	return aggregate, nil
 }
 
 func FilterNegative(values []int64) []int64 {

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -264,7 +264,7 @@ func (a *App) insertPgsql(ctx context.Context, name string, value float64) error
 }
 
 func (a *App) insertRdb(ctx context.Context, name string, value float64) error {
-	key := "latestAggregate:" + name
+	key := "localAggregate:" + name
 	data, err := json.Marshal(redisAggregate{Value: int64(value), Timestamp: time.Now()})
 	if err != nil {
 		return err

--- a/node/pkg/fetcher/fetcher_test.go
+++ b/node/pkg/fetcher/fetcher_test.go
@@ -93,13 +93,13 @@ func TestFetcherRun(t *testing.T) {
 	}
 
 	for _, fetcher := range app.Fetchers {
-		rdbResult, err := db.Get(ctx, "latestAggregate:"+fetcher.Name)
+		rdbResult, err := db.Get(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error reading from redis: %v", err)
 		}
 		assert.NotNil(t, rdbResult)
 
-		err = db.Del(ctx, "latestAggregate:"+fetcher.Name)
+		err = db.Del(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error removing from redis: %v", err)
 		}
@@ -158,13 +158,13 @@ func TestFetcherFetcherStart(t *testing.T) {
 
 	// check rdb and cleanup rdb
 	for _, fetcher := range app.Fetchers {
-		rdbResult, err := db.Get(ctx, "latestAggregate:"+fetcher.Name)
+		rdbResult, err := db.Get(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error reading from redis: %v", err)
 		}
 		assert.NotNil(t, rdbResult)
 
-		err = db.Del(ctx, "latestAggregate:"+fetcher.Name)
+		err = db.Del(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error removing from redis: %v", err)
 		}
@@ -227,13 +227,13 @@ func TestFetcherFetcherStop(t *testing.T) {
 
 	// check rdb and cleanup rdb
 	for _, fetcher := range app.Fetchers {
-		rdbResult, err := db.Get(ctx, "latestAggregate:"+fetcher.Name)
+		rdbResult, err := db.Get(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error reading from redis: %v", err)
 		}
 		assert.NotNil(t, rdbResult)
 
-		err = db.Del(ctx, "latestAggregate:"+fetcher.Name)
+		err = db.Del(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error removing from redis: %v", err)
 		}
@@ -420,7 +420,7 @@ func TestFetcherFetchAndInsertAdapter(t *testing.T) {
 			t.Fatalf("error cleaning up from db: %v", err)
 		}
 
-		rdbResult, err := db.Get(ctx, "latestAggregate:"+fetcher.Name)
+		rdbResult, err := db.Get(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error reading from redis: %v", err)
 		}
@@ -433,7 +433,7 @@ func TestFetcherFetchAndInsertAdapter(t *testing.T) {
 		assert.NotNil(t, redisAgg)
 		assert.NotNil(t, redisAgg.Value)
 
-		err = db.Del(ctx, "latestAggregate:"+fetcher.Name)
+		err = db.Del(ctx, "localAggregate:"+fetcher.Name)
 		if err != nil {
 			t.Fatalf("error removing from redis: %v", err)
 		}


### PR DESCRIPTION
# Description

As local aggregate values are passed from fetcher to aggregator through `redis`,

This PR is an update to store global aggregate values in `redis` to be passed to reporter. (reporter code updates will be followed)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced modularity in database operations, specifically for PostgreSQL and Redis.
- **New Features**
	- Introduced a new data type for Redis global aggregates.
- **Tests**
	- Improved test coverage by adding assertions for Redis results in global aggregate tests.
- **Chores**
	- Updated key strings for Redis operations to reflect local aggregate context.
	- Refined error handling and data processing in utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->