### PR TITLE
(OraklNode) Use ticker instead of timer for leader job

### DIFF
--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -64,6 +64,7 @@ type Raft struct {
 	HeartbeatTimeout time.Duration
 
 	LeaderJobTimeout    time.Duration
+	LeaderJobTicker     *time.Ticker
 	HandleCustomMessage func(Message) error
 	LeaderJob           func() error
 }

--- a/node/taskfiles/taskfile.local.yml
+++ b/node/taskfiles/taskfile.local.yml
@@ -33,7 +33,7 @@ tasks:
   script-test-raft:
     dotenv: [".env"]
     cmds:
-      - go run ./script/test_raft_with_boot_api/main.go -p={{.P}}
+      - go run ./script/test_raft/main.go -p={{.P}}
 
   test-db:
     dotenv: [".env"]


### PR DESCRIPTION
# Description

There was an issue that leader job have not been working in regular basis

At the moment when there were new peer joining the group, the timer seemed to get broken and executed jobs in shorter basis.

This PR uses ticker instead of timer and it is not being reproduced after being implemented

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated leadership management in the Raft protocol for better timeout handling through the introduction of `LeaderJobTicker`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->