### PR TITLE
Fix EN sync check

### DIFF
--- a/monitor/scripts/en-sync-check.sh
+++ b/monitor/scripts/en-sync-check.sh
@@ -3,16 +3,18 @@
 # Dependencies: jq, curl, gcloud-sdk
 
 check_klay_sync() {
-    local our_block=$(get_our_klay_block)
+    local our_block
+    our_block=$(get_our_klay_block)
 
-    local public_block_hex=$(get_public_klay_block)
-    public_block=$((16#$public_block_hex))
+    local public_block_hex
+    public_block_hex=$(get_public_klay_block)
+    public_block=$((16#$public_block_hex)) || { echo "[ERROR] Failed to convert hex to decimal"; exit 1; }
 
     # Calculate difference
     diff=$((our_block - public_block))
 
     # Check if the abs of difference is less than 10
-    if [ $diff -lt 10 ]; then
+    if [ ${diff#-} -lt 10 ]; then
 	echo "[INFO] Klaytn is synchronized"
     else
 	echo "[ERROR] Synchronization failed. Remain blocks to latest: $diff"
@@ -30,9 +32,9 @@ get_public_klay_block() {
 
     # Get block number from response
     # Print result field without "0x" in json response
-    public_klay_blockNumber=$(echo $response | jq -r '.result' | awk '{ sub("0x", ""); print $0 }')
+    public_klay_blockNumber=$(echo "$response" | jq -r '.result' | awk '{ sub("0x", ""); print $0 }')
 
-    echo $public_klay_blockNumber
+    echo "$public_klay_blockNumber"
 }
 
 get_our_klay_block() {
@@ -45,9 +47,9 @@ get_our_klay_block() {
     # Get block number from log
     # If col 8 string starts with "number=",
     # then print the value only integer part
-    our_klay_blockNumber=$(echo $response | awk '$8 ~ /^number*/ { sub(/^number=/, "", $8); print $8 }')
+    our_klay_blockNumber=$(echo "$response" | awk '$8 ~ /^number*/ { sub(/^number=/, "", $8); print $8 }')
 
-    echo $our_klay_blockNumber
+    echo "$our_klay_blockNumber"
 }
 
 check_klay_sync

--- a/monitor/scripts/en-sync-check.sh
+++ b/monitor/scripts/en-sync-check.sh
@@ -3,49 +3,51 @@
 # Dependencies: jq, curl, gcloud-sdk
 
 check_klay_sync() {
-	our_klay_blockNumber="${1}"
-	public_klay_blockNumber="${2}"
+    local our_block=$(get_our_klay_block)
 
-	# Calculate difference
-	diff=$((public_klay_blockNumber - our_klay_blockNumber))
+    local public_block_hex=$(get_public_klay_block)
+    public_block=$((16#$public_block_hex))
 
-	# Check if the abs of difference is less than 10
-	if [ $diff -lt 10 ]; then
-		echo "[INFO] Klaytn is synchronized"
-	else
-		echo "[ERROR] Synchronization failed. Remain blocks to latest: $diff"
-	fi
+    # Calculate difference
+    diff=$((our_block - public_block))
+
+    # Check if the abs of difference is less than 10
+    if [ $diff -lt 10 ]; then
+	echo "[INFO] Klaytn is synchronized"
+    else
+	echo "[ERROR] Synchronization failed. Remain blocks to latest: $diff"
+    fi
 }
 
-get_public_klay_blockNumber() {
-	public_json_rpc="https://public-en-cypress.klaytn.net"
+get_public_klay_block() {
+    public_json_rpc="https://public-en-cypress.klaytn.net"
 
-	# Request block number to public JSON-RPC node
-	response=$(curl \
-		-H "Content-type: application/json" \
-		--data '{"jsonrpc":"2.0","method":"klay_blockNumber","params":[],"id":83}' \
-		$public_json_rpc)
+    # Request block number to public JSON-RPC node
+    response=$(curl \
+		   -H "Content-type: application/json" \
+		   --data '{"jsonrpc":"2.0","method":"klay_blockNumber","params":[],"id":83}' \
+		   $public_json_rpc)
 
-	# Get block number from response
-	# Print result field without "0x" in json response
-	public_klay_blockNumber=$(echo $response | jq -r '.result' | awk '{ sub("0x", ""); print $0 }')
+    # Get block number from response
+    # Print result field without "0x" in json response
+    public_klay_blockNumber=$(echo $response | jq -r '.result' | awk '{ sub("0x", ""); print $0 }')
 
-	echo $public_klay_blockNumber
+    echo $public_klay_blockNumber
 }
 
 get_our_klay_block() {
-	# Get log from JSON-RPC node
-	response=$(gcloud compute ssh orakl-cypress-prod-node \
-		--project=orakl-cypress-prod \
-		--tunnel-through-iap \
-		-- -t tail -1 /data/pruning/log/kend.out)
+    # Get log from JSON-RPC node
+    response=$(gcloud compute ssh orakl-cypress-prod-node \
+		      --project=orakl-cypress-prod \
+		      --tunnel-through-iap \
+		      -- -t tail -1 /data/pruning/log/kend.out)
 
-	# Get block number from log
-	# If col 8 string starts with "number=",
-	# then print the value only integer part
-	our_klay_blockNumber=$(echo $response | awk '$8 ~ /^number*/ { sub(/^number=/, "", $8); print $8 }')
+    # Get block number from log
+    # If col 8 string starts with "number=",
+    # then print the value only integer part
+    our_klay_blockNumber=$(echo $response | awk '$8 ~ /^number*/ { sub(/^number=/, "", $8); print $8 }')
 
-	echo $our_klay_blockNumber
+    echo $our_klay_blockNumber
 }
 
-check_klay_sync get_public_klay_blockNumber get_our_klay_block
+check_klay_sync


### PR DESCRIPTION
# Description

`en-synch-check.sh` did not make request to neither our EN or public EN node and always returned message that EN nodes are synchronized. Block number returned from public node is in hexadecimal format and must be converted to decimal format.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved block number retrieval logic in the synchronization check script for enhanced accuracy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->