### PR TITLE
(OraklNode) Include heartbeat on loading addresses

### DIFF
--- a/node/migrations/000011_submission_interval.down.sql
+++ b/node/migrations/000011_submission_interval.down.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'submission_addresses'
+        AND column_name = 'interval'
+    ) THEN
+        ALTER TABLE submission_addresses
+        DROP COLUMN interval;
+    END IF;
+END $$;

--- a/node/migrations/000011_submission_interval.up.sql
+++ b/node/migrations/000011_submission_interval.up.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'submission_addresses'
+        AND column_name = 'interval'
+    ) THEN
+        ALTER TABLE submission_addresses
+        ADD COLUMN interval int4;
+    END IF;
+END $$;

--- a/node/pkg/admin/submissionAddress/controller.go
+++ b/node/pkg/admin/submissionAddress/controller.go
@@ -14,14 +14,16 @@ import (
 )
 
 type SubmissionAddressModel struct {
-	Id      *int64 `db:"id" json:"id"`
-	Name    string `db:"name" json:"name"`
-	Address string `db:"address" json:"address"`
+	Id       *int64 `db:"id" json:"id"`
+	Name     string `db:"name" json:"name"`
+	Address  string `db:"address" json:"address"`
+	Interval *int   `db:"interval" json:"heartbeat"`
 }
 
 type SubmissionAddressInsertModel struct {
-	Name    string `db:"name" json:"name" validate:"required"`
-	Address string `db:"address" json:"address" validate:"required"`
+	Name     string `db:"name" json:"name" validate:"required"`
+	Address  string `db:"address" json:"address" validate:"required"`
+	Interval *int   `db:"interval" json:"heartbeat"`
 }
 
 type BulkAddresses struct {
@@ -212,8 +214,9 @@ func updateById(c *fiber.Ctx) error {
 
 func insertSubmissionAddress(ctx context.Context, address SubmissionAddressInsertModel) (SubmissionAddressModel, error) {
 	result, err := db.QueryRow[SubmissionAddressModel](ctx, UpsertSubmissionAddress, map[string]any{
-		"name":    address.Name,
-		"address": address.Address,
+		"name":     address.Name,
+		"address":  address.Address,
+		"interval": address.Interval,
 	})
 	if err != nil {
 		return SubmissionAddressModel{}, err

--- a/node/pkg/admin/submissionAddress/queries.go
+++ b/node/pkg/admin/submissionAddress/queries.go
@@ -1,9 +1,9 @@
 package submissionAddress
 
 const (
-	InsertSubmissionAddress = `INSERT INTO submission_addresses (name, address) VALUES (@name, @address) RETURNING *;`
+	InsertSubmissionAddress = `INSERT INTO submission_addresses (name, address, interval) VALUES (@name, @address, @interval) RETURNING *;`
 
-	UpsertSubmissionAddress = `INSERT INTO submission_addresses (name, address) VALUES (@name, @address) ON CONFLICT (name) DO UPDATE SET address = @address RETURNING *;`
+	UpsertSubmissionAddress = `INSERT INTO submission_addresses (name, address, interval) VALUES (@name, @address, @interval) ON CONFLICT (name) DO UPDATE SET address = @address, interval = @interval RETURNING *;`
 
 	GetAggregatorNames = `SELECT name FROM aggregators WHERE active = true;`
 

--- a/node/pkg/admin/tests/main_test.go
+++ b/node/pkg/admin/tests/main_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 
@@ -104,7 +105,7 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 	}
 	tmpData.wallet = tmpWallet
 
-	tmpSubmissionAddress, err := db.QueryRow[submissionAddress.SubmissionAddressModel](ctx, submissionAddress.InsertSubmissionAddress, map[string]any{"name": "test_submission_address", "address": "test_address"})
+	tmpSubmissionAddress, err := db.QueryRow[submissionAddress.SubmissionAddressModel](ctx, submissionAddress.InsertSubmissionAddress, map[string]any{"name": "test_submission_address", "address": "test_address", "interval": sql.NullInt32{Valid: false}})
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -206,7 +206,7 @@ func (n *Aggregator) insertGlobalAggregate(value int64, round int64) error {
 }
 
 func (n *Aggregator) insertPgsql(ctx context.Context, value int64, round int64) error {
-	return db.QueryWithoutResult(n.nodeCtx, InsertGlobalAggregateQuery, map[string]any{"name": n.Name, "value": value, "round": round})
+	return db.QueryWithoutResult(ctx, InsertGlobalAggregateQuery, map[string]any{"name": n.Name, "value": value, "round": round})
 }
 
 func (n *Aggregator) insertRdb(ctx context.Context, value int64, round int64) error {

--- a/node/pkg/aggregator/app_test.go
+++ b/node/pkg/aggregator/app_test.go
@@ -61,7 +61,7 @@ func TestStartAggregator(t *testing.T) {
 			t.Logf("Cleanup failed: %v", cleanupErr)
 		}
 
-		if aggregatorStopErr := testItems.app.stopAggregatorById(ctx, testItems.tmpData.aggregator.ID); aggregatorStopErr != nil {
+		if aggregatorStopErr := testItems.app.stopAggregatorById(testItems.tmpData.aggregator.ID); aggregatorStopErr != nil {
 			t.Logf("error stopping aggregator: %v", aggregatorStopErr)
 		}
 	}()
@@ -130,7 +130,7 @@ func TestStopAggregator(t *testing.T) {
 	}
 	assert.Equal(t, true, testItems.app.Aggregators[testItems.tmpData.aggregator.ID].isRunning)
 
-	err = testItems.app.stopAggregator(ctx, testItems.app.Aggregators[testItems.tmpData.aggregator.ID])
+	err = testItems.app.stopAggregator(testItems.app.Aggregators[testItems.tmpData.aggregator.ID])
 	if err != nil {
 		t.Fatal("error stopping aggregator")
 	}
@@ -159,7 +159,7 @@ func TestStopAggregatorById(t *testing.T) {
 		t.Fatal("error starting aggregator")
 	}
 
-	err = testItems.app.stopAggregatorById(ctx, testItems.app.Aggregators[testItems.tmpData.aggregator.ID].AggregatorModel.ID)
+	err = testItems.app.stopAggregatorById(testItems.app.Aggregators[testItems.tmpData.aggregator.ID].AggregatorModel.ID)
 	if err != nil {
 		t.Fatal("error stopping aggregator")
 	}

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -69,6 +69,10 @@ func (r *Raft) subscribe(ctx context.Context) {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to subscribe to topic")
 	}
+	defer func() {
+		sub.Cancel()
+		r.Topic.Close()
+	}()
 	for {
 		select {
 		case <-ctx.Done():

--- a/node/pkg/reporter/app_test.go
+++ b/node/pkg/reporter/app_test.go
@@ -26,7 +26,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("error running reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }
 
 func TestStopReporter(t *testing.T) {
@@ -46,12 +46,12 @@ func TestStopReporter(t *testing.T) {
 		t.Fatal("error running reporter")
 	}
 
-	err = testItems.app.stopReporter()
+	err = testItems.app.stopReporters()
 	if err != nil {
 		t.Fatal("error stopping reporter")
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, false)
 }
 
 func TestStopReporterByAdmin(t *testing.T) {
@@ -78,7 +78,7 @@ func TestStopReporterByAdmin(t *testing.T) {
 		t.Fatalf("error activating reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, false)
 }
 
 func TestStartReporterByAdmin(t *testing.T) {
@@ -94,14 +94,17 @@ func TestStartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+	err = testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	if err != nil {
+		t.Fatalf("error setting reporters: %v", err)
+	}
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {
 		t.Fatalf("error activating reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }
 
 func TestRestartReporterByAdmin(t *testing.T) {
@@ -119,7 +122,10 @@ func TestRestartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+	err = testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	if err != nil {
+		t.Fatalf("error setting reporters: %v", err)
+	}
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {
@@ -131,5 +137,5 @@ func TestRestartReporterByAdmin(t *testing.T) {
 		t.Fatalf("error refreshing reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -23,15 +23,7 @@ const (
 	MAX_RETRY_DELAY         = 500 * time.Millisecond
 	FUNCTION_STRING         = "submit(address[] memory _feeds, int256[] memory _submissions)"
 
-	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
-		SELECT ga.name, ga.value, ga.round, ga.timestamp, sa.address
-		FROM global_aggregates ga
-		JOIN (
-			SELECT name, MAX(round) as max_round
-			FROM global_aggregates
-			GROUP BY name
-		) subq ON ga.name = subq.name AND ga.round = subq.max_round
-		INNER JOIN submission_addresses sa ON ga.name = sa.name;`
+	GET_SUBMISSIONS_QUERY = `SELECT * FROM submission_addresses;`
 )
 
 type SubmissionAddress struct {
@@ -47,16 +39,17 @@ type SubmissionPair struct {
 }
 
 type App struct {
-	Reporter *Reporter
-	Bus      *bus.MessageBus
-	Host     host.Host
-	Pubsub   *pubsub.PubSub
+	Reporters []*Reporter
+	Bus       *bus.MessageBus
+	Host      host.Host
+	Pubsub    *pubsub.PubSub
 }
 
 type Reporter struct {
-	Raft            *raft.Raft
-	KlaytnHelper    *helper.ChainHelper
-	SubmissionPairs map[string]SubmissionPair
+	Raft               *raft.Raft
+	KlaytnHelper       *helper.ChainHelper
+	SubmissionPairs    map[string]SubmissionPair
+	SubmissionInterval time.Duration
 
 	contractAddress string
 

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -35,9 +35,10 @@ const (
 )
 
 type SubmissionAddress struct {
-	Id      int    `db:"id"`
-	Name    string `db:"name"`
-	Address string `db:"address"`
+	Id       int    `db:"id"`
+	Name     string `db:"name"`
+	Address  string `db:"address"`
+	Interval *int   `db:"interval"`
 }
 
 type SubmissionPair struct {


### PR DESCRIPTION
# Description

Load submission intervals from admin to utilize from reporter
-> code utilizing this data will be updated from further PR

- Add column `interval` to table `submission_addresses`
- Update unittests, type, query related to table updates

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced an "interval" field to the submission addresses, allowing for enhanced data tracking and management.
- **Database Changes**
	- Added scripts for creating and removing the "interval" column in the `submission_addresses` table.
- **Code Enhancements**
	- Updated models and queries in the submission address management system to support the new "interval" field.
- **Tests**
	- Modified test setup to include the "interval" field in sample data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->