### PR TITLE
(OraklNode) multiple submission intervals

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -206,7 +206,7 @@ func (n *Aggregator) insertGlobalAggregate(value int64, round int64) error {
 }
 
 func (n *Aggregator) insertPgsql(ctx context.Context, value int64, round int64) error {
-	return db.QueryWithoutResult(n.nodeCtx, InsertGlobalAggregateQuery, map[string]any{"name": n.Name, "value": value, "round": round})
+	return db.QueryWithoutResult(ctx, InsertGlobalAggregateQuery, map[string]any{"name": n.Name, "value": value, "round": round})
 }
 
 func (n *Aggregator) insertRdb(ctx context.Context, value int64, round int64) error {

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -55,9 +55,9 @@ func (a *App) clearAggregators() error {
 	}
 	for _, aggregator := range a.Aggregators {
 		if aggregator.isRunning {
-			err := a.stopAggregator(context.Background(), aggregator)
+			err := a.stopAggregator(aggregator)
 			if err != nil {
-				log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to stop aggregator")
+				log.Error().Str("Player", "Aggregator").Err(err).Msgf("Failed to stop aggregator with ID: %d", aggregator.ID)
 				return err
 			}
 		}
@@ -131,7 +131,7 @@ func (a *App) startAllAggregators(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) stopAggregator(ctx context.Context, aggregator *Aggregator) error {
+func (a *App) stopAggregator(aggregator *Aggregator) error {
 	log.Debug().Str("Player", "Aggregator").Str("name", aggregator.Name).Msg("stopping aggregator")
 	if !aggregator.isRunning {
 		log.Debug().Str("Player", "Aggregator").Str("name", aggregator.Name).Msg("aggregator already stopped")
@@ -145,17 +145,17 @@ func (a *App) stopAggregator(ctx context.Context, aggregator *Aggregator) error 
 	return nil
 }
 
-func (a *App) stopAggregatorById(ctx context.Context, id int64) error {
+func (a *App) stopAggregatorById(id int64) error {
 	aggregator, ok := a.Aggregators[id]
 	if !ok {
 		return errors.New("aggregator not found")
 	}
-	return a.stopAggregator(ctx, aggregator)
+	return a.stopAggregator(aggregator)
 }
 
-func (a *App) stopAllAggregators(ctx context.Context) error {
+func (a *App) stopAllAggregators() error {
 	for _, aggregator := range a.Aggregators {
-		err := a.stopAggregator(ctx, aggregator)
+		err := a.stopAggregator(aggregator)
 		if err != nil {
 			log.Error().Str("Player", "Aggregator").Err(err).Str("name", aggregator.Name).Msg("failed to stop aggregator")
 			return err
@@ -242,7 +242,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		}
 
 		log.Debug().Str("Player", "Aggregator").Int64("aggregatorId", aggregatorId).Msg("deactivating aggregator")
-		err = a.stopAggregatorById(ctx, aggregatorId)
+		err = a.stopAggregatorById(aggregatorId)
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to stop aggregator")
 			return
@@ -254,7 +254,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			return
 		}
 		log.Debug().Str("Player", "Aggregator").Msg("refresh aggregator msg received")
-		err := a.stopAllAggregators(ctx)
+		err := a.stopAllAggregators()
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to stop all aggregators")
 			return
@@ -276,7 +276,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			return
 		}
 		log.Debug().Str("Player", "Aggregator").Msg("stop aggregator msg received")
-		err := a.stopAllAggregators(ctx)
+		err := a.stopAllAggregators()
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to stop all aggregators")
 			return

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -37,7 +37,7 @@ func (a *App) Run(ctx context.Context) error {
 func (a *App) setAggregators(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
 	err := a.clearAggregators()
 	if err != nil {
-		log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to clear aggregators")
+		log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to clear aggregators in setAggregators method")
 		return err
 	}
 

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -318,12 +318,3 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		}
 	}
 }
-
-func aggregatorIdExists(aggregators []AggregatorModel, id int64) bool {
-	for _, aggregator := range aggregators {
-		if aggregator.ID == id {
-			return true
-		}
-	}
-	return false
-}

--- a/node/pkg/aggregator/app_test.go
+++ b/node/pkg/aggregator/app_test.go
@@ -61,7 +61,7 @@ func TestStartAggregator(t *testing.T) {
 			t.Logf("Cleanup failed: %v", cleanupErr)
 		}
 
-		if aggregatorStopErr := testItems.app.stopAggregatorById(ctx, testItems.tmpData.aggregator.ID); aggregatorStopErr != nil {
+		if aggregatorStopErr := testItems.app.stopAggregatorById(testItems.tmpData.aggregator.ID); aggregatorStopErr != nil {
 			t.Logf("error stopping aggregator: %v", aggregatorStopErr)
 		}
 	}()
@@ -130,7 +130,7 @@ func TestStopAggregator(t *testing.T) {
 	}
 	assert.Equal(t, true, testItems.app.Aggregators[testItems.tmpData.aggregator.ID].isRunning)
 
-	err = testItems.app.stopAggregator(ctx, testItems.app.Aggregators[testItems.tmpData.aggregator.ID])
+	err = testItems.app.stopAggregator(testItems.app.Aggregators[testItems.tmpData.aggregator.ID])
 	if err != nil {
 		t.Fatal("error stopping aggregator")
 	}
@@ -159,7 +159,7 @@ func TestStopAggregatorById(t *testing.T) {
 		t.Fatal("error starting aggregator")
 	}
 
-	err = testItems.app.stopAggregatorById(ctx, testItems.app.Aggregators[testItems.tmpData.aggregator.ID].AggregatorModel.ID)
+	err = testItems.app.stopAggregatorById(testItems.app.Aggregators[testItems.tmpData.aggregator.ID].AggregatorModel.ID)
 	if err != nil {
 		t.Fatal("error stopping aggregator")
 	}

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -69,6 +69,7 @@ func (r *Raft) subscribe(ctx context.Context) {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to subscribe to topic")
 	}
+	defer sub.Cancel()
 	for {
 		select {
 		case <-ctx.Done():

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -69,7 +69,10 @@ func (r *Raft) subscribe(ctx context.Context) {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to subscribe to topic")
 	}
-	defer sub.Cancel()
+	defer func() {
+		sub.Cancel()
+		r.Topic.Close()
+	}()
 	for {
 		select {
 		case <-ctx.Done():

--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/db"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
@@ -12,64 +13,91 @@ import (
 
 func New(bus *bus.MessageBus, h host.Host, ps *pubsub.PubSub) *App {
 	return &App{
-		Reporter: &Reporter{},
-		Bus:      bus,
-		Host:     h,
-		Pubsub:   ps,
+		Reporters: []*Reporter{},
+		Bus:       bus,
+		Host:      h,
+		Pubsub:    ps,
 	}
 }
 
 func (a *App) Run(ctx context.Context) error {
-	err := a.setReporter(ctx, a.Host, a.Pubsub)
+	err := a.setReporters(ctx, a.Host, a.Pubsub)
 	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to set reporter")
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to set reporters")
 		return err
 	}
-
 	a.subscribe(ctx)
 
-	return a.startReporter(ctx)
+	return a.startReporters(ctx)
 }
 
-func (a *App) setReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
-	reporter, err := NewReporter(ctx, h, ps)
+func (a *App) setReporters(ctx context.Context, h host.Host, ps *pubsub.PubSub) error {
+	err := a.clearReporters()
 	if err != nil {
-		return err
-	}
-	a.Reporter = reporter
-	return nil
-}
-
-func (a *App) startReporter(ctx context.Context) error {
-	if a.Reporter.isRunning {
-		log.Debug().Str("Player", "Reporter").Msg("reporter already running")
-		return errors.New("reporter already running")
-	}
-
-	err := a.Reporter.SetKlaytnHelper(ctx)
-	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to set klaytn helper")
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to clear reporters")
 		return err
 	}
 
-	nodeCtx, cancel := context.WithCancel(ctx)
-	a.Reporter.nodeCtx = nodeCtx
-	a.Reporter.nodeCancel = cancel
-	a.Reporter.isRunning = true
+	submissionPairs, err := getSubmissionPairs(ctx)
+	if err != nil {
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to get submission pairs")
+		return err
+	}
 
-	go a.Reporter.Run(nodeCtx)
+	groupedSubmissionPairs := groupSubmissionPairsByIntervals(submissionPairs)
+
+	for groupInterval, pairs := range groupedSubmissionPairs {
+		reporter, err := NewReporter(ctx, h, ps, pairs, groupInterval)
+		if err != nil {
+			log.Error().Str("Player", "Reporter").Err(err).Msg("failed to set reporter")
+			return err
+		}
+		a.Reporters = append(a.Reporters, reporter)
+	}
 	return nil
 }
 
-func (a *App) stopReporter() error {
-	if !a.Reporter.isRunning {
-		log.Debug().Str("Player", "Reporter").Msg("reporter not running")
-		return errors.New("reporter not running")
+func (a *App) clearReporters() error {
+	if a.Reporters == nil {
+		return nil
 	}
+	for _, reporter := range a.Reporters {
+		if reporter.isRunning {
+			err := stopReporter(reporter)
+			if err != nil {
+				log.Error().Str("Player", "Reporter").Err(err).Msg("failed to stop reporter")
+				return err
+			}
+		}
+		err := reporter.Raft.Topic.Close()
+		if err != nil {
+			log.Error().Str("Player", "Reporter").Err(err).Msg("failed to close topic")
+			return err
+		}
+	}
+	a.Reporters = make([]*Reporter, 0)
+	return nil
+}
 
-	a.Reporter.nodeCancel()
-	a.Reporter.isRunning = false
-	a.Reporter.KlaytnHelper.Close()
+func (a *App) startReporters(ctx context.Context) error {
+	for _, reporter := range a.Reporters {
+		err := startReporter(ctx, reporter)
+		if err != nil {
+			log.Error().Str("Player", "Reporter").Err(err).Msg("failed to start reporter")
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *App) stopReporters() error {
+	for _, reporter := range a.Reporters {
+		err := stopReporter(reporter)
+		if err != nil {
+			log.Error().Str("Player", "Reporter").Err(err).Msg("failed to stop reporter")
+			return err
+		}
+	}
 	return nil
 }
 
@@ -103,7 +131,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			bus.HandleMessageError(errors.New("non-admin"), msg, "reporter received message from non-admin")
 			return
 		}
-		err := a.startReporter(ctx)
+		err := a.startReporters(ctx)
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to start reporter")
 			return
@@ -114,7 +142,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			bus.HandleMessageError(errors.New("non-admin"), msg, "reporter received message from non-admin")
 			return
 		}
-		err := a.stopReporter()
+		err := a.stopReporters()
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to stop reporter")
 			return
@@ -125,13 +153,19 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			bus.HandleMessageError(errors.New("non-admin"), msg, "reporter received message from non-admin")
 			return
 		}
-		err := a.stopReporter()
+		err := a.stopReporters()
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to stop reporter")
 			return
 		}
 
-		err = a.startReporter(ctx)
+		err = a.setReporters(ctx, a.Host, a.Pubsub)
+		if err != nil {
+			bus.HandleMessageError(err, msg, "failed to set reporters")
+			return
+		}
+
+		err = a.startReporters(ctx)
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to start reporter")
 			return
@@ -139,4 +173,58 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		msg.Response <- bus.MessageResponse{Success: true}
 	}
 
+}
+
+func startReporter(ctx context.Context, reporter *Reporter) error {
+	if reporter.isRunning {
+		log.Debug().Str("Player", "Reporter").Msg("reporter already running")
+		return errors.New("reporter already running")
+	}
+
+	err := reporter.SetKlaytnHelper(ctx)
+	if err != nil {
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to set klaytn helper")
+		return err
+	}
+
+	nodeCtx, cancel := context.WithCancel(ctx)
+	reporter.nodeCtx = nodeCtx
+	reporter.nodeCancel = cancel
+	reporter.isRunning = true
+
+	go reporter.Run(nodeCtx)
+	return nil
+}
+
+func stopReporter(reporter *Reporter) error {
+	if !reporter.isRunning {
+		log.Debug().Str("Player", "Reporter").Msg("reporter not running")
+		return errors.New("reporter not running")
+	}
+
+	reporter.nodeCancel()
+	reporter.isRunning = false
+	reporter.KlaytnHelper.Close()
+	return nil
+}
+
+func getSubmissionPairs(ctx context.Context) ([]SubmissionAddress, error) {
+	submissionAddresses, err := db.QueryRows[SubmissionAddress](ctx, "SELECT * FROM submission_addresses;", nil)
+	if err != nil {
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to load submission addresses")
+		return nil, err
+	}
+	return submissionAddresses, nil
+}
+
+func groupSubmissionPairsByIntervals(submissionAddresses []SubmissionAddress) map[int][]SubmissionAddress {
+	grouped := make(map[int][]SubmissionAddress)
+	for _, sa := range submissionAddresses {
+		var interval = 5000
+		if sa.Interval != nil || *sa.Interval > 0 {
+			interval = *sa.Interval
+		}
+		grouped[interval] = append(grouped[interval], sa)
+	}
+	return grouped
 }

--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -69,11 +69,6 @@ func (a *App) clearReporters() error {
 				return err
 			}
 		}
-		err := reporter.Raft.Topic.Close()
-		if err != nil {
-			log.Error().Str("Player", "Reporter").Err(err).Msg("failed to close topic")
-			return err
-		}
 	}
 	a.Reporters = make([]*Reporter, 0)
 	return nil

--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
@@ -62,6 +63,7 @@ func (a *App) setReporters(ctx context.Context, h host.Host, ps *pubsub.PubSub) 
 		return errors.New("no reporters set")
 	}
 
+	log.Info().Str("Player", "Reporter").Msgf("%d reporters set", len(a.Reporters))
 	return nil
 }
 
@@ -189,7 +191,15 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		}
 		msg.Response <- bus.MessageResponse{Success: true}
 	}
