### PR TITLE
(OraklNode) Fix raft leaderId property not being set from leader node

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -93,8 +93,8 @@ func (n *Aggregator) HandleRoundSyncMessage(ctx context.Context, msg raft.Messag
 	}
 
 	if msg.SentFrom != n.Raft.GetLeader() {
-		log.Warn().Str("Player", "Aggregator").Msg("trigger message sent from non-leader")
-		return fmt.Errorf("trigger message sent from non-leader")
+		log.Warn().Str("Player", "Aggregator").Msg("round sync message sent from non-leader")
+		return fmt.Errorf("round sync message sent from non-leader")
 	}
 
 	if roundSyncMessage.LeaderID == "" || roundSyncMessage.RoundID == 0 {

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -92,6 +92,11 @@ func (n *Aggregator) HandleRoundSyncMessage(ctx context.Context, msg raft.Messag
 		return err
 	}
 
+	if msg.SentFrom != n.Raft.GetLeader() {
+		log.Warn().Str("Player", "Aggregator").Msg("trigger message sent from non-leader")
+		return fmt.Errorf("trigger message sent from non-leader")
+	}
+
 	if roundSyncMessage.LeaderID == "" || roundSyncMessage.RoundID == 0 {
 		log.Error().Str("Player", "Aggregator").Msg("invalid round sync message")
 		return fmt.Errorf("invalid round sync message: %v", roundSyncMessage)

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -309,6 +309,7 @@ func (r *Raft) becomeLeader(ctx context.Context) {
 	r.Resign = make(chan interface{})
 	r.ElectionTimer.Stop()
 	r.UpdateRole(Leader)
+	r.UpdateLeader(r.GetHostId())
 	r.HeartbeatTicker = time.NewTicker(r.HeartbeatTimeout)
 	r.LeaderJobTicker = time.NewTicker(r.LeaderJobTimeout)
 


### PR DESCRIPTION
# Description

`UpdateLeader` has been called only on receiving heartbeat message, this lead to result ending up where all followers setting up leader id but leader node leaving its leader id empty.

this pr fixes the issue by setting leader id as itself from `becomeLeader` function

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced security by verifying the leader's identity before processing round sync messages in the aggregator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->