### PR TITLE
Update cli settings urls

### DIFF
--- a/cli/src/settings.ts
+++ b/cli/src/settings.ts
@@ -12,17 +12,17 @@ const default_fetcher_host = production
 const default_fetcher_port = production ? '4040' : '3001'
 
 const default_listener_host = production
-  ? 'http://orakl-aggregator-listener.orakl.svc.cluster.local'
+  ? 'http://aggregator-listener.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_listener_port = production ? '4000' : '4000'
 
 const default_worker_host = production
-  ? 'http://orakl-aggregator-worker.orakl.svc.cluster.local'
+  ? 'http://aggregator-worker.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_worker_port = production ? '5000' : '5001'
 
 const default_reporter_host = production
-  ? 'http://orakl-aggregator-reporter.orakl.svc.cluster.local'
+  ? 'http://aggregator-reporter.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_reporter_port = production ? '6000' : '6000'
 

--- a/cli/src/settings.ts
+++ b/cli/src/settings.ts
@@ -1,28 +1,28 @@
 const production = process.env.NODE_ENV == 'production'
 const default_api_url = production
-  ? 'http://api.orakl.svc.cluster.local'
+  ? 'http://orakl-api.orakl.svc.cluster.local'
   : 'http://localhost:3000/api/v1'
 const default_delegator_url = production
-  ? 'http://delegator.orakl.svc.cluster.local'
+  ? 'http://orakl-delegator.orakl.svc.cluster.local'
   : 'http://localhost:3002/api/v1'
 
 const default_fetcher_host = production
-  ? 'http://fetcher.orakl.svc.cluster.local'
+  ? 'http://orakl-fetcher.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_fetcher_port = production ? '4040' : '3001'
 
 const default_listener_host = production
-  ? 'http://aggregator-listener.orakl.svc.cluster.local'
+  ? 'http://orakl-aggregator-listener.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_listener_port = production ? '4000' : '4000'
 
 const default_worker_host = production
-  ? 'http://aggregator-worker.orakl.svc.cluster.local'
+  ? 'http://orakl-aggregator-worker.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_worker_port = production ? '5000' : '5001'
 
 const default_reporter_host = production
-  ? 'http://aggregator-reporter.orakl.svc.cluster.local'
+  ? 'http://orakl-aggregator-reporter.orakl.svc.cluster.local'
   : 'http://localhost'
 const default_reporter_port = production ? '6000' : '6000'
 


### PR DESCRIPTION
# Description

currently env variables should also be updated from pods
commands such as followed aren't working unless sending host port parameter together
`yarn cli listener active`

```
Error: getaddrinfo ENOTFOUND orakl-core-aggregator-listener.orakl.svc.cluster.local
```
Assuming it should be updated to `http://orakl-aggregator-listener.orakl.svc.cluster.local`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
