### PR TITLE
Push also latest tag when push image

### DIFF
--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -93,7 +93,9 @@ jobs:
 
       - name: Publish Image to ECR(api)
         run: |
-          docker push ${{ env.ecr_url }}:latest
+          if [ "${GITHUB_REF##*/}" == "master" ]; then
+            docker push ${{ env.ecr_url }}:latest
+          fi
           docker tag orakl-api ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/api.image+upload.yaml
+++ b/.github/workflows/api.image+upload.yaml
@@ -93,6 +93,7 @@ jobs:
 
       - name: Publish Image to ECR(api)
         run: |
+          docker push ${{ env.ecr_url }}:latest
           docker tag orakl-api ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/cli.image+upload.yaml
+++ b/.github/workflows/cli.image+upload.yaml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Publish Image to ECR(cli)
         run: |
+          docker push ${{ env.ecr_url }}:latest
           docker tag orakl-cli ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Publish Image to ECR(core)
         run: |
-          docker push ${{ env.ecr_url }}:latest
+          if [ "${GITHUB_REF##*/}" == "master" ]; then
+            docker push ${{ env.ecr_url }}:latest
+          fi
           docker tag orakl-core ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/core.image+upload.yaml
+++ b/.github/workflows/core.image+upload.yaml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Publish Image to ECR(core)
         run: |
+          docker push ${{ env.ecr_url }}:latest
           docker tag orakl-core ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/delegator.image+upload.yaml
+++ b/.github/workflows/delegator.image+upload.yaml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Publish Image to ECR(delegator)
         run: |
+          docker push ${{ env.ecr_url }}:latest
           docker tag orakl-delegator ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/delegator.image+upload.yaml
+++ b/.github/workflows/delegator.image+upload.yaml
@@ -90,7 +90,9 @@ jobs:
 
       - name: Publish Image to ECR(delegator)
         run: |
-          docker push ${{ env.ecr_url }}:latest
+          if [ "${GITHUB_REF##*/}" == "master" ]; then
+            docker push ${{ env.ecr_url }}:latest
+          fi
           docker tag orakl-delegator ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Publish Image to ECR(fetcher)
         run: |
+          docker push ${{ env.ecr_url }}:latest
           docker tag orakl-fetcher ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/fetcher.image+upload.yaml
+++ b/.github/workflows/fetcher.image+upload.yaml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Publish Image to ECR(fetcher)
         run: |
-          docker push ${{ env.ecr_url }}:latest
+          if [ "${GITHUB_REF##*/}" == "master" ]; then
+            docker push ${{ env.ecr_url }}:latest
+          fi
           docker tag orakl-fetcher ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 

--- a/.github/workflows/godelegator.image+upload.yaml
+++ b/.github/workflows/godelegator.image+upload.yaml
@@ -1,15 +1,13 @@
-name: CLI Deploy to Amazon ECR
+name: Go Delegator Deploy to Amazon ECR
 
 on:
   push:
     branches:
       - master
     paths:
-      - "cli/**"
-  workflow_dispatch:
-
+      - "go-delegator/**"
 env:
-  ecr_url: public.ecr.aws/bisonai/orakl-cli
+  ecr_url: public.ecr.aws/bisonai/orakl-godelegator
 
 jobs:
   prepare:
@@ -33,8 +31,8 @@ jobs:
       - name: Get package version
         id: package
         run: |
-          echo "version=$(node -p -e "require('./cli/package.json').version")" >> $GITHUB_OUTPUT
-
+          version=$(cat "./go-delegator/.version")
+          echo "version=${version}" >> $GITHUB_OUTPUT
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -51,8 +49,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Docker build orakl-cli
-        run: SERVICE_NAME=orakl-cli docker-compose -f docker-compose.build.yaml build
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.5"
+          check-latest: true
+          cache-dependency-path: |
+            ./go-delegator/go.sum
+
+      - name: Run lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54
+          working-directory: go-delegator
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=10m --skip-dirs=tests
+
+      - name: Run vet
+        run: |
+          cd ./go-delegator
+          go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+          go vet
+          go vet -vettool=$(which shadow)
+
+      - name: Docker build orakl-godelegator
+        run: SERVICE_NAME=orakl-godelegator docker-compose -f docker-compose.build.yaml build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -66,19 +88,19 @@ jobs:
         with:
           registry-type: public
 
-      - name: Publish Image to ECR(cli)
+      - name: Publish Image to ECR(delegator)
         run: |
           if [ "${GITHUB_REF##*/}" == "master" ]; then
             docker push ${{ env.ecr_url }}:latest
           fi
-          docker tag orakl-cli ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker tag orakl-godelegator ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
           docker push ${{ env.ecr_url }}:v${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
 
   create-helmchart-pr:
     needs: [prepare, build]
     uses: ./.github/workflows/create-helmchart-pr.yaml
     with:
-      project-name: "cli"
+      project-name: "godelegator"
       version: ${{ needs.prepare.outputs.version }}
       tag_date: ${{ needs.prepare.outputs.tag_date }}
       tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}

--- a/monitor/scripts/ecr-check.sh
+++ b/monitor/scripts/ecr-check.sh
@@ -79,8 +79,8 @@ check_tag() {
 
 # orakl-general has quite mixed set of tags, so we skip it
 # check_repository_tags "orakl-general"
-check_repository_tags "orakl-core" 5 "vrf" "request-response" "aggregator"
-check_repository_tags "orakl-api" 5 "api"
-check_repository_tags "orakl-cli" 5 "cli"
-check_repository_tags "orakl-fetcher" 5 "fetcher"
-check_repository_tags "orakl-delegator" 5 "delegator"
+check_repository_tags "orakl-core" 6 "vrf" "request-response" "aggregator"
+check_repository_tags "orakl-api" 6 "api"
+check_repository_tags "orakl-cli" 6 "cli"
+check_repository_tags "orakl-fetcher" 6 "fetcher"
+check_repository_tags "orakl-delegator" 6 "delegator"


### PR DESCRIPTION
# Description
The workflow still push image with formatted tag, but also push the latest tag.
And also, the ECR recognize image digest, so it'd push same image with different tag, it won't take any space.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.

## Deployment
- [x] Should publish Docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the continuous integration process by automating the push of the latest Docker images to the ECR repository across multiple components.
	- Updated version numbers in the `ecr-check.sh` script for specific repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->