### PR TITLE
(OraklNode) add more sync options

### DIFF
--- a/node/pkg/admin/aggregator/queries.go
+++ b/node/pkg/admin/aggregator/queries.go
@@ -4,7 +4,7 @@ const (
 	InsertAggregator = `INSERT INTO aggregators (name) VALUES (@name) RETURNING *;`
 
 	UpsertAggregator = `INSERT INTO aggregators (name) VALUES (@name)
-	ON CONFILCT (name) DO UPDATE SET active = true
+	ON CONFLICT (name) DO UPDATE SET active = true
 	RETURNING *;`
 
 	GetAggregator = `SELECT * FROM aggregators;`

--- a/node/pkg/admin/aggregator/route.go
+++ b/node/pkg/admin/aggregator/route.go
@@ -16,6 +16,7 @@ func Routes(router fiber.Router) {
 
 	aggregator.Post("/sync/adapter", syncWithAdapter)
 	aggregator.Post("/sync/config", SyncFromOraklConfig)
+	aggregator.Post("/sync/config/:name", addFromOraklConfig)
 	aggregator.Get("/:id", getById)
 	aggregator.Delete("/:id", deleteById)
 	aggregator.Post("/activate/:id", activate)

--- a/node/pkg/admin/submissionAddress/queries.go
+++ b/node/pkg/admin/submissionAddress/queries.go
@@ -5,6 +5,8 @@ const (
 
 	UpsertSubmissionAddress = `INSERT INTO submission_addresses (name, address) VALUES (@name, @address) ON CONFLICT (name) DO UPDATE SET address = @address RETURNING *;`
 
+	GetAggregatorNames = `SELECT name FROM aggregators WHERE active = true;`
+
 	GetSubmissionAddress = `SELECT * FROM submission_addresses;`
 
 	GetSubmissionAddressById = `SELECT * FROM submission_addresses WHERE id = @id;`

--- a/node/pkg/admin/submissionAddress/route.go
+++ b/node/pkg/admin/submissionAddress/route.go
@@ -7,7 +7,9 @@ import (
 func Routes(router fiber.Router) {
 	submissionAddress := router.Group("/submission-address")
 
-	submissionAddress.Post("/sync", SyncFromOraklConfig)
+	submissionAddress.Post("/sync/aggregator", syncWithAggregator)
+	submissionAddress.Post("/sync/config", SyncFromOraklConfig)
+	submissionAddress.Post("/sync/config/:name", addFromOraklConfig)
 	submissionAddress.Post("", insert)
 	submissionAddress.Get("", get)
 	submissionAddress.Get("/:id", getById)


### PR DESCRIPTION
# Description

## Add more sync options

### Aggregator

- `addFromOraklConfig()`: adds entry to `aggregators` table if given name exists in orakl-config

### SubmissionAddress

- `syncWithAggregator()`: adds all entries which is inside `aggregators` table into `submission_addresses` table (adds only if exists in orakl config)
- `addFromOraklConfig()`: adds entry to `submission_addresses` table if given name exists in orakl-config

### Minor updates
- Test code for new functionalities are included
- fix typo in sql query

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for adding and syncing aggregators and submission addresses from Orakl configuration.
	- Added endpoints for syncing with an aggregator and adding data from Orakl config.
- **Bug Fixes**
	- Corrected a typo in the SQL query to ensure proper upsert operations for aggregators.
- **Tests**
	- Implemented new tests for aggregator synchronization and addition from Orakl config, including endpoint modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->