### PR TITLE
(Delegator) Update logic which caused invalid chainid err

### DIFF
--- a/delegator/sign/controller.go
+++ b/delegator/sign/controller.go
@@ -173,6 +173,11 @@ func insertV2(c *fiber.Ctx) error {
 		panic(err)
 	}
 
+	transaction, err := HashToTx(payload.RawTx)
+	if err != nil {
+		panic(err)
+	}
+
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
 		panic(err)
@@ -192,10 +197,16 @@ func insertV2(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	err = signTxByFeePayer(c, tx)
+	signedTransaction, err := signTxByFeePayerV2(c, transaction)
 	if err != nil {
 		panic(err)
 	}
+
+	succeed := true
+	rawTxHash := TxToHash(signedTransaction)
+	tx.Succeed = &succeed
+	tx.SignedRawTx = &rawTxHash
+
 	result, err := updateTransaction(c, tx)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Description

Use `signTxByFeePayerV2` instead of `signTxByFeePayer`. Assuming there has been an issue on setting up chain id from the function, leading to error on submitting transaction, 

which didn't happen from `onlySign` function which uses `signTxByFeePayerV2`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction processing by introducing improved signing and updating mechanisms for transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->