### PR TITLE
(OraklNode) Boot-api, check connection on sync request

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -19,9 +19,8 @@ TEST_FEE_PAYER_PK=
 # (optional) required to set private network
 PRIVATE_NETWORK_SECRET=
 
-# (optional) defaults to 8089, 9999 if not set
+# (optional) defaults to 8089 if not set
 BOOT_API_PORT=
-BOOT_LISTEN_PORT=
 
 # (optional) required if utilizing boot api, defaults to http://localhost:8089
 BOOT_API_URL=

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/boot/peer"
@@ -83,19 +82,7 @@ func RefreshJob(ctx context.Context) error {
 		return nil
 	}
 
-	bootPortStr := os.Getenv("BOOT_LISTEN_PORT")
-	if bootPortStr == "" {
-		log.Info().Msg("BOOT_PORT not set, defaulting to 10010")
-		bootPortStr = "10010"
-	}
-
-	bootPort, err := strconv.Atoi(bootPortStr)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert BOOT_PORT to int")
-		bootPort = 10010
-	}
-
-	h, err := libp2p_setup.MakeHost(bootPort)
+	h, err := libp2p_setup.MakeHost(0)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to make host")
 		return err

--- a/node/pkg/boot/peer/queries.go
+++ b/node/pkg/boot/peer/queries.go
@@ -3,11 +3,6 @@ package peer
 const (
 	InsertPeer = `INSERT INTO peers (ip, port, host_id) VALUES (@ip, @port, @host_id) RETURNING *;`
 
-	UpsertPeer = `
-		INSERT INTO peers (ip, port, host_id) VALUES (@ip, @port, @host_id)
-		ON CONFLICT (ip) DO UPDATE SET port = @port, host_id = @host_id RETURNING *;
-	`
-
 	GetPeer = `SELECT * FROM peers;`
 
 	DeletePeerById = `DELETE FROM peers WHERE id = @id RETURNING *;`

--- a/node/pkg/boot/tests/main_test.go
+++ b/node/pkg/boot/tests/main_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -52,7 +51,6 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 		return nil, err
 	}
 	tmpData.peer = tmpPeer
-	fmt.Println(tmpPeer)
 	return tmpData, nil
 }
 

--- a/node/pkg/boot/tests/peer_test.go
+++ b/node/pkg/boot/tests/peer_test.go
@@ -12,6 +12,8 @@ import (
 	"bisonai.com/orakl/node/pkg/boot/peer"
 	"bisonai.com/orakl/node/pkg/db"
 	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2p_utils "bisonai.com/orakl/node/pkg/libp2p/utils"
+
 	_peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
@@ -79,16 +81,35 @@ func TestSync(t *testing.T) {
 	}
 	defer cleanup()
 
+	mockHost1, err := libp2p_setup.MakeHost(0)
+	if err != nil {
+		t.Fatalf("error making host: %v", err)
+	}
+
+	mockHost2, err := libp2p_setup.MakeHost(0)
+	if err != nil {
+		t.Fatalf("error making host: %v", err)
+	}
+
+	ip1, port1, hostId1, err := libp2p_utils.ExtractPayloadFromHost(mockHost1)
+	if err != nil {
+		t.Fatalf("error extracting payload from host: %v", err)
+	}
+	ip2, port2, hostId2, err := libp2p_utils.ExtractPayloadFromHost(mockHost2)
+	if err != nil {
+		t.Fatalf("error extracting payload from host: %v", err)
+	}
+
 	mockPeer1 := peer.PeerInsertModel{
-		Ip:     "127.0.0.2",
-		Port:   10002,
-		HostId: "12DGKooWM8vWWqGPWWNCVPqb4tfqGrzx45W257GDBSeYbDSSLdef",
+		Ip:     ip1,
+		Port:   port1,
+		HostId: hostId1,
 	}
 
 	mockPeer2 := peer.PeerInsertModel{
-		Ip:     "127.0.0.3",
-		Port:   10003,
-		HostId: "12DGKooWM8vWWqGPWWNCVPqb4tfqGrzx45W257GDBSeYbDSSLghi",
+		Ip:     ip2,
+		Port:   port2,
+		HostId: hostId2,
 	}
 
 	syncResult, err := adminTests.PostRequest[[]peer.PeerModel](testItems.app, "/api/v1/peer/sync", mockPeer1)

--- a/node/pkg/libp2p/setup/setup.go
+++ b/node/pkg/libp2p/setup/setup.go
@@ -104,8 +104,11 @@ func MakeHost(listenPort int) (host.Host, error) {
 
 func makeHost(listenPort int, priv crypto.PrivKey) (host.Host, error) {
 	opts := []libp2p.Option{
-		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort)),
 		libp2p.Identity(priv),
+	}
+
+	if listenPort != 0 {
+		opts = append(opts, libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort)))
 	}
 
 	secretString := os.Getenv("PRIVATE_NETWORK_SECRET")


### PR DESCRIPTION
# Description

- Checks host connection on sync requested
- Make port param optional for libp2p host generation (if `0` is given use default setting)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced peer connectivity in the network with libp2p integration.

- **Bug Fixes**
	- Removed redundant database constant for peer updates.
	- Fixed default API port configuration to improve setup ease.

- **Refactor**
	- Simplified host port setup logic for better maintainability.
	- Updated peer management to utilize new libp2p utilities for efficiency.

- **Chores**
	- Cleaned up unnecessary debug prints in tests to enhance code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->