### PR TITLE
(OraklNode) Reporter updates

### DIFF
--- a/.github/workflows/node.test.yaml
+++ b/.github/workflows/node.test.yaml
@@ -94,4 +94,4 @@ jobs:
           PROVIDER_URL: "https://api.baobab.klaytn.net:8651"
           REPORTER_PK: ${{ secrets.TEST_DELEGATOR_REPORTER_PK}}
           TEST_FEE_PAYER_PK: ${{ secrets.DELEGATOR_FEEPAYER_PK}}
-          SUBMISSION_PROXY_CONTRACT: "0x8fb610c0Cc27Ca7726fad4c8696d09ca0E8eAee1"
+          SUBMISSION_PROXY_CONTRACT: "0xc9fC64584AcbF0f6bEb1819b1b6cd3F5aeFe34Ea"

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -3,8 +3,10 @@ package reporter
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/admin/reporter"
 	"bisonai.com/orakl/node/pkg/admin/utils"
@@ -15,7 +17,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING *`
+const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING name, value, round`
 const InsertAddressQuery = `INSERT INTO submission_addresses (name, address) VALUES (@name, @address) RETURNING *`
 
 type TestItems struct {
@@ -25,13 +27,21 @@ type TestItems struct {
 	tmpData    *TmpData
 }
 type TmpData struct {
-	globalAggregate   GlobalAggregateBase
+	globalAggregate   GlobalAggregate
 	submissionAddress SubmissionAddress
 }
 
 func insertSampleData(ctx context.Context) (*TmpData, error) {
 	var tmpData = new(TmpData)
-	tmpGlobalAggregate, err := db.QueryRow[GlobalAggregateBase](ctx, InsertGlobalAggregateQuery, map[string]any{"name": "test-aggregate", "value": int64(15), "round": int64(1)})
+
+	key := "globalAggregate:" + "test-aggregate"
+	data, err := json.Marshal(map[string]any{"value": int64(15), "round": int64(1)})
+	if err != nil {
+		return nil, err
+	}
+	db.Set(ctx, key, string(data), time.Duration(10*time.Second))
+
+	tmpGlobalAggregate, err := db.QueryRow[GlobalAggregate](ctx, InsertGlobalAggregateQuery, map[string]any{"name": "test-aggregate", "value": int64(15), "round": int64(1)})
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -24,13 +24,6 @@ type TestItems struct {
 	messageBus *bus.MessageBus
 	tmpData    *TmpData
 }
-
-type SubmissionAddress struct {
-	Id      int64  `db:"id"`
-	Name    string `db:"name"`
-	Address string `db:"address"`
-}
-
 type TmpData struct {
 	globalAggregate   GlobalAggregateBase
 	submissionAddress SubmissionAddress

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -96,7 +96,7 @@ func TestFilterInvalidAggregates(t *testing.T) {
 	result := testItems.app.Reporter.filterInvalidAggregates(aggregates)
 	assert.Equal(t, result, aggregates)
 
-	testItems.app.Reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	testItems.app.Reporter.SubmissionPairs = map[string]SubmissionPair{"test-aggregate": {LastSubmission: 1, Address: common.HexToAddress("0x1234")}}
 	result = testItems.app.Reporter.filterInvalidAggregates(aggregates)
 	assert.Equal(t, result, []GlobalAggregate{})
 }
@@ -118,7 +118,7 @@ func TestIsAggValid(t *testing.T) {
 	result := testItems.app.Reporter.isAggValid(agg)
 	assert.Equal(t, result, true)
 
-	testItems.app.Reporter.lastSubmissions = map[string]int64{"test-aggregate": 1}
+	testItems.app.Reporter.SubmissionPairs = map[string]SubmissionPair{"test-aggregate": {LastSubmission: 1, Address: common.HexToAddress("0x1234")}}
 	result = testItems.app.Reporter.isAggValid(agg)
 	assert.Equal(t, result, false)
 }

--- a/node/pkg/reporter/node_test.go
+++ b/node/pkg/reporter/node_test.go
@@ -3,6 +3,7 @@ package reporter
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -88,10 +89,9 @@ func TestFilterInvalidAggregates(t *testing.T) {
 	defer cleanup()
 	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
 	aggregates := []GlobalAggregate{{
-		Name:    "test-aggregate",
-		Value:   15,
-		Round:   1,
-		Address: "0x1234",
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
 	}}
 	result := testItems.app.Reporter.filterInvalidAggregates(aggregates)
 	assert.Equal(t, result, aggregates)
@@ -110,10 +110,9 @@ func TestIsAggValid(t *testing.T) {
 	defer cleanup()
 	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
 	agg := GlobalAggregate{
-		Name:    "test-aggregate",
-		Value:   15,
-		Round:   1,
-		Address: "0x1234",
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
 	}
 	result := testItems.app.Reporter.isAggValid(agg)
 	assert.Equal(t, result, true)
@@ -132,16 +131,54 @@ func TestMakeContractArgs(t *testing.T) {
 	defer cleanup()
 	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
 	agg := GlobalAggregate{
-		Name:    "test-aggregate",
-		Value:   15,
-		Round:   1,
-		Address: "0x1234",
+		Name:  "test-aggregate",
+		Value: 15,
+		Round: 1,
 	}
 	addresses, values, err := testItems.app.Reporter.makeContractArgs([]GlobalAggregate{agg})
 	if err != nil {
 		t.Fatal("error making contract args")
 	}
 
-	assert.Equal(t, addresses[0], common.HexToAddress(agg.Address))
+	assert.Equal(t, addresses[0], testItems.app.Reporter.SubmissionPairs[agg.Name].Address)
 	assert.Equal(t, values[0], big.NewInt(15))
+}
+
+func TestGetLatestGlobalAggregatesRdb(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+
+	result, err := testItems.app.Reporter.getLatestGlobalAggregatesRdb(ctx)
+	if err != nil {
+		t.Fatal("error getting latest global aggregates from rdb")
+	}
+
+	assert.Equal(t, result[0].Name, testItems.tmpData.globalAggregate.Name)
+	assert.Equal(t, result[0].Value, testItems.tmpData.globalAggregate.Value)
+}
+
+func TestGetLatestGlobalAggregatesPgsql(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+
+	result, err := testItems.app.Reporter.getLatestGlobalAggregatesPgsql(ctx)
+	if err != nil {
+		fmt.Println(err)
+		t.Fatal("error getting latest global aggregates from pgs")
+	}
+
+	assert.Equal(t, result[0].Name, testItems.tmpData.globalAggregate.Name)
+	assert.Equal(t, result[0].Value, testItems.tmpData.globalAggregate.Value)
 }

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -7,6 +7,7 @@ import (
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/raft"
 	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
+	"github.com/klaytn/klaytn/common"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 )
@@ -20,17 +21,25 @@ const (
 	MAX_RETRY_DELAY         = 500 * time.Millisecond
 	FUNCTION_STRING         = "batchSubmit(address[] memory _addresses, int256[] memory _prices)"
 
-	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
-		SELECT ga.name, ga.value, ga.round, ga.timestamp, sa.address
-		FROM global_aggregates ga
-		JOIN (
-			SELECT name, MAX(round) as max_round
-			FROM global_aggregates
-			GROUP BY name
-		) subq ON ga.name = subq.name AND ga.round = subq.max_round
-		INNER JOIN submission_addresses sa ON ga.name = sa.name;
+	GET_LATEST_GLOBAL_AGGREGATE_QUERY = `
+		SELECT value, round
+		FROM global_aggregates
+		WHERE name = @name
+		ORDER BY round DESC
+		LIMIT 1;
 	`
 )
+
+type SubmissionAddress struct {
+	Id      int    `db:"id"`
+	Name    string `db:"name"`
+	Address string `db:"address"`
+}
+
+type SubmissionPair struct {
+	LastSubmission int64 `db:"last_submission"`
+	Address        common.Address
+}
 
 type App struct {
 	Reporter *ReporterNode
@@ -40,10 +49,10 @@ type App struct {
 }
 
 type ReporterNode struct {
-	Raft     *raft.Raft
-	TxHelper *klaytn_helper.TxHelper
+	Raft            *raft.Raft
+	TxHelper        *klaytn_helper.TxHelper
+	SubmissionPairs map[string]SubmissionPair
 
-	lastSubmissions map[string]int64
 	contractAddress string
 
 	nodeCtx    context.Context
@@ -51,17 +60,8 @@ type ReporterNode struct {
 	isRunning  bool
 }
 
-type GlobalAggregateBase struct {
-	Name      string    `db:"name"`
-	Value     int64     `db:"value"`
-	Round     int64     `db:"round"`
-	Timestamp time.Time `db:"timestamp"`
-}
-
 type GlobalAggregate struct {
-	Name      string    `db:"name"`
-	Value     int64     `db:"value"`
-	Round     int64     `db:"round"`
-	Timestamp time.Time `db:"timestamp"`
-	Address   string    `db:"address"`
+	Name  string `db:"name" json:"name"`
+	Value int64  `db:"value" json:"value"`
+	Round int64  `db:"round" json:"round"`
 }


### PR DESCRIPTION
# Description

### Structure update

- Removed `lastSubmissions` element from reporter struct and added `submissionPairs` struct element which contains latestSubmission round and submission contract address
- Now stores submission addresses into the new struct on calling `NewNode()`

### Query update

- Since pairs with available contract addresses are saved in application struct variable, remove `submission_addresses` table join on loading latest global aggregate from pgsql
- Query generator based on pair name (`makeGetLatestGlobalAggregatesQuery`)

### Redis utilize

- Now first tries to get latest global aggregates through redis mget and try to get from pgsql if fails

### Minor updates

- Update test contract address for dummy submission

### Test code updates

- Related test code updates based on structure updates and function updates

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced data handling for global aggregates, including specific field returns.
	- Implemented submission pair tracking within the reporting functionality.
	- Added support for separate database query methods for Rdb and Pgsql in global aggregates retrieval.
- **Refactor**
	- Refactored the reporting node's job scheduling and aggregate validation logic.
	- Updated test structures and added new tests for database-specific aggregate retrieval.
- **Chores**
	- Updated workflow configuration with new `SUBMISSION_PROXY_CONTRACT` address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->