### PR TITLE
(OraklNode) Set timeout for tx mined, add more logs

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -91,9 +91,9 @@ func main() {
 		defer wg.Done()
 
 		a := aggregator.New(mb, host, ps)
-		aaggreegatorErr := a.Run(ctx)
-		if aaggreegatorErr != nil {
-			log.Error().Err(aaggreegatorErr).Msg("Failed to start aggregator")
+		aggregatorErr := a.Run(ctx)
+		if aggregatorErr != nil {
+			log.Error().Err(aggregatorErr).Msg("Failed to start aggregator")
 			return
 		}
 	}()

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/db"
 
@@ -341,7 +342,10 @@ func SubmitRawTx(ctx context.Context, client ClientInterface, tx *types.Transact
 		return err
 	}
 
-	receipt, err := bind.WaitMined(ctx, client, tx)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	receipt, err := bind.WaitMined(ctxWithTimeout, client, tx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

reporter stopped from baobab test with following last tx
https://baobab.klaytnfinder.io/tx/0x3efc3fdfdc3a6e09311cb8a9c07541ce44a0e8b605b3112b0c7da1c3be1a6ebb

And there have been no further logs from reporter after following last log
```
{
insertId: "sbtk1btp66cec4jm"
jsonPayload: {
Player: "Reporter"
error: "nonce too low"
level: "error"
message: "reporting directly"
}
labels: {5}
logName: "projects/orakl-baobab-prod/logs/stderr"
receiveTimestamp: "2024-04-03T07:56:05.888280349Z"
resource: {2}
severity: "ERROR"
timestamp: "2024-04-03T07:56:03Z"
}
```

if it worked as expected, there should have been more logs after failure and logs with retries, but it didn't happen. Assuming it is hanging infinitely somewhere, this PR tries to implement timeout on waiting tx to be mined

- Additionally, it has minor updates adding more logs and fixing typo

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and variable naming in the node initialization process.
- **New Features**
	- Enhanced transaction submission with a timeout feature to improve reliability.
- **Improvements**
	- Updated job failure handling with dynamic timeouts and added detailed logging for debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->