### PR TITLE
(OraklNode) Unify struct for global aggregate

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -211,7 +211,7 @@ func (n *Aggregator) insertPgsql(ctx context.Context, value int64, round int64) 
 
 func (n *Aggregator) insertRdb(ctx context.Context, value int64, round int64) error {
 	key := "globalAggregate:" + n.Name
-	data, err := json.Marshal(redisGlobalAggregate{Value: value, Round: round})
+	data, err := json.Marshal(globalAggregate{Name: n.Name, Value: value, Round: round, Timestamp: time.Now()})
 	if err != nil {
 		log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to marshal global aggregate")
 		return err

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -25,11 +25,6 @@ type redisLocalAggregate struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-type redisGlobalAggregate struct {
-	Value int64 `json:"value"`
-	Round int64 `json:"round"`
-}
-
 type pgsLocalAggregate struct {
 	Name      string    `db:"name"`
 	Value     int64     `db:"value"`
@@ -37,10 +32,10 @@ type pgsLocalAggregate struct {
 }
 
 type globalAggregate struct {
-	Name      string    `db:"name"`
-	Value     int64     `db:"value"`
-	Round     int64     `db:"round"`
-	Timestamp time.Time `db:"timestamp"`
+	Name      string    `db:"name" json:"name"`
+	Value     int64     `db:"value" json:"value"`
+	Round     int64     `db:"round" json:"round"`
+	Timestamp time.Time `db:"timestamp" json:"timestamp"`
 }
 
 type App struct {

--- a/node/pkg/aggregator/utils.go
+++ b/node/pkg/aggregator/utils.go
@@ -26,9 +26,9 @@ func GetLatestLocalAggregateFromPgs(ctx context.Context, name string) (pgsLocalA
 	return db.QueryRow[pgsLocalAggregate](ctx, SelectLatestLocalAggregateQuery, map[string]any{"name": name})
 }
 
-func GetLatestGlobalAggregateFromRdb(ctx context.Context, name string) (redisGlobalAggregate, error) {
+func GetLatestGlobalAggregateFromRdb(ctx context.Context, name string) (globalAggregate, error) {
 	key := "globalAggregate:" + name
-	var aggregate redisGlobalAggregate
+	var aggregate globalAggregate
 	data, err := db.Get(ctx, key)
 	if err != nil {
 		return aggregate, err

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -37,7 +37,7 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 	var tmpData = new(TmpData)
 
 	key := "globalAggregate:" + "test-aggregate"
-	data, err := json.Marshal(map[string]any{"value": int64(15), "round": int64(1)})
+	data, err := json.Marshal(map[string]any{"name": "test-aggregate", "value": int64(15), "round": int64(1)})
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/chain/helper"
@@ -181,7 +180,6 @@ func (r *Reporter) getLatestGlobalAggregatesRdb(ctx context.Context) ([]GlobalAg
 			log.Error().Str("Player", "Reporter").Err(err).Str("key", keys[i]).Msg("failed to unmarshal aggregate")
 			continue
 		}
-		aggregate.Name = strings.TrimPrefix(keys[i], "globalAggregate:")
 		aggregates = append(aggregates, aggregate)
 	}
 


### PR DESCRIPTION
# Description

### AS-IS
Separated struct for pgsql and rdb from aggregator while using the same struct in reporter

### TO-BE
Remove `redisGlobalAggregate` type and use `globalAggregate` type instead for rdb



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
