### PR TITLE
(OraklNode) Use ticker for boot api refresh goroutine

### DIFF
--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const REFRESH_INTERVAL = 30 * time.Second
+const REFRESH_INTERVAL = 60 * time.Second
 
 func Run(ctx context.Context) error {
 

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const REFRESH_INTERVAL = 60 * time.Second
+const REFRESH_INTERVAL = 30 * time.Second
 
 func Run(ctx context.Context) error {
 
@@ -39,18 +39,18 @@ func Run(ctx context.Context) error {
 		port = "8089"
 	}
 
-	refreshTimer := time.NewTimer(REFRESH_INTERVAL)
+	refreshTicker := time.NewTicker(REFRESH_INTERVAL)
 	go func() {
 		for {
 			select {
-			case <-refreshTimer.C:
+			case <-refreshTicker.C:
 				err = RefreshJob(ctx)
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to refresh peers")
 				}
 			case <-ctx.Done():
 				log.Debug().Msg("context cancelled")
-				refreshTimer.Stop()
+				refreshTicker.Stop()
 				return
 			}
 		}
@@ -72,6 +72,7 @@ func Run(ctx context.Context) error {
 }
 
 func RefreshJob(ctx context.Context) error {
+	log.Info().Msg("Refreshing peers")
 	peers, err := db.QueryRows[peer.PeerModel](ctx, peer.GetPeer, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to get peers")


### PR DESCRIPTION
# Description

### AS-IS
Even though timer was set, the timer wasn't reset inside go routine leading to only one time execution of refresh

### TO-BE
Use ticker to regularly execute refresh job

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the refresh interval for periodic job refreshing from 60 seconds to 30 seconds and switched from a timer to a ticker for more efficient operation.
	- Enhanced logging to include notifications when peers are being refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->