### PR TITLE
(OraklNode) Multiple json rpc support

### DIFF
--- a/node/migrations/000012_provider_urls.down.sql
+++ b/node/migrations/000012_provider_urls.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS provider_urls;

--- a/node/migrations/000012_provider_urls.up.sql
+++ b/node/migrations/000012_provider_urls.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS provider_urls (
+    id SERIAL PRIMARY KEY,
+    chain TEXT NOT NULL,
+    chain_id INT NOT NULL,
+    url TEXT NOT NULL,
+    priority INT
+)

--- a/node/migrations/000012_provider_urls.up.sql
+++ b/node/migrations/000012_provider_urls.up.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS provider_urls (
     id SERIAL PRIMARY KEY,
-    chain TEXT NOT NULL,
     chain_id INT NOT NULL,
     url TEXT NOT NULL,
     priority INT

--- a/node/pkg/admin/providerUrl/controller.go
+++ b/node/pkg/admin/providerUrl/controller.go
@@ -8,14 +8,12 @@ import (
 
 type ProviderUrlModel struct {
 	Id       *int64 `db:"id" json:"id"`
-	Chain    string `db:"chain" json:"chain"`
 	ChainId  *int   `db:"chain_id" json:"chain_id"`
 	Url      string `db:"url" json:"url"`
 	Priority *int   `db:"priority" json:"priority"`
 }
 
 type ProviderUrlInsertModel struct {
-	Chain    string `db:"chain" json:"chain" validate:"required"`
 	ChainId  *int   `db:"chain_id" json:"chain_id" validate:"required"`
 	Url      string `db:"url" json:"url" validate:"required"`
 	Priority *int   `db:"priority" json:"priority"`
@@ -33,7 +31,6 @@ func insert(c *fiber.Ctx) error {
 	}
 
 	result, err := db.QueryRow[ProviderUrlModel](c.Context(), InsertProviderUrl, map[string]any{
-		"chain":    payload.Chain,
 		"chain_id": payload.ChainId,
 		"url":      payload.Url,
 		"priority": payload.Priority,

--- a/node/pkg/admin/providerUrl/controller.go
+++ b/node/pkg/admin/providerUrl/controller.go
@@ -1,0 +1,71 @@
+package providerUrl
+
+import (
+	"bisonai.com/orakl/node/pkg/db"
+	"github.com/go-playground/validator"
+	"github.com/gofiber/fiber/v2"
+)
+
+type ProviderUrlModel struct {
+	Id       *int64 `db:"id" json:"id"`
+	Chain    string `db:"chain" json:"chain"`
+	ChainId  *int   `db:"chain_id" json:"chain_id"`
+	Url      string `db:"url" json:"url"`
+	Priority *int   `db:"priority" json:"priority"`
+}
+
+type ProviderUrlInsertModel struct {
+	Chain    string `db:"chain" json:"chain" validate:"required"`
+	ChainId  *int   `db:"chain_id" json:"chain_id" validate:"required"`
+	Url      string `db:"url" json:"url" validate:"required"`
+	Priority *int   `db:"priority" json:"priority"`
+}
+
+func insert(c *fiber.Ctx) error {
+	payload := new(ProviderUrlInsertModel)
+	if err := c.BodyParser(payload); err != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to parse body for provider insert payload: " + err.Error())
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(payload); err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString("failed to validate provider insert payload: " + err.Error())
+	}
+
+	result, err := db.QueryRow[ProviderUrlModel](c.Context(), InsertProviderUrl, map[string]any{
+		"chain":    payload.Chain,
+		"chain_id": payload.ChainId,
+		"url":      payload.Url,
+		"priority": payload.Priority,
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute provider insert query: " + err.Error())
+	}
+	return c.JSON(result)
+}
+
+func get(c *fiber.Ctx) error {
+	results, err := db.QueryRows[ProviderUrlModel](c.Context(), GetProviderUrl, nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute provider get query: " + err.Error())
+	}
+	return c.JSON(results)
+}
+
+func getById(c *fiber.Ctx) error {
+	id := c.Params("id")
+	result, err := db.QueryRow[ProviderUrlModel](c.Context(), GetProviderUrlById, map[string]any{"id": id})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute provider get by id query: " + err.Error())
+	}
+	return c.JSON(result)
+}
+
+func deleteById(c *fiber.Ctx) error {
+	id := c.Params("id")
+	result, err := db.QueryRow[ProviderUrlModel](c.Context(), DeleteProviderUrlById, map[string]any{"id": id})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to execute provider delete by id query: " + err.Error())
+	}
+	return c.JSON(result)
+}

--- a/node/pkg/admin/providerUrl/queries.go
+++ b/node/pkg/admin/providerUrl/queries.go
@@ -1,0 +1,8 @@
+package providerUrl
+
+const (
+	InsertProviderUrl     = `INSERT INTO provider_urls (chain, chain_id, url, priority) VALUES (@chain, @chain_id, @url, @priority) RETURNING *;`
+	GetProviderUrl        = `SELECT * FROM provider_urls;`
+	GetProviderUrlById    = `SELECT * FROM provider_urls WHERE id = @id;`
+	DeleteProviderUrlById = `DELETE FROM provider_urls WHERE id = @id RETURNING *;`
+)

--- a/node/pkg/admin/providerUrl/queries.go
+++ b/node/pkg/admin/providerUrl/queries.go
@@ -1,7 +1,7 @@
 package providerUrl
 
 const (
-	InsertProviderUrl     = `INSERT INTO provider_urls (chain, chain_id, url, priority) VALUES (@chain, @chain_id, @url, @priority) RETURNING *;`
+	InsertProviderUrl     = `INSERT INTO provider_urls (chain_id, url, priority) VALUES (@chain_id, @url, @priority) RETURNING *;`
 	GetProviderUrl        = `SELECT * FROM provider_urls;`
 	GetProviderUrlById    = `SELECT * FROM provider_urls WHERE id = @id;`
 	DeleteProviderUrlById = `DELETE FROM provider_urls WHERE id = @id RETURNING *;`

--- a/node/pkg/admin/providerUrl/route.go
+++ b/node/pkg/admin/providerUrl/route.go
@@ -1,0 +1,14 @@
+package providerUrl
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func Routes(router fiber.Router) {
+	providerUrls := router.Group("/provider-url")
+
+	providerUrls.Post("", insert)
+	providerUrls.Get("", get)
+	providerUrls.Get("/:id", getById)
+	providerUrls.Delete("/:id", deleteById)
+}

--- a/node/pkg/admin/tests/aggregator_test.go
+++ b/node/pkg/admin/tests/aggregator_test.go
@@ -299,4 +299,7 @@ func TestAggregatorAddFromOraklConfig(t *testing.T) {
 
 	// cleanup
 	_, err = db.QueryRow[aggregator.AggregatorModel](context.Background(), "DELETE FROM aggregators;", nil)
+	if err != nil {
+		t.Fatalf("error cleaning up test: %v", err)
+	}
 }

--- a/node/pkg/admin/tests/main_test.go
+++ b/node/pkg/admin/tests/main_test.go
@@ -114,7 +114,7 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 	}
 	tmpData.submissionAddress = tmpSubmissionAddress
 
-	tmpProviderUrl, err := db.QueryRow[providerUrl.ProviderUrlModel](ctx, providerUrl.InsertProviderUrl, map[string]any{"chain": "test_chain", "chain_id": 1, "url": "test_url", "priority": 1})
+	tmpProviderUrl, err := db.QueryRow[providerUrl.ProviderUrlModel](ctx, providerUrl.InsertProviderUrl, map[string]any{"chain_id": 1, "url": "test_url", "priority": 1})
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/admin/tests/providerUrl_test.go
+++ b/node/pkg/admin/tests/providerUrl_test.go
@@ -22,7 +22,6 @@ func TestProviderUrlInsert(t *testing.T) {
 	testChainId := 1
 
 	mockProviderUrl1 := providerUrl.ProviderUrlInsertModel{
-		Chain:   "test_provider_chain_1",
 		ChainId: &testChainId,
 		Url:     "test_provider_url_1",
 	}

--- a/node/pkg/admin/tests/providerUrl_test.go
+++ b/node/pkg/admin/tests/providerUrl_test.go
@@ -1,0 +1,111 @@
+//nolint:all
+package tests
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/admin/providerUrl"
+	"bisonai.com/orakl/node/pkg/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderUrlInsert(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	testChainId := 1
+
+	mockProviderUrl1 := providerUrl.ProviderUrlInsertModel{
+		Chain:   "test_provider_chain_1",
+		ChainId: &testChainId,
+		Url:     "test_provider_url_1",
+	}
+
+	readResultBefore, err := GetRequest[[]providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls before: %v", err)
+	}
+
+	_, err = PostRequest[providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", mockProviderUrl1)
+	if err != nil {
+		t.Fatalf("error inserting provider url: %v", err)
+	}
+
+	readResultAfter, err := GetRequest[[]providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls after: %v", err)
+	}
+
+	assert.Greaterf(t, len(readResultAfter), len(readResultBefore), "expected to have more provider urls after insertion")
+
+	//cleanup
+	err = db.QueryWithoutResult(ctx, "DELETE FROM provider_urls;", nil)
+	if err != nil {
+		t.Fatalf("error cleaning up test: %v", err)
+	}
+}
+
+func TestProviderUrlGet(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	readResult, err := GetRequest[[]providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls: %v", err)
+	}
+
+	assert.Greater(t, len(readResult), 0)
+}
+
+func TestProviderUrlGetById(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	readResult, err := GetRequest[providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url/"+strconv.FormatInt(*testItems.tmpData.providerUrl.Id, 10), nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls: %v", err)
+	}
+
+	assert.Equal(t, testItems.tmpData.providerUrl, readResult)
+
+}
+
+func TestProviderDeleteById(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	readResultBefore, err := GetRequest[[]providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls before: %v", err)
+	}
+
+	_, err = db.QueryRow[providerUrl.ProviderUrlModel](context.Background(), providerUrl.DeleteProviderUrlById, map[string]interface{}{"id": testItems.tmpData.providerUrl.Id})
+	if err != nil {
+		t.Fatalf("error cleaning up test: %v", err)
+	}
+
+	readResultAfter, err := GetRequest[[]providerUrl.ProviderUrlModel](testItems.app, "/api/v1/provider-url", nil)
+	if err != nil {
+		t.Fatalf("error getting provider urls after: %v", err)
+	}
+
+	assert.Less(t, len(readResultAfter), len(readResultBefore))
+}

--- a/node/pkg/chain/helper/helper.go
+++ b/node/pkg/chain/helper/helper.go
@@ -65,8 +65,9 @@ func NewEthHelper(ctx context.Context, providerUrl string) (*ChainHelper, error)
 		log.Error().Err(err).Msg("failed to load provider urls")
 		return nil, err
 	}
-	clients := make([]utils.ClientInterface, len(providerUrls)+1)
-	clients[0] = primaryClient
+
+	clients := make([]utils.ClientInterface, 0, len(providerUrls)+1)
+	clients = append(clients, primaryClient)
 	for _, url := range providerUrls {
 		subClient, err := eth_client.Dial(url)
 		if err != nil {
@@ -104,8 +105,9 @@ func NewKlayHelper(ctx context.Context, providerUrl string) (*ChainHelper, error
 		log.Error().Err(err).Msg("failed to load provider urls")
 		return nil, err
 	}
-	clients := make([]utils.ClientInterface, len(providerUrls)+1)
-	clients[0] = primaryClient
+
+	clients := make([]utils.ClientInterface, 0, len(providerUrls)+1)
+	clients = append(clients, primaryClient)
 	for _, url := range providerUrls {
 		subClient, err := client.Dial(url)
 		if err != nil {
@@ -246,6 +248,10 @@ func (t *ChainHelper) ReadContract(ctx context.Context, contractAddressHex strin
 
 func (t *ChainHelper) ChainID() *big.Int {
 	return t.chainID
+}
+
+func (t *ChainHelper) NumClients() int {
+	return len(t.clients)
 }
 
 func (t *ChainHelper) retryOnJsonRpcFailure(ctx context.Context, job func(c utils.ClientInterface) error) error {

--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -77,7 +77,7 @@ type ClientInterface interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }
 
-type JsonError interface {
+type JsonRpcError interface {
 	Error() string
 	ErrorCode() int
 	ErrorData() interface{}

--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -11,13 +11,21 @@ import (
 )
 
 const (
-	DEFAULT_GAS_LIMIT    = uint64(6000000)
-	SELECT_WALLETS_QUERY = "SELECT * FROM wallets;"
+	DEFAULT_GAS_LIMIT          = uint64(6000000)
+	SELECT_WALLETS_QUERY       = "SELECT * FROM wallets;"
+	SELECT_PROVIDER_URLS_QUERY = "SELECT * FROM provider_urls WHERE chain_id = @chain_id ORDER BY priority;"
 )
 
 type Wallet struct {
 	ID int64  `db:"id"`
 	PK string `db:"pk"`
+}
+
+type ProviderUrl struct {
+	Id       *int64 `db:"id"`
+	ChainId  *int   `db:"chain_id"`
+	Url      string `db:"url"`
+	Priority *int   `db:"priority"`
 }
 
 type SignInsertPayload struct {
@@ -67,4 +75,10 @@ type ClientInterface interface {
 	NetworkID(ctx context.Context) (*big.Int, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+}
+
+type JsonError interface {
+	Error() string
+	ErrorCode() int
+	ErrorData() interface{}
 }

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -507,3 +507,16 @@ func MakeAbiFuncAttribute(args string) string {
 	}
 	return strings.Join(parts, ",\n")
 }
+
+func LoadProviderUrls(ctx context.Context, chainId int) ([]string, error) {
+	providerUrls, err := db.QueryRows[ProviderUrl](ctx, SELECT_PROVIDER_URLS_QUERY, map[string]interface{}{"chain_id": chainId})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, len(providerUrls))
+	for i, providerUrl := range providerUrls {
+		result[i] = providerUrl.Url
+	}
+
+	return result, nil
+}

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -530,6 +530,7 @@ func ShouldRetryWithSwitchedJsonRPC(err error) bool {
 	return false
 }
 
+// errorCode reference: https://www.jsonrpc.org/specification
 func IsJsonRpcFailureError(errorCode int) bool {
 	if errorCode == -32603 {
 		return true

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -520,3 +520,22 @@ func LoadProviderUrls(ctx context.Context, chainId int) ([]string, error) {
 
 	return result, nil
 }
+
+// reference: https://github.com/ethereum/go-ethereum/issues/19766#issuecomment-963442824
+func ShouldRetryWithSwitchedJsonRPC(err error) bool {
+	jsonErr, ok := err.(JsonRpcError)
+	if ok {
+		return IsJsonRpcFailureError(jsonErr.ErrorCode())
+	}
+	return false
+}
+
+func IsJsonRpcFailureError(errorCode int) bool {
+	if errorCode == -32603 {
+		return true
+	}
+	if errorCode <= -32000 && errorCode >= -32099 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
# Description

Multiple JSON RPC Support

- Adds table and CRUD functionality in admin for managing JSON RPC.
- Updates the ChainHelper struct to maintain a list of clients instead of a single client. Backup clients with different JSON RPC endpoints are utilized in case of RPC request failures.
- During initialization of ChainHelper, it first checks the environment variable for the primary JSON RPC endpoint. and then it loads JSON RPC endpoints from the database with the same chain_id as backup JSON RPC endpoints.
- A lower `priority` indicates higher prioritization.
- From `ChainHelper`, it only retries on JsonRpc failure, in other cases it'll return err immediately. if JsonRpc failure occurs, it'll try to use clients declared with different json rpcs

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new table for managing provider URLs with capabilities to add, retrieve, and delete entries.
	- Added API routes for provider URL management including insertion, listing, and deletion.
	- Enhanced chain helper utilities to support multiple clients and improved error handling for JSON-RPC failures.
	- Implemented retry logic for JSON-RPC requests to ensure reliability.

- **Bug Fixes**
	- Improved error handling in test cleanup processes to prevent potential issues during test execution.

- **Tests**
	- Added comprehensive tests for provider URL management functionalities.
	- Enhanced chain-related tests with new assertions and setup for provider URLs.

- **Refactor**
	- Updated the `ChainHelper` structure to better support multiple clients and introduced more robust error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->