### PR TITLE
(OraklNode) Separate `chain` pkg from `pkg/utils`

### DIFF
--- a/node/pkg/chain/tests/chain_test.go
+++ b/node/pkg/chain/tests/chain_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
+	"bisonai.com/orakl/node/pkg/chain/tx"
+	chain_utils "bisonai.com/orakl/node/pkg/chain/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTxHelper(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -19,7 +20,7 @@ func TestNewTxHelper(t *testing.T) {
 
 func TestNextReporter(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -33,7 +34,7 @@ func TestNextReporter(t *testing.T) {
 
 func TestMakeDirectTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestMakeDirectTx(t *testing.T) {
 
 func TestMakeFeeDelegatedTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestMakeFeeDelegatedTx(t *testing.T) {
 
 func TestTxToHashToTx(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -72,10 +73,10 @@ func TestTxToHashToTx(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	hash := klaytn_helper.TxToHash(rawTx)
+	hash := chain_utils.TxToHash(rawTx)
 	assert.NotEqual(t, hash, "")
 
-	tx, err := klaytn_helper.HashToTx(hash)
+	tx, err := chain_utils.HashToTx(hash)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -85,13 +86,13 @@ func TestTxToHashToTx(t *testing.T) {
 
 func TestGenerateABI(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	defer txHelper.Close()
 
-	abi, err := klaytn_helper.GenerateABI("increment()")
+	abi, err := chain_utils.GenerateABI("increment()")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -101,7 +102,7 @@ func TestGenerateABI(t *testing.T) {
 
 func TestSubmitRawTxString(t *testing.T) {
 	ctx := context.Background()
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestSubmitRawTxString(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	rawTxString := klaytn_helper.TxToHash(signedTx)
+	rawTxString := chain_utils.TxToHash(signedTx)
 	err = txHelper.SubmitRawTxString(ctx, rawTxString)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/node/pkg/chain/tx/tx.go
+++ b/node/pkg/chain/tx/tx.go
@@ -1,0 +1,117 @@
+package tx
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"strings"
+
+	chain_utils "bisonai.com/orakl/node/pkg/chain/utils"
+	"bisonai.com/orakl/node/pkg/utils/request"
+
+	"github.com/klaytn/klaytn/blockchain/types"
+	"github.com/klaytn/klaytn/client"
+
+	"github.com/rs/zerolog/log"
+)
+
+type TxHelper struct {
+	client       *client.Client
+	wallets      []string
+	chainID      *big.Int
+	delegatorUrl string
+
+	lastUsed int
+}
+
+type signedTx struct {
+	SignedRawTx *string `json:"signedRawTx" db:"signedRawTx"`
+}
+
+func NewTxHelper(ctx context.Context) (*TxHelper, error) {
+	wallets, err := chain_utils.GetWallets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if os.Getenv("REPORTER_PK") != "" {
+		wallet := strings.TrimPrefix(os.Getenv("REPORTER_PK"), "0x")
+		wallets = append(wallets, wallet)
+	}
+
+	delegatorUrl := os.Getenv("DELEGATOR_URL")
+	providerUrl := os.Getenv("PROVIDER_URL")
+
+	client, err := client.Dial(providerUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	chainID, err := chain_utils.GetChainID(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TxHelper{
+		client:       client,
+		wallets:      wallets,
+		chainID:      chainID,
+		delegatorUrl: delegatorUrl,
+	}, nil
+}
+
+func (t *TxHelper) Close() {
+	t.client.Close()
+}
+
+func (t *TxHelper) GetSignedFromDelegator(tx *types.Transaction) (*types.Transaction, error) {
+	if t.delegatorUrl == "" {
+		return nil, errors.New("delegator url not set")
+	}
+
+	payload, err := chain_utils.MakePayload(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := request.UrlRequest[signedTx](t.delegatorUrl+"/api/v1/sign/volatile", "POST", payload, nil, "")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to request sign from delegator")
+		return nil, err
+	}
+
+	if result.SignedRawTx == nil {
+		return nil, errors.New("no signed raw tx")
+	}
+	return chain_utils.HashToTx(*result.SignedRawTx)
+}
+
+func (t *TxHelper) NextReporter() string {
+	if len(t.wallets) == 0 {
+		return ""
+	}
+	reporter := t.wallets[t.lastUsed]
+	t.lastUsed = (t.lastUsed + 1) % len(t.wallets)
+	return reporter
+}
+
+func (t *TxHelper) MakeDirectTx(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (*types.Transaction, error) {
+	return chain_utils.MakeDirectTx(ctx, t.client, contractAddressHex, t.NextReporter(), functionString, t.chainID, args...)
+}
+
+func (t *TxHelper) MakeFeeDelegatedTx(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (*types.Transaction, error) {
+	return chain_utils.MakeFeeDelegatedTx(ctx, t.client, contractAddressHex, t.NextReporter(), functionString, t.chainID, args...)
+}
+
+func (t *TxHelper) SubmitRawTx(ctx context.Context, tx *types.Transaction) error {
+	return chain_utils.SubmitRawTx(ctx, t.client, tx)
+}
+
+func (t *TxHelper) SubmitRawTxString(ctx context.Context, rawTx string) error {
+	return chain_utils.SubmitRawTxString(ctx, t.client, rawTx)
+}
+
+func (t *TxHelper) SignTxByFeePayer(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
+	return chain_utils.SignTxByFeePayer(ctx, t.client, tx, t.chainID)
+}

--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"time"
+)
+
+const (
+	DEFAULT_GAS_LIMIT    = uint64(1200000)
+	SELECT_WALLETS_QUERY = "SELECT * FROM wallets;"
+)
+
+type Wallet struct {
+	ID int64  `db:"id"`
+	PK string `db:"pk"`
+}
+
+type SignInsertPayload struct {
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Input    string `json:"input"`
+	Gas      string `json:"gas"`
+	Value    string `json:"value"`
+	ChainId  string `json:"chainId"`
+	GasPrice string `json:"gasPrice"`
+	Nonce    string `json:"nonce"`
+	V        string `json:"v"`
+	R        string `json:"r"`
+	S        string `json:"s"`
+	RawTx    string `json:"rawTx"`
+}
+
+type SignModel struct {
+	Id          int64     `json:"id" db:"transaction_id"`
+	Timestamp   time.Time `json:"timestamp" db:"timestamp"`
+	From        string    `json:"from" db:"from"`
+	To          string    `json:"to" db:"to"`
+	Input       string    `json:"input" db:"input"`
+	Gas         string    `json:"gas" db:"gas"`
+	Value       string    `json:"value" db:"value"`
+	ChainId     string    `json:"chainId" db:"chainId"`
+	GasPrice    string    `json:"gasPrice" db:"gasPrice"`
+	Nonce       string    `json:"nonce" db:"nonce"`
+	V           string    `json:"v" db:"v"`
+	R           string    `json:"r" db:"r"`
+	S           string    `json:"s" db:"s"`
+	RawTx       string    `json:"rawTx" db:"rawTx"`
+	SignedRawTx *string   `json:"signedRawTx" db:"signedRawTx"`
+	Succeed     *bool     `json:"succeed" db:"succeed"`
+	FunctionId  int64     `json:"functionId" db:"functionId"`
+	ContractId  int64     `json:"contractId" db:"contractId"`
+	ReporterId  int64     `json:"reporterId" db:"reporterId"`
+}

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -1,4 +1,4 @@
-package klaytn_helper
+package utils
 
 import (
 	"context"
@@ -9,10 +9,8 @@ import (
 	"math/big"
 	"os"
 	"strings"
-	"time"
 
 	"bisonai.com/orakl/node/pkg/db"
-	"bisonai.com/orakl/node/pkg/utils/request"
 
 	"github.com/klaytn/klaytn"
 	"github.com/klaytn/klaytn/accounts/abi"
@@ -26,162 +24,45 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const (
-	DEFAULT_GAS_LIMIT    = uint64(1200000)
-	SELECT_WALLETS_QUERY = "SELECT * FROM wallets;"
-)
-
-type Wallet struct {
-	ID int64  `db:"id"`
-	PK string `db:"pk"`
-}
-
-type TxHelper struct {
-	client       *client.Client
-	wallets      []string
-	chainID      *big.Int
-	delegatorUrl string
-
-	lastUsed int
-}
-
-type SignInsertPayload struct {
-	From     string `json:"from"`
-	To       string `json:"to"`
-	Input    string `json:"input"`
-	Gas      string `json:"gas"`
-	Value    string `json:"value"`
-	ChainId  string `json:"chainId"`
-	GasPrice string `json:"gasPrice"`
-	Nonce    string `json:"nonce"`
-	V        string `json:"v"`
-	R        string `json:"r"`
-	S        string `json:"s"`
-	RawTx    string `json:"rawTx"`
-}
-
-type SignModel struct {
-	Id          int64     `json:"id" db:"transaction_id"`
-	Timestamp   time.Time `json:"timestamp" db:"timestamp"`
-	From        string    `json:"from" db:"from"`
-	To          string    `json:"to" db:"to"`
-	Input       string    `json:"input" db:"input"`
-	Gas         string    `json:"gas" db:"gas"`
-	Value       string    `json:"value" db:"value"`
-	ChainId     string    `json:"chainId" db:"chainId"`
-	GasPrice    string    `json:"gasPrice" db:"gasPrice"`
-	Nonce       string    `json:"nonce" db:"nonce"`
-	V           string    `json:"v" db:"v"`
-	R           string    `json:"r" db:"r"`
-	S           string    `json:"s" db:"s"`
-	RawTx       string    `json:"rawTx" db:"rawTx"`
-	SignedRawTx *string   `json:"signedRawTx" db:"signedRawTx"`
-	Succeed     *bool     `json:"succeed" db:"succeed"`
-	FunctionId  int64     `json:"functionId" db:"functionId"`
-	ContractId  int64     `json:"contractId" db:"contractId"`
-	ReporterId  int64     `json:"reporterId" db:"reporterId"`
-}
-
-func NewTxHelper(ctx context.Context) (*TxHelper, error) {
-	wallets, err := getWallets(ctx)
+func MakePayload(tx *types.Transaction) (SignInsertPayload, error) {
+	rawFrom, err := tx.From()
 	if err != nil {
-		return nil, err
+		log.Error().Err(err).Msg("failed to get from")
+		return SignInsertPayload{}, err
 	}
 
-	if os.Getenv("REPORTER_PK") != "" {
-		wallet := strings.TrimPrefix(os.Getenv("REPORTER_PK"), "0x")
-		wallets = append(wallets, wallet)
+	from := strings.ToLower(rawFrom.Hex())
+	to := strings.ToLower(tx.To().Hex())
+	input := "0x" + hex.EncodeToString(tx.Data())
+	gas := fmt.Sprintf("0x%x", tx.Gas())
+	value := "0x" + tx.Value().String()
+	chainId := tx.ChainId()
+	gasPrice := "0x" + tx.GasPrice().String()
+	nonce := fmt.Sprintf("0x%x", tx.Nonce())
+
+	sig := tx.RawSignatureValues()
+	r := "0x" + sig[0].R.Text(16)
+	s := "0x" + sig[0].S.Text(16)
+	v := "0x" + sig[0].V.Text(16)
+
+	rawTx := "0x" + TxToHash(tx)
+
+	payload := SignInsertPayload{
+		From:     from,
+		To:       to,
+		Input:    input,
+		Gas:      gas,
+		Value:    value,
+		ChainId:  "0x" + chainId.Text(16),
+		GasPrice: gasPrice,
+		Nonce:    nonce,
+		V:        r,
+		R:        s,
+		S:        v,
+		RawTx:    rawTx,
 	}
 
-	if len(wallets) == 0 {
-		return nil, errors.New("no wallets found")
-	}
-
-	delegatorUrl := os.Getenv("DELEGATOR_URL")
-
-	return newTxHelper(ctx, os.Getenv("PROVIDER_URL"), wallets, delegatorUrl)
-}
-
-func newTxHelper(ctx context.Context, providerUrl string, reporterPKs []string, delegatorUrl string) (*TxHelper, error) {
-	if providerUrl == "" {
-		return nil, errors.New("provider url not set")
-	}
-
-	client, err := client.Dial(providerUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	chainID, err := getChainID(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(reporterPKs) == 0 {
-		return nil, errors.New("no wallets found")
-	}
-
-	return &TxHelper{
-		client:       client,
-		wallets:      reporterPKs,
-		chainID:      chainID,
-		delegatorUrl: delegatorUrl,
-	}, nil
-}
-
-func (t *TxHelper) Close() {
-	t.client.Close()
-}
-
-func (t *TxHelper) GetSignedFromDelegator(tx *types.Transaction) (*types.Transaction, error) {
-	if t.delegatorUrl == "" {
-		return nil, errors.New("delegator url not set")
-	}
-
-	payload, err := makeSignPayload(tx)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := request.UrlRequest[SignModel](t.delegatorUrl+"/api/v1/sign/volatile", "POST", payload, nil, "")
-	if err != nil {
-		log.Error().Err(err).Msg("failed to request sign from delegator")
-		return nil, err
-	}
-
-	if result.SignedRawTx == nil {
-		return nil, errors.New("no signed raw tx")
-	}
-	return HashToTx(*result.SignedRawTx)
-}
-
-func (t *TxHelper) NextReporter() string {
-	if len(t.wallets) == 0 {
-		return ""
-	}
-	reporter := t.wallets[t.lastUsed]
-	t.lastUsed = (t.lastUsed + 1) % len(t.wallets)
-	return reporter
-}
-
-func (t *TxHelper) MakeDirectTx(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (*types.Transaction, error) {
-	return makeDirectTx(ctx, t.client, contractAddressHex, t.NextReporter(), functionString, t.chainID, args...)
-}
-
-func (t *TxHelper) MakeFeeDelegatedTx(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (*types.Transaction, error) {
-	return makeFeeDelegatedTx(ctx, t.client, contractAddressHex, t.NextReporter(), functionString, t.chainID, args...)
-}
-
-func (t *TxHelper) SubmitRawTx(ctx context.Context, tx *types.Transaction) error {
-	return submitRawTx(ctx, t.client, tx)
-}
-
-func (t *TxHelper) SubmitRawTxString(ctx context.Context, rawTx string) error {
-	return submitRawTxString(ctx, t.client, rawTx)
-}
-
-func (t *TxHelper) SignTxByFeePayer(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
-	return signTxByFeePayer(ctx, t.client, tx, t.chainID)
+	return payload, nil
 }
 
 func TxToHash(tx *types.Transaction) string {
@@ -253,11 +134,7 @@ func GenerateABI(functionString string) (*abi.ABI, error) {
 	return &parsedABI, nil
 }
 
-func getChainID(ctx context.Context, client *client.Client) (*big.Int, error) {
-	return client.NetworkID(ctx)
-}
-
-func getWallets(ctx context.Context) ([]string, error) {
+func GetWallets(ctx context.Context) ([]string, error) {
 	reporterModels, err := db.QueryRows[Wallet](ctx, SELECT_WALLETS_QUERY, nil)
 	if err != nil {
 		return nil, err
@@ -271,7 +148,11 @@ func getWallets(ctx context.Context) ([]string, error) {
 	return wallets, nil
 }
 
-func makeDirectTx(ctx context.Context, client *client.Client, contractAddressHex string, reporter string, functionString string, chainID *big.Int, args ...interface{}) (*types.Transaction, error) {
+func GetChainID(ctx context.Context, client *client.Client) (*big.Int, error) {
+	return client.NetworkID(ctx)
+}
+
+func MakeDirectTx(ctx context.Context, client *client.Client, contractAddressHex string, reporter string, functionString string, chainID *big.Int, args ...interface{}) (*types.Transaction, error) {
 	abi, err := GenerateABI(functionString)
 	if err != nil {
 		return nil, err
@@ -324,7 +205,7 @@ func makeDirectTx(ctx context.Context, client *client.Client, contractAddressHex
 	return types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 }
 
-func makeFeeDelegatedTx(ctx context.Context, client *client.Client, contractAddressHex string, reporter string, functionString string, chainID *big.Int, args ...interface{}) (*types.Transaction, error) {
+func MakeFeeDelegatedTx(ctx context.Context, client *client.Client, contractAddressHex string, reporter string, functionString string, chainID *big.Int, args ...interface{}) (*types.Transaction, error) {
 	abi, err := GenerateABI(functionString)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to generate abi")
@@ -393,7 +274,7 @@ func makeFeeDelegatedTx(ctx context.Context, client *client.Client, contractAddr
 	return types.SignTx(unsigned, types.NewEIP155Signer(chainID), privateKey)
 }
 
-func signTxByFeePayer(ctx context.Context, client *client.Client, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+func SignTxByFeePayer(ctx context.Context, client *client.Client, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
 	feePayer := strings.TrimPrefix(os.Getenv("TEST_FEE_PAYER_PK"), "0x")
 	feePayerPrivateKey, err := crypto.HexToECDSA(feePayer)
 	if err != nil {
@@ -406,7 +287,7 @@ func signTxByFeePayer(ctx context.Context, client *client.Client, tx *types.Tran
 		return nil, errors.New("error casting public key to ECDSA")
 	}
 
-	updatedTx, err := updateFeePayer(tx, crypto.PubkeyToAddress(*publicKeyECDSA))
+	updatedTx, err := UpdateFeePayer(tx, crypto.PubkeyToAddress(*publicKeyECDSA))
 	if err != nil {
 		return nil, err
 	}
@@ -414,8 +295,7 @@ func signTxByFeePayer(ctx context.Context, client *client.Client, tx *types.Tran
 	return types.SignTxAsFeePayer(updatedTx, types.NewEIP155Signer(chainID), feePayerPrivateKey)
 }
 
-func submitRawTx(ctx context.Context, client *client.Client, tx *types.Transaction) error {
-
+func SubmitRawTx(ctx context.Context, client *client.Client, tx *types.Transaction) error {
 	err := client.SendTransaction(ctx, tx)
 	if err != nil {
 		return err
@@ -429,7 +309,7 @@ func submitRawTx(ctx context.Context, client *client.Client, tx *types.Transacti
 	return nil
 }
 
-func submitRawTxString(ctx context.Context, client *client.Client, rawTx string) error {
+func SubmitRawTxString(ctx context.Context, client *client.Client, rawTx string) error {
 	rawTxBytes, err := hex.DecodeString(rawTx)
 	if err != nil {
 		return err
@@ -442,10 +322,10 @@ func submitRawTxString(ctx context.Context, client *client.Client, rawTx string)
 		return err
 	}
 
-	return submitRawTx(ctx, client, tx)
+	return SubmitRawTx(ctx, client, tx)
 }
 
-func updateFeePayer(tx *types.Transaction, feePayer common.Address) (*types.Transaction, error) {
+func UpdateFeePayer(tx *types.Transaction, feePayer common.Address) (*types.Transaction, error) {
 	from, err := tx.From()
 	if err != nil {
 		return nil, err
@@ -471,45 +351,4 @@ func updateFeePayer(tx *types.Transaction, feePayer common.Address) (*types.Tran
 
 	newTx.SetSignature(tx.GetTxInternalData().RawSignatureValues())
 	return newTx, err
-}
-
-func makeSignPayload(tx *types.Transaction) (SignInsertPayload, error) {
-	rawFrom, err := tx.From()
-	if err != nil {
-		log.Error().Err(err).Msg("failed to get from")
-		return SignInsertPayload{}, err
-	}
-
-	from := strings.ToLower(rawFrom.Hex())
-	to := strings.ToLower(tx.To().Hex())
-	input := "0x" + hex.EncodeToString(tx.Data())
-	gas := fmt.Sprintf("0x%x", tx.Gas())
-	value := "0x" + tx.Value().String()
-	chainId := tx.ChainId()
-	gasPrice := "0x" + tx.GasPrice().String()
-	nonce := fmt.Sprintf("0x%x", tx.Nonce())
-
-	sig := tx.RawSignatureValues()
-	r := "0x" + sig[0].R.Text(16)
-	s := "0x" + sig[0].S.Text(16)
-	v := "0x" + sig[0].V.Text(16)
-
-	rawTx := "0x" + TxToHash(tx)
-
-	payload := SignInsertPayload{
-		From:     from,
-		To:       to,
-		Input:    input,
-		Gas:      gas,
-		Value:    value,
-		ChainId:  "0x" + chainId.Text(16),
-		GasPrice: gasPrice,
-		Nonce:    nonce,
-		V:        r,
-		R:        s,
-		S:        v,
-		RawTx:    rawTx,
-	}
-
-	return payload, nil
 }

--- a/node/pkg/reporter/node.go
+++ b/node/pkg/reporter/node.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"bisonai.com/orakl/node/pkg/chain/tx"
 	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/raft"
-	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 
 	"github.com/klaytn/klaytn/common"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -29,7 +29,7 @@ func NewNode(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*ReporterNode
 	}
 
 	raft := raft.NewRaftNode(h, ps, topic, MESSAGE_BUFFER, LEADER_TIMEOUT)
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/chain/tx"
 	"bisonai.com/orakl/node/pkg/raft"
-	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
 	"github.com/klaytn/klaytn/common"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -54,7 +54,7 @@ type App struct {
 
 type ReporterNode struct {
 	Raft            *raft.Raft
-	TxHelper        *klaytn_helper.TxHelper
+	TxHelper        *tx.TxHelper
 	SubmissionPairs map[string]SubmissionPair
 
 	contractAddress string

--- a/node/script/test_submission/main.go
+++ b/node/script/test_submission/main.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"math/big"
 
-	"bisonai.com/orakl/node/pkg/utils/klaytn_helper"
+	"bisonai.com/orakl/node/pkg/chain/tx"
 	"github.com/rs/zerolog/log"
 )
 
 // send single submission through this script
 
 func testContractDelegatedCall(ctx context.Context, contractAddress string, contractFunction string, args ...interface{}) error {
-	txHelper, err := klaytn_helper.NewTxHelper(ctx)
+	txHelper, err := tx.NewTxHelper(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("NewTxHelper")
 		return err

--- a/node/taskfiles/taskfile.local.yml
+++ b/node/taskfiles/taskfile.local.yml
@@ -70,6 +70,10 @@ tasks:
     dotenv: [".env"]
     cmds:
       - go test ./pkg/boot/tests -v
+  test-chain:
+    dotenv: [".env"]
+    cmds:
+      - go test ./pkg/chain/tests -v
   test:
     cmds:
       - task: test-db
@@ -81,3 +85,4 @@ tasks:
       - task: test-aggregator
       - task: test-reporter
       - task: test-boot
+      - task: test-chain


### PR DESCRIPTION
# Description

Moves `klaytn helper` inside `utils` into `chain` pkg for modularity.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the transaction handling and ABI generation functionality across various modules to use the new `tx` package and `chain_utils`.
- **New Features**
	- Introduced a `TxHelper` struct for enhanced transaction management in blockchain applications.
	- Added utility types and constants for wallet operations and transaction signing.
- **Bug Fixes**
	- Removed unused constants, types, and methods to streamline transaction-related utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->