### PR TITLE
Ignore latest tag when check to count of images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 .DS_Store
 dockerfiles/local-data-feed/tmp/**
 .env
+.aider*

--- a/monitor/scripts/ecr-check.sh
+++ b/monitor/scripts/ecr-check.sh
@@ -16,7 +16,7 @@ check_repository_tags() {
 
     # Count the number of tags
     available_tags=$(echo "$response" | jq '.imageTagDetails |= sort_by(.createdAt)')
-    tag_count=$(echo "$available_tags" | jq '.imageTagDetails[].imageTag' | wc -l | tr -d '[:space:]')
+    tag_count=$(echo "$available_tags" | jq '.imageTagDetails[].imageTag | select(. != "latest")' | wc -l | tr -d '[:space:]')
 
     # Check if the tag count exceeds the maximum allowed
     if [ "${tag_count}" -gt "${max_tag_count}" ]; then


### PR DESCRIPTION
# Description
Tiny change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude files starting with `.aider*`.
- **Bug Fixes**
	- Improved tag counting logic in the monitoring script to exclude the "latest" tag, ensuring accurate compliance with tag limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->