+}
 
+func (a *App) GetReporterWithInterval(interval int) (*Reporter, error) {
+	for _, reporter := range a.Reporters {
+		if reporter.SubmissionInterval == time.Duration(interval)*time.Millisecond {
+			return reporter, nil
+		}
+	}
+	return nil, errors.New("reporter not found")
 }
 
 func startReporter(ctx context.Context, reporter *Reporter) error {

--- a/node/pkg/reporter/app_test.go
+++ b/node/pkg/reporter/app_test.go
@@ -26,7 +26,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("error running reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }
 
 func TestStopReporter(t *testing.T) {
@@ -46,12 +46,12 @@ func TestStopReporter(t *testing.T) {
 		t.Fatal("error running reporter")
 	}
 
-	err = testItems.app.stopReporter()
+	err = testItems.app.stopReporters()
 	if err != nil {
 		t.Fatal("error stopping reporter")
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, false)
 }
 
 func TestStopReporterByAdmin(t *testing.T) {
@@ -78,7 +78,7 @@ func TestStopReporterByAdmin(t *testing.T) {
 		t.Fatalf("error activating reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, false)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, false)
 }
 
 func TestStartReporterByAdmin(t *testing.T) {
@@ -94,14 +94,14 @@ func TestStartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+	testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {
 		t.Fatalf("error activating reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }
 
 func TestRestartReporterByAdmin(t *testing.T) {
@@ -119,7 +119,7 @@ func TestRestartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporter(ctx, testItems.app.Host, testItems.app.Pubsub)
+	testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {
@@ -131,5 +131,5 @@ func TestRestartReporterByAdmin(t *testing.T) {
 		t.Fatalf("error refreshing reporter: %v", err)
 	}
 
-	assert.Equal(t, testItems.app.Reporter.isRunning, true)
+	assert.Equal(t, testItems.app.Reporters[0].isRunning, true)
 }

--- a/node/pkg/reporter/app_test.go
+++ b/node/pkg/reporter/app_test.go
@@ -94,7 +94,10 @@ func TestStartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	err = testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	if err != nil {
+		t.Fatalf("error setting reporters: %v", err)
+	}
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {
@@ -119,7 +122,10 @@ func TestRestartReporterByAdmin(t *testing.T) {
 	}()
 
 	testItems.app.subscribe(ctx)
-	testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	err = testItems.app.setReporters(ctx, testItems.app.Host, testItems.app.Pubsub)
+	if err != nil {
+		t.Fatalf("error setting reporters: %v", err)
+	}
 
 	_, err = tests.RawPostRequest(testItems.admin, "/api/v1/reporter/activate", nil)
 	if err != nil {

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -20,6 +20,7 @@ import (
 
 const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING name, value, round`
 const InsertAddressQuery = `INSERT INTO submission_addresses (name, address, interval) VALUES (@name, @address, @interval) RETURNING *`
+const TestInterval = 15000
 
 type TestItems struct {
 	app        *App
@@ -47,17 +48,27 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 		return nil, err
 	}
 
+	err = db.QueryWithoutResult(ctx, aggregator.InsertAggregator, map[string]any{"name": "test-aggregate2"})
+	if err != nil {
+		return nil, err
+	}
+
 	tmpGlobalAggregate, err := db.QueryRow[GlobalAggregate](ctx, InsertGlobalAggregateQuery, map[string]any{"name": "test-aggregate", "value": int64(15), "round": int64(1)})
 	if err != nil {
 		return nil, err
 	}
 	tmpData.globalAggregate = tmpGlobalAggregate
 
-	tmpAddress, err := db.QueryRow[SubmissionAddress](ctx, InsertAddressQuery, map[string]any{"name": "test-aggregate", "address": "0x1234", "interval": 15000})
+	tmpAddress, err := db.QueryRow[SubmissionAddress](ctx, InsertAddressQuery, map[string]any{"name": "test-aggregate", "address": "0x1234", "interval": TestInterval})
 	if err != nil {
 		return nil, err
 	}
 	tmpData.submissionAddress = tmpAddress
+
+	_, err = db.QueryRow[SubmissionAddress](ctx, InsertAddressQuery, map[string]any{"name": "test-aggregate2", "address": "0x1234", "interval": 20000})
+	if err != nil {
+		return nil, err
+	}
 
 	return tmpData, nil
 }

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (name, value, round) VALUES (@name, @value, @round) RETURNING name, value, round`
-const InsertAddressQuery = `INSERT INTO submission_addresses (name, address) VALUES (@name, @address) RETURNING *`
+const InsertAddressQuery = `INSERT INTO submission_addresses (name, address, interval) VALUES (@name, @address, @interval) RETURNING *`
 
 type TestItems struct {
 	app        *App
@@ -53,7 +53,7 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 	}
 	tmpData.globalAggregate = tmpGlobalAggregate
 
-	tmpAddress, err := db.QueryRow[SubmissionAddress](ctx, InsertAddressQuery, map[string]any{"name": "test-aggregate", "address": "0x1234"})
+	tmpAddress, err := db.QueryRow[SubmissionAddress](ctx, InsertAddressQuery, map[string]any{"name": "test-aggregate", "address": "0x1234", "interval": 15000})
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/big"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,16 +21,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*Reporter, error) {
-	topicString := TOPIC_STRING
-
+func NewReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub, submissionPairs []SubmissionAddress, interval int) (*Reporter, error) {
+	topicString := TOPIC_STRING + "-" + strconv.Itoa(interval)
 	topic, err := ps.Join(topicString)
 	if err != nil {
 		log.Error().Str("Player", "Reporter").Err(err).Msg("Failed to join topic")
 		return nil, err
 	}
 
-	raft := raft.NewRaftNode(h, ps, topic, MESSAGE_BUFFER, LEADER_TIMEOUT)
+	raft := raft.NewRaftNode(h, ps, topic, MESSAGE_BUFFER, time.Duration(interval)*time.Millisecond)
 
 	contractAddress := os.Getenv("SUBMISSION_PROXY_CONTRACT")
 	if contractAddress == "" {
@@ -40,11 +40,12 @@ func NewReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub) (*Reporter
 		Raft:            raft,
 		contractAddress: contractAddress,
 	}
-	err = reporter.loadSubmissionPairs(ctx)
-	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to load submission pairs")
-		return nil, err
+
+	reporter.SubmissionPairs = make(map[string]SubmissionPair)
+	for _, sa := range submissionPairs {
+		reporter.SubmissionPairs[sa.Name] = SubmissionPair{LastSubmission: 0, Address: common.HexToAddress(sa.Address)}
 	}
+
 	reporter.Raft.LeaderJob = reporter.leaderJob
 	reporter.Raft.HandleCustomMessage = reporter.handleCustomMessage
 
@@ -77,7 +78,6 @@ func (r *Reporter) retry(job func() error) error {
 }
 
 func (r *Reporter) leaderJob() error {
-	log.Debug().Str("Player", "Reporter").Msg("reporting")
 	start := time.Now()
 	r.Raft.IncreaseTerm()
 	ctx := context.Background()
@@ -91,7 +91,7 @@ func (r *Reporter) leaderJob() error {
 
 		validAggregates := r.filterInvalidAggregates(aggregates)
 		if len(validAggregates) == 0 {
-			log.Error().Str("Player", "Reporter").Msg("no valid aggregates to report")
+			log.Warn().Str("Player", "Reporter").Msg("no valid aggregates to report")
 			return nil
 		}
 
@@ -263,27 +263,6 @@ func (r *Reporter) makeContractArgs(aggregates []GlobalAggregate) ([]common.Addr
 	}
 
 	return addresses, values, nil
-}
-
-func (r *Reporter) loadSubmissionPairs(ctx context.Context) error {
-	if r.SubmissionPairs == nil {
-		r.SubmissionPairs = make(map[string]SubmissionPair)
-	}
-
-	submissionAddresses, err := db.QueryRows[SubmissionAddress](ctx, "SELECT * FROM submission_addresses;", nil)
-	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to load submission addresses")
-		return err
-	}
-
-	if len(submissionAddresses) == 0 {
-		log.Warn().Str("Player", "Reporter").Msg("no submission addresses found")
-	}
-
-	for _, sa := range submissionAddresses {
-		r.SubmissionPairs[sa.Name] = SubmissionPair{LastSubmission: 0, Address: common.HexToAddress(sa.Address)}
-	}
-	return nil
 }
 
 func (r *Reporter) SetKlaytnHelper(ctx context.Context) error {

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -23,16 +23,7 @@ const (
 	MAX_RETRY_DELAY         = 500 * time.Millisecond
 	FUNCTION_STRING         = "submit(address[] memory _feeds, int256[] memory _submissions)"
 
-	GET_SUBMISSIONS_QUERY              = `SELECT * FROM submission_addresses;`
-	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
-		SELECT ga.name, ga.value, ga.round, ga.timestamp, sa.address
-		FROM global_aggregates ga
-		JOIN (
-			SELECT name, MAX(round) as max_round
-			FROM global_aggregates
-			GROUP BY name
-		) subq ON ga.name = subq.name AND ga.round = subq.max_round
-		INNER JOIN submission_addresses sa ON ga.name = sa.name;`
+	GET_SUBMISSIONS_QUERY = `SELECT * FROM submission_addresses;`
 )
 
 type SubmissionAddress struct {

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -23,6 +23,7 @@ const (
 	MAX_RETRY_DELAY         = 500 * time.Millisecond
 	FUNCTION_STRING         = "submit(address[] memory _feeds, int256[] memory _submissions)"
 
+	GET_SUBMISSIONS_QUERY              = `SELECT * FROM submission_addresses;`
 	GET_LATEST_GLOBAL_AGGREGATES_QUERY = `
 		SELECT ga.name, ga.value, ga.round, ga.timestamp, sa.address
 		FROM global_aggregates ga
@@ -47,16 +48,17 @@ type SubmissionPair struct {
 }
 
 type App struct {
-	Reporter *Reporter
-	Bus      *bus.MessageBus
-	Host     host.Host
-	Pubsub   *pubsub.PubSub
+	Reporters []*Reporter
+	Bus       *bus.MessageBus
+	Host      host.Host
+	Pubsub    *pubsub.PubSub
 }
 
 type Reporter struct {
-	Raft            *raft.Raft
-	KlaytnHelper    *helper.ChainHelper
-	SubmissionPairs map[string]SubmissionPair
+	Raft               *raft.Raft
+	KlaytnHelper       *helper.ChainHelper
+	SubmissionPairs    map[string]SubmissionPair
+	SubmissionInterval time.Duration
 
 	contractAddress string
 


### PR DESCRIPTION
# Description


- Reporter app now holds multiple reporters instead of single reporter
- Each reporters will have different submission intervals
- Updated unit tests based on the update

### minor updates

- Add `clearAggregators()` and `clearReporters()` functions to be called before initialization
- Update raft code to close subscription and topic on ctx cancel has been called

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the aggregator to use context more efficiently in database operations.
	- Improved resource management in the Raft protocol implementation with cleanup operations.
	- Upgraded the reporting system to support multiple reporters, increasing modularity and scalability.

- **Bug Fixes**
	- Fixed issues with aggregator initialization and cleanup to ensure smoother operation.

- **Refactor**
	- Consolidated and optimized reporter management functions.
	- Updated reporter initialization to handle submission pairs and intervals more effectively.

- **Tests**
	- Adapted unit tests to accommodate changes in the reporting system's structure and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->