### PR TITLE
Allow only single oracle to submit to Feed contract

### DIFF
--- a/contracts/v0.2/script/Full.s.sol
+++ b/contracts/v0.2/script/Full.s.sol
@@ -35,7 +35,7 @@ contract DeployFull is Script {
             uint256 numFeeds = abi.decode(numFeedsRaw, (uint256));
 
             for (uint256 j = 0; j < numFeeds; j++) {
-                buildFeed(json, j, address(sp), oracle);
+                buildFeed(json, j, address(sp));
             }
             config.updateMigration(dirPath, migrationFilePath);
         }
@@ -43,19 +43,13 @@ contract DeployFull is Script {
         vm.stopBroadcast();
     }
 
-    function buildFeed(string memory json, uint256 feedIndex, address submissionProxy, address oracle) internal {
+    function buildFeed(string memory json, uint256 feedIndex, address oracle) internal {
         UtilsScript.FeedConstructor memory constructor_ =
             abi.decode(json.parseRaw(buildJsonQuery(feedIndex)), (UtilsScript.FeedConstructor));
         uint8 decimals = uint8(constructor_.decimals);
         string memory description = constructor_.description;
 
-        Feed feed = new Feed(decimals, description);
-        address[] memory remove_;
-        address[] memory add_ = new address[](2);
-        add_[0] = submissionProxy;
-	add_[1] = oracle;
-        feed.changeOracles(remove_, add_);
-
+        Feed feed = new Feed(decimals, description, oracle);
         console.log(description, address(feed));
     }
 

--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -42,6 +42,7 @@ contract Feed is Ownable, IFeed {
      * @dev The deployer of the contract will become the owner.
      * @param _decimals The number of decimals for the feed
      * @param _description The description of the feed
+     * @param _oracle The address of the oracle
      */
     constructor(uint8 _decimals, string memory _description, address _oracle) Ownable(msg.sender) {
         decimals = _decimals;

--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -13,8 +13,8 @@ import {IFeed} from "./interfaces/IFeed.sol";
  * `SubmissionProxy` contract.
  */
 contract Feed is Ownable, IFeed {
-    uint8 public override decimals;
-    string public override description;
+    uint8 public decimals;
+    string public description;
     address public oracle;
 
     struct Round {
@@ -23,7 +23,7 @@ contract Feed is Ownable, IFeed {
     }
 
     uint64 private latestRoundId;
-    mapping(uint64 => Round) internal rounds;
+    mapping(uint64 roundId => Round data) internal rounds;
 
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
 

--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -8,19 +8,15 @@ import {IFeed} from "./interfaces/IFeed.sol";
  * @title Orakl Network Feed
  * @author Bisonai Labs
  * @notice A contract that stores the historical and latest answers, and
- * the timestamp submitted by a whitelisted set of oracles. The
- * contract owner can add or remove oracles from the whitelist using
- * `changeOracles` function.
- * @dev A set of oracles is represented with `oracles` list and
- * `whitelist` mapping. The submitted answers are expected to be
- * submitted directly by whitelisted EOA oracles or through a
+ * the timestamp submitted by oracle.
+ * @dev The submitted answers are expected to be submitted through a
  * `SubmissionProxy` contract.
  */
 contract Feed is Ownable, IFeed {
     uint8 public override decimals;
     string public override description;
+    address public oracle;
 
-    // round data
     struct Round {
         int256 answer;
         uint64 updatedAt;
@@ -29,20 +25,13 @@ contract Feed is Ownable, IFeed {
     uint64 private latestRoundId;
     mapping(uint64 => Round) internal rounds;
 
-    // whitelisted oracles
-    address[] private oracles;
-    mapping(address oracle => bool isWhitelisted) private whitelist;
-
-    event OraclePermissionsUpdated(address indexed oracle, bool indexed whitelisted);
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
 
     error OnlyOracle();
-    error OracleAlreadyEnabled();
-    error OracleNotEnabled();
     error NoDataPresent();
 
     modifier onlyOracle() {
-        if (!whitelist[msg.sender]) {
+        if (msg.sender != oracle) {
             revert OnlyOracle();
         }
         _;
@@ -54,16 +43,17 @@ contract Feed is Ownable, IFeed {
      * @param _decimals The number of decimals for the feed
      * @param _description The description of the feed
      */
-    constructor(uint8 _decimals, string memory _description) Ownable(msg.sender) {
+    constructor(uint8 _decimals, string memory _description, address _oracle) Ownable(msg.sender) {
         decimals = _decimals;
         description = _description;
+	oracle = _oracle;
     }
 
     /**
      * @notice Submit the answer for the current round. The round ID
      * is derived from the current round ID, and the answer together
-     * with timestamp is stored in the contract. Only whitelisted
-     * oracles can submit the answer.
+     * with timestamp is stored in the contract. Only oracle can
+     * submit the answer.
      * @param _answer The answer for the current round
      */
     function submit(int256 _answer) external onlyOracle {
@@ -74,40 +64,6 @@ contract Feed is Ownable, IFeed {
 
         emit FeedUpdated(_answer, roundId_, block.timestamp);
         latestRoundId = roundId_;
-    }
-
-    /**
-     * @notice Change the set of whitelisted oracles that can submit
-     * answer through `submit` function.
-     * @dev Only owner can call this function. The set of whitelisted
-     * oracles is tracked through `oracles` list and `whitelist`
-     * mapping. If an oracle is already in the whitelist, it will
-     * revert with `OracleAlreadyEnabled` error, and if an oracle is
-     * not in the whitelist, it will revert with `OracleNotEnabled`
-     * error.
-     * @param _removed The list of oracles to be removed from the
-     * whitelist
-     * @param _added The list of oracles to be added to the whitelist
-     */
-    function changeOracles(address[] calldata _removed, address[] calldata _added) external onlyOwner {
-        for (uint256 i = 0; i < _removed.length; i++) {
-            removeOracle(_removed[i]);
-        }
-
-        for (uint256 i = 0; i < _added.length; i++) {
-            if (_added[i] == address(0)) {
-                continue;
-            }
-            addOracle(_added[i]);
-        }
-    }
-
-    /**
-     * @notice Get list of whitelisted oracles
-     * @return The list of whitelisted oracles
-     */
-    function getOracles() external view returns (address[] memory) {
-        return oracles;
     }
 
     /**
@@ -154,48 +110,5 @@ contract Feed is Ownable, IFeed {
         }
 
         return (_roundId, r.answer, r.updatedAt);
-    }
-
-    /**
-     * @notice Attempt to add oracle to a set of whitelisted oracles.
-     * @dev If the oracle is already in the whitelist, it will revert
-     * with `OracleAlreadyEnabled` error. If oracle is successfully
-     * added, `OraclePermissionsUpdated` event is emitted.
-     * @param _oracle The address of the oracle to be whitelisted
-     */
-    function addOracle(address _oracle) private {
-        if (whitelist[_oracle]) {
-            revert OracleAlreadyEnabled();
-        }
-
-        whitelist[_oracle] = true;
-        oracles.push(_oracle);
-        emit OraclePermissionsUpdated(_oracle, true);
-    }
-
-    /**
-     * @notice Attempt to remove oracle from a set of whitelisted
-     * oracles.
-     * @dev If the oracle is not in the whitelist, it will revert with
-     * `OracleNotEnabled` error. If oracle is successfully removed,
-     * `OraclePermissionsUpdated` event is emitted.
-     * @param _oracle The address of the oracle to be removed from the
-     * whitelist
-     */
-    function removeOracle(address _oracle) private {
-        if (!whitelist[_oracle]) {
-            revert OracleNotEnabled();
-        }
-
-        whitelist[_oracle] = false;
-        for (uint256 i = 0; i < oracles.length; i++) {
-            if (oracles[i] == _oracle) {
-                oracles[i] = oracles[oracles.length - 1];
-                oracles.pop();
-                break;
-            }
-        }
-
-        emit OraclePermissionsUpdated(_oracle, false);
     }
 }

--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -46,7 +46,7 @@ contract Feed is Ownable, IFeed {
     constructor(uint8 _decimals, string memory _description, address _oracle) Ownable(msg.sender) {
         decimals = _decimals;
         description = _description;
-	oracle = _oracle;
+        oracle = _oracle;
     }
 
     /**
@@ -69,13 +69,7 @@ contract Feed is Ownable, IFeed {
     /**
      * @inheritdoc IFeed
      */
-    function latestRoundData()
-        external
-        view
-        virtual
-        override
-        returns (uint64 id, int256 answer, uint256 updatedAt)
-    {
+    function latestRoundData() external view virtual override returns (uint64 id, int256 answer, uint256 updatedAt) {
         return getRoundData(latestRoundId);
     }
 

--- a/contracts/v0.2/src/FeedProxy.sol
+++ b/contracts/v0.2/src/FeedProxy.sol
@@ -43,11 +43,7 @@ contract FeedProxy is Ownable, IFeedProxy {
      * @return answer The oracle answer.
      * @return updatedAt Timestamp of the last update.
      */
-    function getRoundData(uint64 _roundId)
-        external
-        view
-        returns (uint64 id, int256 answer, uint256 updatedAt)
-    {
+    function getRoundData(uint64 _roundId) external view returns (uint64 id, int256 answer, uint256 updatedAt) {
         return feed.getRoundData(_roundId);
     }
 

--- a/contracts/v0.2/src/interfaces/IFeed.sol
+++ b/contracts/v0.2/src/interfaces/IFeed.sol
@@ -21,10 +21,7 @@ interface IFeed {
      * @return answer The oracle answer.
      * @return updatedAt Timestamp of the last update.
      */
-    function getRoundData(uint64 _roundId)
-        external
-        view
-        returns (uint64 id, int256 answer, uint256 updatedAt);
+    function getRoundData(uint64 _roundId) external view returns (uint64 id, int256 answer, uint256 updatedAt);
 
     /**
      * @notice Get latest round data of the feed.

--- a/contracts/v0.2/src/interfaces/IFeedProxy.sol
+++ b/contracts/v0.2/src/interfaces/IFeedProxy.sol
@@ -22,10 +22,7 @@ interface IFeedProxy is IFeed {
      * @return answer The oracle answer.
      * @return updatedAt Timestamp of the last update.
      */
-    function proposedLatestRoundData()
-        external
-        view
-        returns (uint64 id, int256 answer, uint256 updatedAt);
+    function proposedLatestRoundData() external view returns (uint64 id, int256 answer, uint256 updatedAt);
 
     /**
      * @notice Get address of the feed.

--- a/contracts/v0.2/test/Feed.t.sol
+++ b/contracts/v0.2/test/Feed.t.sol
@@ -16,7 +16,7 @@ contract FeedTest is Test {
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
 
     function setUp() public {
-	oracle = makeAddr("oracle");
+        oracle = makeAddr("oracle");
         feed = new Feed(decimals, description, oracle);
     }
 

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -91,8 +91,8 @@ contract SubmissionProxyTest is Test {
         (address[] memory feeds_, int256[] memory submissions_) =
             prepareFeedsSubmissions(numOracles_, submissionValue_, oracle_);
 
-	bytes[] memory proofs_ = new bytes[](1);
-	proofs_[0] = "invalid-proof";
+        bytes[] memory proofs_ = new bytes[](1);
+        proofs_[0] = "invalid-proof";
 
         vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
         submissionProxy.submit(feeds_, submissions_, proofs_);
@@ -106,15 +106,15 @@ contract SubmissionProxyTest is Test {
         (address[] memory feeds_, int256[] memory submissions_) =
             prepareFeedsSubmissions(numOracles_, submissionValue_, oracle_);
 
-	bytes[] memory proofs_ = new bytes[](1);
-	proofs_[0] = "invalid-proof";
+        bytes[] memory proofs_ = new bytes[](1);
+        proofs_[0] = "invalid-proof";
 
-	submissionProxy.setProofThreshold(feeds_[0], 1);
+        submissionProxy.setProofThreshold(feeds_[0], 1);
 
         submissionProxy.submit(feeds_, submissions_, proofs_);
 
         vm.expectRevert(Feed.NoDataPresent.selector);
-	IFeed(feeds_[0]).latestRoundData();
+        IFeed(feeds_[0]).latestRoundData();
     }
 
     function prepareFeedsSubmissions(uint256 _numOracles, int256 _submissionValue, address _oracle)
@@ -156,7 +156,7 @@ contract SubmissionProxyTest is Test {
         feeds[0] = address(feed);
         submissions[0] = 10;
 
-	submissionProxy.setProofThreshold(feeds[0], 3);
+        submissionProxy.setProofThreshold(feeds[0], 3);
 
         /* proofs[0] = abi.encodePacked(createProof(aliceSk, hash)); */
         /* proofs[0] = abi.encodePacked(createProof(aliceSk, hash), createProof(bobSk, hash)); */

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -123,17 +123,11 @@ contract SubmissionProxyTest is Test {
     {
         submissionProxy.addOracle(_oracle);
 
-        address[] memory remove_;
-        address[] memory add_ = new address[](1);
-        add_[0] = address(submissionProxy);
-
         address[] memory feeds_ = new address[](_numOracles);
         int256[] memory submissions_ = new int256[](_numOracles);
 
         for (uint256 i = 0; i < _numOracles; i++) {
-            Feed feed_ = new Feed(DECIMALS, DESCRIPTION);
-
-            feed_.changeOracles(remove_, add_);
+            Feed feed_ = new Feed(DECIMALS, DESCRIPTION, address(submissionProxy));
 
             feeds_[i] = address(feed_);
             submissions_[i] = _submissionValue;
@@ -145,9 +139,9 @@ contract SubmissionProxyTest is Test {
     function test_submitWithProof() public {
         address offChainSubmissionProxyReporter = makeAddr("submission-proxy-reporter");
         submissionProxy.addOracle(offChainSubmissionProxyReporter);
-        (address alice, uint256 aliceSk) = makeAddrAndKey("alice");
-        (address bob, uint256 bobSk) = makeAddrAndKey("bob");
-        (address celine, uint256 celineSk) = makeAddrAndKey("celine");
+        (, uint256 aliceSk) = makeAddrAndKey("alice");
+        (, uint256 bobSk) = makeAddrAndKey("bob");
+        (, uint256 celineSk) = makeAddrAndKey("celine");
 
         bytes32 hash = keccak256(abi.encodePacked(int256(10)));
 
@@ -157,14 +151,7 @@ contract SubmissionProxyTest is Test {
         bytes[] memory proofs = new bytes[](numSubmissions);
 
         // single data feed
-        address[] memory oracleRemove;
-        address[] memory oracleAdd = new address[](4);
-        Feed feed = new Feed(DECIMALS, DESCRIPTION);
-        oracleAdd[0] = address(submissionProxy);
-        oracleAdd[1] = address(alice);
-        oracleAdd[2] = address(bob);
-        oracleAdd[3] = address(celine);
-        feed.changeOracles(oracleRemove, oracleAdd);
+        Feed feed = new Feed(DECIMALS, DESCRIPTION, address(submissionProxy));
 
         feeds[0] = address(feed);
         submissions[0] = 10;


### PR DESCRIPTION
# Description

Remove a whitelist from `Feed` contract and allow submissions only by a single address that cannot be updated.  If there is a need to update submitter, new `Feed` contract will be deployed and `FeedProxy` will be redirected to read from it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the deployment process by simplifying parameter requirements in the `DeployFull` contract.
	- Streamlined oracle management in the `Feed` contract by directly assigning an oracle address and updating event handling for feed updates.
- **Refactor**
	- Improved code readability and organization in `FeedProxy`, `SubmissionProxy`, and test contracts through better formatting and indentation.
- **Tests**
	- Updated test setups and methods in `FeedTest` to incorporate new oracle parameter, ensuring alignment with the latest contract changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->