### PR TITLE
(OraklNode) Wait context done before returning

### DIFF
--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -142,6 +142,7 @@ func (a *App) stopAggregator(aggregator *Aggregator) error {
 	}
 	aggregator.nodeCancel()
 	aggregator.isRunning = false
+	<-aggregator.nodeCtx.Done()
 	return nil
 }
 

--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -250,6 +250,7 @@ func stopReporter(reporter *Reporter) error {
 	reporter.nodeCancel()
 	reporter.isRunning = false
 	reporter.KlaytnHelper.Close()
+	<-reporter.nodeCtx.Done()
 	return nil
 }
 


### PR DESCRIPTION
# Description

`stopAggregator` and `stopReporter` returns immediately after calling ctx.Cancel() function. Adds additional step to check if context is actually done and proceed

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the shutdown process for both the aggregator and reporter components, ensuring they properly complete their tasks before closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->