### PR TITLE
Proof generation, oracle removal and relative threshold

### DIFF
--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -8,14 +8,14 @@ import {IFeed} from "./interfaces/IFeed.sol";
  * @title Orakl Network Feed
  * @author Bisonai Labs
  * @notice A contract that stores the historical and latest answers, and
- * the timestamp submitted by oracle.
+ * the timestamp submitted by submitter.
  * @dev The submitted answers are expected to be submitted through a
  * `SubmissionProxy` contract.
  */
 contract Feed is Ownable, IFeed {
     uint8 public decimals;
     string public description;
-    address public oracle;
+    address public submitter;
 
     struct Round {
         int256 answer;
@@ -27,12 +27,12 @@ contract Feed is Ownable, IFeed {
 
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
 
-    error OnlyOracle();
+    error OnlySubmitter();
     error NoDataPresent();
 
-    modifier onlyOracle() {
-        if (msg.sender != oracle) {
-            revert OnlyOracle();
+    modifier onlySubmitter() {
+        if (msg.sender != submitter) {
+            revert OnlySubmitter();
         }
         _;
     }
@@ -42,22 +42,22 @@ contract Feed is Ownable, IFeed {
      * @dev The deployer of the contract will become the owner.
      * @param _decimals The number of decimals for the feed
      * @param _description The description of the feed
-     * @param _oracle The address of the oracle
+     * @param _submitter The address of the submitter
      */
-    constructor(uint8 _decimals, string memory _description, address _oracle) Ownable(msg.sender) {
+    constructor(uint8 _decimals, string memory _description, address _submitter) Ownable(msg.sender) {
         decimals = _decimals;
         description = _description;
-        oracle = _oracle;
+        submitter = _submitter;
     }
 
     /**
      * @notice Submit the answer for the current round. The round ID
      * is derived from the current round ID, and the answer together
-     * with timestamp is stored in the contract. Only oracle can
+     * with timestamp is stored in the contract. Only submitter can
      * submit the answer.
      * @param _answer The answer for the current round
      */
-    function submit(int256 _answer) external onlyOracle {
+    function submit(int256 _answer) external onlySubmitter {
         uint64 roundId_ = latestRoundId + 1;
 
         rounds[roundId_].answer = _answer;

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -279,7 +279,7 @@ contract SubmissionProxy is Ownable {
     }
 
     /**
-     * @notice Split bytes into chunks of 65 bytes
+     * @notice Split bytes into proof chunks and indexes
      * @param data The bytes to be split
      * @return chunks The split bytes
      * @return indexes The indexes of the split bytes

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -30,6 +30,7 @@ contract SubmissionProxy is Ownable {
     mapping(address feed => uint8 threshold) thresholds;
 
     event OracleAdded(address oracle, uint256 expirationTime);
+    event OracleRemoved(address oracle);
     event MaxSubmissionSet(uint256 maxSubmission);
     event ExpirationPeriodSet(uint256 expirationPeriod);
     event ThresholdSet(address feed, uint8 threshold);
@@ -136,6 +137,26 @@ contract SubmissionProxy is Ownable {
 
 	emit OracleAdded(_oracle, expirationTime_);
 	return index;
+    }
+
+    /**
+     * @notice Remove an oracle from the whitelist. The oracle will not be
+     * able to produce valid submission proofs after the expiration
+     * time.
+     * @param _oracle The address of the oracle
+     */
+    function removeOracle(address _oracle) external onlyOwner {
+	whitelist[_oracle] = block.timestamp;
+
+	for (uint256 i = 0; i < oracles.length; i++) {
+	    if (_oracle == oracles[i]) {
+		oracles[i] = oracles[oracles.length - 1];
+		oracles.pop();
+		break;
+	    }
+	}
+
+	emit OracleRemoved(_oracle);
     }
 
     /**

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -48,7 +48,7 @@ contract SubmissionProxy is Ownable {
     error IndexesNotAscending();
 
     modifier onlyOracle() {
-	if (!isWhitelisted(msg.sender))  {
+        if (!isWhitelisted(msg.sender)) {
             revert OnlyOracle();
         }
         _;
@@ -91,11 +91,11 @@ contract SubmissionProxy is Ownable {
      * 100.
      */
     function setDefaultProofThreshold(uint8 _threshold) external onlyOwner {
-	if (_threshold < MIN_THRESHOLD || _threshold > MAX_THRESHOLD) {
+        if (_threshold < MIN_THRESHOLD || _threshold > MAX_THRESHOLD) {
             revert InvalidThreshold();
         }
 
-	threshold = _threshold;
+        threshold = _threshold;
         emit DefaultThresholdSet(_threshold);
     }
 
@@ -107,7 +107,7 @@ contract SubmissionProxy is Ownable {
      * 100.
      */
     function setProofThreshold(address _feed, uint8 _threshold) external onlyOwner {
-	if (_threshold < MIN_THRESHOLD || _threshold > MAX_THRESHOLD) {
+        if (_threshold < MIN_THRESHOLD || _threshold > MAX_THRESHOLD) {
             revert InvalidThreshold();
         }
 
@@ -132,31 +132,31 @@ contract SubmissionProxy is Ownable {
             revert InvalidOracle();
         }
 
-	bool found = false;
-	uint256 index = 0;
+        bool found = false;
+        uint256 index = 0;
 
-	// register the oracle
-	for (uint256 i = 0; i < oracles.length; i++) {
-	    // reuse existing oracle slot if it is expired
-	    if (!isWhitelisted(oracles[i])) {
-		oracles[i] = _oracle;
-		found = true;
-		index = i;
-		break;
-	    }
-	}
+        // register the oracle
+        for (uint256 i = 0; i < oracles.length; i++) {
+            // reuse existing oracle slot if it is expired
+            if (!isWhitelisted(oracles[i])) {
+                oracles[i] = _oracle;
+                found = true;
+                index = i;
+                break;
+            }
+        }
 
-	if (!found) {
-	    oracles.push(_oracle);
-	    index = oracles.length - 1;
-	}
+        if (!found) {
+            oracles.push(_oracle);
+            index = oracles.length - 1;
+        }
 
-	// set the expiration time
-	uint256 expirationTime_ = block.timestamp + expirationPeriod;
-	whitelist[_oracle] = expirationTime_;
+        // set the expiration time
+        uint256 expirationTime_ = block.timestamp + expirationPeriod;
+        whitelist[_oracle] = expirationTime_;
 
-	emit OracleAdded(_oracle, expirationTime_);
-	return index;
+        emit OracleAdded(_oracle, expirationTime_);
+        return index;
     }
 
     /**
@@ -166,17 +166,17 @@ contract SubmissionProxy is Ownable {
      * @param _oracle The address of the oracle
      */
     function removeOracle(address _oracle) external onlyOwner {
-	whitelist[_oracle] = block.timestamp;
+        whitelist[_oracle] = block.timestamp;
 
-	for (uint256 i = 0; i < oracles.length; i++) {
-	    if (_oracle == oracles[i]) {
-		oracles[i] = oracles[oracles.length - 1];
-		oracles.pop();
-		break;
-	    }
-	}
+        for (uint256 i = 0; i < oracles.length; i++) {
+            if (_oracle == oracles[i]) {
+                oracles[i] = oracles[oracles.length - 1];
+                oracles.pop();
+                break;
+            }
+        }
 
-	emit OracleRemoved(_oracle);
+        emit OracleRemoved(_oracle);
     }
 
     /**
@@ -191,19 +191,19 @@ contract SubmissionProxy is Ownable {
             revert InvalidOracle();
         }
 
-	// deactivate the old oracle
-	whitelist[msg.sender] = block.timestamp;
+        // deactivate the old oracle
+        whitelist[msg.sender] = block.timestamp;
 
-	// update the oracle address
-	for (uint256 i = 0; i < oracles.length; i++) {
-	    if (msg.sender == oracles[i]) {
-		oracles[i] = _oracle;
-		break;
-	    }
-	}
+        // update the oracle address
+        for (uint256 i = 0; i < oracles.length; i++) {
+            if (msg.sender == oracles[i]) {
+                oracles[i] = _oracle;
+                break;
+            }
+        }
 
-	// extend the expiration time
-	uint256 expirationTime_ = block.timestamp + expirationPeriod;
+        // extend the expiration time
+        uint256 expirationTime_ = block.timestamp + expirationPeriod;
         whitelist[_oracle] = expirationTime_;
 
         emit OracleAdded(_oracle, expirationTime_);
@@ -229,25 +229,25 @@ contract SubmissionProxy is Ownable {
 
             bool isVerified_ = false;
             uint8 verifiedSignatures_ = 0;
-	    uint8 lastIndex_ = 0;
-	    uint256 oracleCount_ = oracles.length;
+            uint8 lastIndex_ = 0;
+            uint256 oracleCount_ = oracles.length;
 
             uint8 threshold_ = thresholds[_feeds[feedIdx]];
             if (threshold_ == 0) {
-		threshold_ = threshold;
+                threshold_ = threshold;
             }
-	    uint8 requiredSignatures_ = quorum(threshold_);
+            uint8 requiredSignatures_ = quorum(threshold_);
 
             for (uint256 proofIdx_ = 0; proofIdx_ < proofs_.length; proofIdx_++) {
-		uint8 oracleIndex_ =  indexes_[proofIdx_];
-		if (proofIdx_ != 0 && oracleIndex_ <= lastIndex_) {
-		    revert IndexesNotAscending();
-		}
-		lastIndex_ = oracleIndex_;
+                uint8 oracleIndex_ = indexes_[proofIdx_];
+                if (proofIdx_ != 0 && oracleIndex_ <= lastIndex_) {
+                    revert IndexesNotAscending();
+                }
+                lastIndex_ = oracleIndex_;
 
-		if (oracleIndex_ >= oracleCount_) {
-		    revert IndexOutOfBounds();
-		}
+                if (oracleIndex_ >= oracleCount_) {
+                    revert IndexOutOfBounds();
+                }
 
                 bytes memory singleProof_ = proofs_[proofIdx_];
                 address signer_ = recoverSigner(message_, singleProof_);
@@ -288,7 +288,7 @@ contract SubmissionProxy is Ownable {
         uint256 dataLength = data.length;
         uint256 numChunks = dataLength / 66;
         bytes[] memory chunks = new bytes[](numChunks);
-	uint8[] memory indexes = new uint8[](numChunks);
+        uint8[] memory indexes = new uint8[](numChunks);
 
         bytes32 firstHalf;
         bytes32 secondHalf;
@@ -302,7 +302,7 @@ contract SubmissionProxy is Ownable {
             }
 
             chunks[i] = abi.encodePacked(firstHalf, secondHalf, data[(i * 66) + 65]);
-	    indexes[i] = uint8(data[i * 66]);
+            indexes[i] = uint8(data[i * 66]);
         }
 
         return (chunks, indexes);
@@ -363,7 +363,7 @@ contract SubmissionProxy is Ownable {
      * @return The quorum
      */
     function quorum(uint8 _threshold) private view returns (uint8) {
-	uint256 nominator = oracles.length * _threshold;
-	return uint8((nominator / 100) + (nominator % 100 == 0 ? 0 : 1));
+        uint256 nominator = oracles.length * _threshold;
+        return uint8((nominator / 100) + (nominator % 100 == 0 ? 0 : 1));
     }
 }

--- a/contracts/v0.2/src/interfaces/IFeedProxy.sol
+++ b/contracts/v0.2/src/interfaces/IFeedProxy.sol
@@ -44,8 +44,5 @@ interface IFeedProxy is IFeed {
      * @param minCount The minimum number of data points
      * @return The TWAP
      */
-    function twap(uint256 interval, uint256 latestUpdatedAtTolerance, int256 minCount)
-        external
-        view
-        returns (int256);
+    function twap(uint256 interval, uint256 latestUpdatedAtTolerance, int256 minCount) external view returns (int256);
 }

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -36,6 +36,21 @@ contract SubmissionProxyTest is Test {
         submissionProxy.addOracle(oracle_);
     }
 
+    function test_RemoveOracle() public {
+        address oracle_ = makeAddr("oracle");
+
+	// add
+        submissionProxy.addOracle(oracle_);
+	assertEq(submissionProxy.oracles(0), oracle_);
+	assertGe(submissionProxy.whitelist(oracle_), block.timestamp);
+
+	// remove
+	submissionProxy.removeOracle(oracle_);
+	vm.expectRevert(bytes("")); // "EvmError: Revert"
+	submissionProxy.oracles(0);
+	assertEq(submissionProxy.whitelist(oracle_), block.timestamp);
+    }
+
     function test_UpdateOracle() public {
 	address oracle_ = makeAddr("oracle");
         submissionProxy.addOracle(oracle_);

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -117,21 +117,6 @@ contract SubmissionProxyTest is Test {
         submissionProxy.setExpirationPeriod(1 weeks);
     }
 
-    function test_SubmitInvalidThreshold() public {
-        uint256 numOracles_ = 1;
-        int256 submissionValue_ = 10;
-        address oracle_ = makeAddr("oracle");
-
-        (address[] memory feeds_, int256[] memory submissions_) =
-            prepareFeedsSubmissions(numOracles_, submissionValue_, oracle_);
-
-        bytes[] memory proofs_ = new bytes[](1);
-        proofs_[0] = "invalid-proof";
-
-        vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
-        submissionProxy.submit(feeds_, submissions_, proofs_);
-    }
-
     function test_SubmitInvalidProof() public {
         uint256 numOracles_ = 1;
         int256 submissionValue_ = 10;

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -213,8 +213,6 @@ contract SubmissionProxyTest is Test {
 
         submissionProxy.setProofThreshold(feeds[0], 100);
 
-        /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash)); */
-        /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(bobIdx), createProof(bobSk, hash)); */
         proofs[0] = abi.encodePacked(
             uint8(aliceIdx),
             createProof(aliceSk, hash),

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -85,6 +85,28 @@ contract SubmissionProxyTest is Test {
 	submissionProxy.updateOracle(newestOracle_);
     }
 
+    function test_SetDefaultProofThreshold() public {
+	// SUCCESS - 1 is a valid threshold
+	uint8 defaultProofThreshold_ = 1;
+	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+	assertEq(submissionProxy.threshold(), defaultProofThreshold_);
+
+	// SUCCESS - 100 is a valid threshold
+	defaultProofThreshold_ = 100;
+	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+	assertEq(submissionProxy.threshold(), defaultProofThreshold_);
+
+	// FAIL - 0 is not a valid threshold
+	defaultProofThreshold_ = 0;
+	vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
+	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+
+	// FAIL - 101 is not a valid threshold
+	defaultProofThreshold_ = 101;
+	vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
+	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+    }
+
     function test_SetMaxSubmission() public {
         uint256 maxSubmission_ = 10;
         submissionProxy.setMaxSubmission(maxSubmission_);
@@ -143,8 +165,6 @@ contract SubmissionProxyTest is Test {
         bytes[] memory proofs_ = new bytes[](1);
         proofs_[0] = "invalid-proof";
 
-        submissionProxy.setProofThreshold(feeds_[0], 1);
-
         submissionProxy.submit(feeds_, submissions_, proofs_);
 
         vm.expectRevert(Feed.NoDataPresent.selector);
@@ -190,7 +210,7 @@ contract SubmissionProxyTest is Test {
         feeds[0] = address(feed);
         submissions[0] = 10;
 
-        submissionProxy.setProofThreshold(feeds[0], 3);
+        submissionProxy.setProofThreshold(feeds[0], 100);
 
         /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash)); */
         /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(bobIdx), createProof(bobSk, hash)); */

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -39,72 +39,72 @@ contract SubmissionProxyTest is Test {
     function test_RemoveOracle() public {
         address oracle_ = makeAddr("oracle");
 
-	// add
+        // add
         submissionProxy.addOracle(oracle_);
-	assertEq(submissionProxy.oracles(0), oracle_);
-	assertGe(submissionProxy.whitelist(oracle_), block.timestamp);
+        assertEq(submissionProxy.oracles(0), oracle_);
+        assertGe(submissionProxy.whitelist(oracle_), block.timestamp);
 
-	// remove
-	submissionProxy.removeOracle(oracle_);
-	vm.expectRevert(bytes("")); // "EvmError: Revert"
-	submissionProxy.oracles(0);
-	assertEq(submissionProxy.whitelist(oracle_), block.timestamp);
+        // remove
+        submissionProxy.removeOracle(oracle_);
+        vm.expectRevert(bytes("")); // "EvmError: Revert"
+        submissionProxy.oracles(0);
+        assertEq(submissionProxy.whitelist(oracle_), block.timestamp);
     }
 
     function test_UpdateOracle() public {
-	address oracle_ = makeAddr("oracle");
+        address oracle_ = makeAddr("oracle");
         submissionProxy.addOracle(oracle_);
 
-	address newOracle_ = makeAddr("new-oracle");
-	address nonOracle_ = makeAddr("non-oracle");
+        address newOracle_ = makeAddr("new-oracle");
+        address nonOracle_ = makeAddr("non-oracle");
 
-	// FAIL - Only registered oracle can update its address
-	vm.prank(nonOracle_);
-	vm.expectRevert(SubmissionProxy.OnlyOracle.selector);
-	submissionProxy.updateOracle(newOracle_);
+        // FAIL - Only registered oracle can update its address
+        vm.prank(nonOracle_);
+        vm.expectRevert(SubmissionProxy.OnlyOracle.selector);
+        submissionProxy.updateOracle(newOracle_);
 
-	// Expiration time is larger than the current block timestamp.
-	uint256 duringUpdateTimestamp = block.timestamp;
-	assertGe(submissionProxy.whitelist(oracle_), duringUpdateTimestamp);
+        // Expiration time is larger than the current block timestamp.
+        uint256 duringUpdateTimestamp = block.timestamp;
+        assertGe(submissionProxy.whitelist(oracle_), duringUpdateTimestamp);
 
-	// SUCCESS - Registered oracle can update its address
-	vm.prank(oracle_);
-	submissionProxy.updateOracle(newOracle_);
+        // SUCCESS - Registered oracle can update its address
+        vm.prank(oracle_);
+        submissionProxy.updateOracle(newOracle_);
 
-	// Old oracle has expiration time changed to the timestamp
-	// during which the update occured.
-	assertEq(submissionProxy.whitelist(oracle_), duringUpdateTimestamp);
+        // Old oracle has expiration time changed to the timestamp
+        // during which the update occured.
+        assertEq(submissionProxy.whitelist(oracle_), duringUpdateTimestamp);
 
-	// New oracle has expiration time larger than the current block timestamp.
-	assertGe(submissionProxy.whitelist(newOracle_), block.timestamp);
+        // New oracle has expiration time larger than the current block timestamp.
+        assertGe(submissionProxy.whitelist(newOracle_), block.timestamp);
 
-	// FAIL - Cannot update with outdated oracle address
-	address newestOracle_ = makeAddr("newest-oracle");
-	vm.expectRevert(SubmissionProxy.OnlyOracle.selector);
-	vm.prank(oracle_);
-	submissionProxy.updateOracle(newestOracle_);
+        // FAIL - Cannot update with outdated oracle address
+        address newestOracle_ = makeAddr("newest-oracle");
+        vm.expectRevert(SubmissionProxy.OnlyOracle.selector);
+        vm.prank(oracle_);
+        submissionProxy.updateOracle(newestOracle_);
     }
 
     function test_SetDefaultProofThreshold() public {
-	// SUCCESS - 1 is a valid threshold
-	uint8 defaultProofThreshold_ = 1;
-	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
-	assertEq(submissionProxy.threshold(), defaultProofThreshold_);
+        // SUCCESS - 1 is a valid threshold
+        uint8 defaultProofThreshold_ = 1;
+        submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+        assertEq(submissionProxy.threshold(), defaultProofThreshold_);
 
-	// SUCCESS - 100 is a valid threshold
-	defaultProofThreshold_ = 100;
-	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
-	assertEq(submissionProxy.threshold(), defaultProofThreshold_);
+        // SUCCESS - 100 is a valid threshold
+        defaultProofThreshold_ = 100;
+        submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+        assertEq(submissionProxy.threshold(), defaultProofThreshold_);
 
-	// FAIL - 0 is not a valid threshold
-	defaultProofThreshold_ = 0;
-	vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
-	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+        // FAIL - 0 is not a valid threshold
+        defaultProofThreshold_ = 0;
+        vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
+        submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
 
-	// FAIL - 101 is not a valid threshold
-	defaultProofThreshold_ = 101;
-	vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
-	submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
+        // FAIL - 101 is not a valid threshold
+        defaultProofThreshold_ = 101;
+        vm.expectRevert(SubmissionProxy.InvalidThreshold.selector);
+        submissionProxy.setDefaultProofThreshold(defaultProofThreshold_);
     }
 
     function test_SetMaxSubmission() public {
@@ -196,13 +196,14 @@ contract SubmissionProxyTest is Test {
         (address celine, uint256 celineSk) = makeAddrAndKey("celine");
 
         uint256 aliceIdx = submissionProxy.addOracle(alice);
-	uint256 bobIdx = submissionProxy.addOracle(bob);
-	uint256 celineIdx = submissionProxy.addOracle(celine);
+        uint256 bobIdx = submissionProxy.addOracle(bob);
+        uint256 celineIdx = submissionProxy.addOracle(celine);
 
         bytes32 hash = keccak256(abi.encodePacked(int256(10)));
 
         uint256 numSubmissions = 1;
-	(address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) = createSubmitParameters(numSubmissions);
+        (address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) =
+            createSubmitParameters(numSubmissions);
 
         // single data feed
         Feed feed = new Feed(DECIMALS, DESCRIPTION, address(submissionProxy));
@@ -214,9 +215,16 @@ contract SubmissionProxyTest is Test {
 
         /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash)); */
         /* proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(bobIdx), createProof(bobSk, hash)); */
-        proofs[0] = abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(bobIdx), createProof(bobSk, hash), uint8(celineIdx), createProof(celineSk, hash));
+        proofs[0] = abi.encodePacked(
+            uint8(aliceIdx),
+            createProof(aliceSk, hash),
+            uint8(bobIdx),
+            createProof(bobSk, hash),
+            uint8(celineIdx),
+            createProof(celineSk, hash)
+        );
 
-	submissionProxy.submit(feeds, submissions, proofs);
+        submissionProxy.submit(feeds, submissions, proofs);
     }
 
     function test_SubmitIndexOutOfBounds() public {
@@ -224,25 +232,24 @@ contract SubmissionProxyTest is Test {
         (address bob, uint256 bobSk) = makeAddrAndKey("bob");
 
         uint256 aliceIdx = submissionProxy.addOracle(alice); // index 0
-	uint256 bobIdx = submissionProxy.addOracle(bob); // index 1
-	uint256 wrongIdx = 3; // cannot be index 3 (out of bounds)
-	assertEq((wrongIdx - bobIdx) != 0, true);
+        uint256 bobIdx = submissionProxy.addOracle(bob); // index 1
+        uint256 wrongIdx = 3; // cannot be index 3 (out of bounds)
+        assertEq((wrongIdx - bobIdx) != 0, true);
 
         uint256 numSubmissions = 1;
-	(address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) = createSubmitParameters(numSubmissions);
+        (address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) =
+            createSubmitParameters(numSubmissions);
 
         Feed feed = new Feed(DECIMALS, DESCRIPTION, address(submissionProxy));
 
         feeds[0] = address(feed);
         submissions[0] = 10;
-	bytes32 hash = keccak256(abi.encodePacked(int256(submissions[0])));
-        proofs[0] = abi.encodePacked(
-	    uint8(aliceIdx), createProof(aliceSk, hash),
-	    uint8(wrongIdx), createProof(bobSk, hash)
-	);
+        bytes32 hash = keccak256(abi.encodePacked(int256(submissions[0])));
+        proofs[0] =
+            abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(wrongIdx), createProof(bobSk, hash));
 
-	vm.expectRevert(SubmissionProxy.IndexOutOfBounds.selector);
-	submissionProxy.submit(feeds, submissions, proofs);
+        vm.expectRevert(SubmissionProxy.IndexOutOfBounds.selector);
+        submissionProxy.submit(feeds, submissions, proofs);
     }
 
     function test_SubmitIndexNotAscending() public {
@@ -250,33 +257,36 @@ contract SubmissionProxyTest is Test {
         (address bob, uint256 bobSk) = makeAddrAndKey("bob");
 
         uint256 aliceIdx = submissionProxy.addOracle(alice); // index 0
-	uint256 bobIdx = submissionProxy.addOracle(bob); // index 1
-	uint256 wrongIdx = 0; // cannot be index 0 (repetitive index)
-	assertGe(bobIdx, wrongIdx);
+        uint256 bobIdx = submissionProxy.addOracle(bob); // index 1
+        uint256 wrongIdx = 0; // cannot be index 0 (repetitive index)
+        assertGe(bobIdx, wrongIdx);
 
         uint256 numSubmissions = 1;
-	(address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) = createSubmitParameters(numSubmissions);
+        (address[] memory feeds, int256[] memory submissions, bytes[] memory proofs) =
+            createSubmitParameters(numSubmissions);
 
         Feed feed = new Feed(DECIMALS, DESCRIPTION, address(submissionProxy));
 
         feeds[0] = address(feed);
         submissions[0] = 10;
-	bytes32 hash = keccak256(abi.encodePacked(int256(submissions[0])));
-        proofs[0] = abi.encodePacked(
-	    uint8(aliceIdx), createProof(aliceSk, hash),
-	    uint8(wrongIdx), createProof(bobSk, hash)
-	);
+        bytes32 hash = keccak256(abi.encodePacked(int256(submissions[0])));
+        proofs[0] =
+            abi.encodePacked(uint8(aliceIdx), createProof(aliceSk, hash), uint8(wrongIdx), createProof(bobSk, hash));
 
-	vm.expectRevert(SubmissionProxy.IndexesNotAscending.selector);
-	submissionProxy.submit(feeds, submissions, proofs);
+        vm.expectRevert(SubmissionProxy.IndexesNotAscending.selector);
+        submissionProxy.submit(feeds, submissions, proofs);
     }
 
-    function createSubmitParameters(uint256 numSubmissions) internal pure returns (address[] memory, int256[] memory, bytes[] memory) {
+    function createSubmitParameters(uint256 numSubmissions)
+        internal
+        pure
+        returns (address[] memory, int256[] memory, bytes[] memory)
+    {
         address[] memory feeds = new address[](numSubmissions);
         int256[] memory submissions = new int256[](numSubmissions);
         bytes[] memory proofs = new bytes[](numSubmissions);
 
-	return (feeds, submissions, proofs);
+        return (feeds, submissions, proofs);
     }
 
     function createProof(uint256 sk, bytes32 hash) internal pure returns (bytes memory) {


### PR DESCRIPTION
# Description

This PR updates the 1) proof generation, and allows to 2) remove oracle and 3) specify relative signature threshold.

## Proof generation

Every node (off-chain oracle) is defined by an index obtained during `addOracle` function execution. This index will stay with node until the node keeps extending its expiration time, or is removed (`removeOracle`) by contract owner. The node index is given to node operator and can be also fetched from `oracles` public array. Submitted proofs have to be sorted based on given indexes, otherwise the verification process fails.

## Oracle removal

Previously, we assumed that every node will be allowed to produce proofs until it keeps extending its expiration time, however, sometimes, it might be necessary to remove a certain node operator. New function `removeOracle` that accomplishes this functionality has been added.

## Relative threshold

Previously, threshold proof was defined as an minimum number of valid proofs. This PR integrates a relative definition of threshold proof (e.g. 50 %) and defines a default threshold that is used if there is no custom threshold setup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added constants `MIN_THRESHOLD` and `MAX_THRESHOLD`.
	- Introduced `threshold` variable and `oracles` array.
	- Enhanced proof verification logic with indexes and quorum calculation.
	- Added `splitBytesToChunks` function to handle proof splitting.
	- Implemented `quorum` function to calculate the quorum for a threshold.

- **Bug Fixes**
	- Adjusted access control modifiers and error messages in `Feed.sol`.
	- Improved error handling for out-of-bounds and non-ascending index submissions during proof verification.

- **Documentation**
	- Streamlined function declaration in the `IFeedProxy` interface for clarity.

- **Tests**
	- Expanded testing suite to cover new functionalities like oracle management, proof submission, and threshold settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->