### PR TITLE
Automate oracle expiration/renewal mechanism

### DIFF
--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -23,7 +23,7 @@ contract SubmissionProxy is Ownable {
 
     uint256 public maxSubmission = 50;
     uint256 public expirationPeriod = 5 weeks;
-    mapping(address oracle => uint256 expirationTime) whitelist;
+    mapping(address oracle => uint256 expirationTime) public whitelist;
     mapping(address feed => uint8 threshold) thresholds;
 
     event OracleAdded(address oracle, uint256 expirationTime);

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -26,7 +26,7 @@ contract SubmissionProxy is Ownable {
     mapping(address oracle => uint256 expirationTime) whitelist;
     mapping(address feed => uint8 threshold) thresholds;
 
-    event OracleAdded(address oracle);
+    event OracleAdded(address oracle, uint256 expirationTime);
     event MaxSubmissionSet(uint256 maxSubmission);
     event ExpirationPeriodSet(uint256 expirationPeriod);
     event ThresholdSet(address feed, uint8 threshold);
@@ -92,8 +92,9 @@ contract SubmissionProxy is Ownable {
             revert InvalidOracle();
         }
 
-        whitelist[_oracle] = block.timestamp + expirationPeriod;
-        emit OracleAdded(_oracle);
+	uint256 expirationTime = block.timestamp + expirationPeriod;
+        whitelist[_oracle] = expirationTime;
+        emit OracleAdded(_oracle, expirationTime);
     }
 
     /**


### PR DESCRIPTION
# Description

Previously, `addOracle` function was meant to be used both for 1) registration of new node operator and 2) extending expiration period of new oracle EOA. This PR separates those steps into two functions: `addOracle` and `updateOracle`.

* `addOracle` is used for the registration of the oracle EOA for new node operator, and must be executed by the owner of `SubmissionProxy` contract. Every registered oracle is limited by expiration time.
* `updateOracle` is used for extension of expiration time under new oracle EOA. It must be executed by the currently active oracle EOA. If oracle fails to update itself, node operator must request contract owner for new registration.

The issue with previous solution was that for a certain time period (after registration of new oracle EOA and before expiring old oracle EOA), there was a larger number of active oracles than required. Additionally, contract was responsible for both the first and second update steps. With the current proposal, update of oracle can be automated in off-chain implementation and executed without human intervention.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security features and oracle management in the `SubmissionProxy` contract.
	- Added new error handling mechanisms.
- **Tests**
	- Introduced a test for updating oracle addresses.
- **Bug Fixes**
	- Improved naming consistency in test functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->