### PR TITLE
Allow to update submitter

### DIFF
--- a/contracts/v0.2/src/Feed.sol
+++ b/contracts/v0.2/src/Feed.sol
@@ -26,7 +26,9 @@ contract Feed is Ownable, IFeed {
     mapping(uint64 roundId => Round data) internal rounds;
 
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
+    event SubmitterUpdated(address indexed submitter);
 
+    error InvalidSubmitter();
     error OnlySubmitter();
     error NoDataPresent();
 
@@ -48,6 +50,19 @@ contract Feed is Ownable, IFeed {
         decimals = _decimals;
         description = _description;
         submitter = _submitter;
+    }
+
+    /**
+     * @notice Update the submitter address.
+     * @param _submitter The address of the new submitter
+     */
+    function updateSubmitter(address _submitter) external onlyOwner {
+	if (_submitter == address(0)) {
+	    revert InvalidSubmitter();
+	}
+
+	submitter = _submitter;
+	emit SubmitterUpdated(_submitter);
     }
 
     /**

--- a/contracts/v0.2/test/Feed.t.sol
+++ b/contracts/v0.2/test/Feed.t.sol
@@ -12,9 +12,40 @@ contract FeedTest is Test {
     string description = "Test Feed";
 
     event FeedUpdated(int256 indexed answer, uint256 indexed roundId, uint256 updatedAt);
+    event SubmitterUpdated(address indexed submitter);
+    error OwnableUnauthorizedAccount(address account);
 
     function setUp() public {
         feed = new Feed(decimals, description, oracle);
+    }
+
+    function test_UpdateSubmitter() public {
+	address newSubmitter = makeAddr("new-submitter");
+	assert(feed.submitter() != newSubmitter);
+
+	// SUCCESS
+	vm.expectEmit(true, true, true, true);
+        emit SubmitterUpdated(newSubmitter);
+	feed.updateSubmitter(newSubmitter);
+	assertEq(feed.submitter(), newSubmitter);
+    }
+
+    function test_UpdateSubmitterWithNonOwner() public {
+	address nonOwner = makeAddr("non-owner");
+	address newSubmitter = makeAddr("new-submitter");
+
+	// FAIL - only owner can update submitter
+	vm.prank(nonOwner);
+	vm.expectRevert(
+	    abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, nonOwner)
+	);
+	feed.updateSubmitter(newSubmitter);
+    }
+
+    function test_UpdateSubmitterWithZeroAddress() public {
+	// FAIL - cannot set submitter to address(0)
+	vm.expectRevert(Feed.InvalidSubmitter.selector);
+	feed.updateSubmitter(address(0));
     }
 
     function test_SubmitAndReadResponse() public {


### PR DESCRIPTION
# Description

Owner of `Feed` contract is allowed to update `submitter` address (smart contract or EOA that can submit to `Feed`). The new value of `submitter` cannot be zero address.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability for users to update the submitter address in the system.
- **Bug Fixes**
	- Introduced error handling for invalid submitter addresses.
- **Tests**
	- Enhanced testing for submitter address updates, including tests for unauthorized and zero address scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->