### PR TITLE
(Maintenance) Update return type for hash endpoint

### DIFF
--- a/api/adapter/controller.go
+++ b/api/adapter/controller.go
@@ -26,6 +26,13 @@ type AdapterInsertModel struct {
 	Feeds       []feed.FeedInsertModel `json:"feeds"`
 }
 
+type HashInsertModel struct {
+	AdapterHash string                           `db:"adapter_hash" json:"adapterHash"`
+	Name        string                           `db:"name" json:"name" validate:"required"`
+	Decimals    *utils.CustomInt32               `db:"decimals" json:"decimals" validate:"required"`
+	Feeds       []feed.FeedWithoutAdapterIdModel `json:"feeds"`
+}
+
 type AdapterModel struct {
 	AdapterId   *utils.CustomInt64 `db:"adapter_id" json:"id"`
 	AdapterHash string             `db:"adapter_hash" json:"adapterHash"`
@@ -93,7 +100,7 @@ func hash(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	var payload AdapterInsertModel
+	var payload HashInsertModel
 
 	if err := c.BodyParser(&payload); err != nil {
 		panic(err)
@@ -104,7 +111,7 @@ func hash(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	err = computeAdapterHash(&payload, verify)
+	err = computeAdapterHashForHashRoute(&payload, verify)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
 	}
@@ -138,6 +145,24 @@ func deleteById(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(result)
+}
+
+func computeAdapterHashForHashRoute(data *HashInsertModel, verify bool) error {
+	input := AdapterHashModel{data.Name, data.Decimals, data.Feeds}
+	out, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("failed to compute adapter hash: %s", err.Error())
+	}
+
+	hash := crypto.Keccak256Hash([]byte(out))
+	hashString := fmt.Sprintf("0x%x", hash)
+	if verify && data.AdapterHash != hashString {
+		hashComputeErr := fmt.Errorf("hashes do not match!\nexpected %s, received %s", hashString, data.AdapterHash)
+		return fmt.Errorf("failed to compute adapter hash: %s", hashComputeErr.Error())
+	}
+
+	data.AdapterHash = hashString
+	return nil
 }
 
 func computeAdapterHash(data *AdapterInsertModel, verify bool) error {


### PR DESCRIPTION
# Description

now /api/v1/adapter/hash endpoint returns value without adapter id included for each feeds

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
