### PR TITLE
(Delegator) Use custom error handler instead of panic

### DIFF
--- a/delegator/contract/controller.go
+++ b/delegator/contract/controller.go
@@ -46,17 +46,17 @@ type ReporterModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ContractInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ContractModel](c, InsertContract, map[string]any{"address": strings.ToLower(payload.Address)})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -66,7 +66,7 @@ func get(c *fiber.Ctx) error {
 
 	contractResults, err := utils.QueryRows[ContractModel](c, GetContract, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	results := make([]ContractDetailModel, len(contractResults))
@@ -76,7 +76,7 @@ func get(c *fiber.Ctx) error {
 
 		reporters, err := utils.QueryRows[ReporterModel](c, GetConnectedReporters, map[string]any{"contractId": contract.ContractId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		results[i].Reporter = make([]string, len(reporters))
@@ -86,7 +86,7 @@ func get(c *fiber.Ctx) error {
 
 		functions, err := utils.QueryRows[FunctionModel](c, GetConnectedFunctions, map[string]any{"contractId": contract.ContractId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		results[i].EncodedName = make([]string, len(functions))
@@ -102,7 +102,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	contractResult, err := utils.QueryRow[ContractModel](c, GetContractById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result := ContractDetailModel{
 		Address:    contractResult.Address,
@@ -110,7 +110,7 @@ func getById(c *fiber.Ctx) error {
 	}
 	reporters, err := utils.QueryRows[ReporterModel](c, GetConnectedReporters, map[string]any{"contractId": contractResult.ContractId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result.Reporter = make([]string, len(reporters))
 	for i, reporter := range reporters {
@@ -119,7 +119,7 @@ func getById(c *fiber.Ctx) error {
 
 	functions, err := utils.QueryRows[FunctionModel](c, GetConnectedFunctions, map[string]any{"contractId": contractResult.ContractId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.EncodedName = make([]string, len(functions))
@@ -133,17 +133,17 @@ func getById(c *fiber.Ctx) error {
 func connectReporter(c *fiber.Ctx) error {
 	payload := new(ContractConnectModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	err := utils.RawQueryWithoutReturn(c, ConnectReporter, map[string]any{"contractId": payload.ContractId, "reporterId": payload.ReporterId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(nil)
@@ -152,17 +152,17 @@ func connectReporter(c *fiber.Ctx) error {
 func disconnectReporter(c *fiber.Ctx) error {
 	payload := new(ContractConnectModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	err := utils.RawQueryWithoutReturn(c, DisconnectReporter, map[string]any{"contractId": payload.ContractId, "reporterId": payload.ReporterId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(nil)
 }
@@ -171,17 +171,17 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ContractInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ContractModel](c, UpdateContract, map[string]any{"id": id, "address": payload.Address})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -190,7 +190,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ContractModel](c, DeleteContract, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }

--- a/delegator/function/controller.go
+++ b/delegator/function/controller.go
@@ -36,12 +36,12 @@ type ContractModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(FunctionInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	hash := crypto.Keccak256([]byte(payload.Name))
@@ -53,7 +53,7 @@ func insert(c *fiber.Ctx) error {
 		"encodedName": encodedName,
 	})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -62,14 +62,14 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	functionResults, err := utils.QueryRows[FunctionModel](c, GetFunction, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	results := make([]FunctionDetailModel, len(functionResults))
 	for i, function := range functionResults {
 		contract, err := utils.QueryRow[ContractModel](c, GetContractById, map[string]any{"id": function.ContractId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		results[i] = FunctionDetailModel{
 			FunctionId:  function.FunctionId,
@@ -86,11 +86,11 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	function, err := utils.QueryRow[FunctionModel](c, GetFunctionById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	contract, err := utils.QueryRow[ContractModel](c, GetContractById, map[string]any{"id": function.ContractId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result := FunctionDetailModel{
 		FunctionId:  function.FunctionId,
@@ -106,12 +106,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(FunctionInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	hash := crypto.Keccak256([]byte(payload.Name))
@@ -119,7 +119,7 @@ func updateById(c *fiber.Ctx) error {
 
 	result, err := utils.QueryRow[FunctionModel](c, UpdateFunctionById, map[string]any{"id": id, "name": payload.Name, "contract_id": payload.ContractId, "encodedName": encodedName})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -129,7 +129,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[FunctionModel](c, DeleteFunctionById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/delegator/organization/controller.go
+++ b/delegator/organization/controller.go
@@ -18,17 +18,17 @@ type OrganizationModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(OrganizationInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[OrganizationModel](c, InsertOrganization, map[string]any{"name": payload.Name})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 
@@ -37,7 +37,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	result, err := utils.QueryRows[OrganizationModel](c, GetOrganization, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -46,7 +46,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[OrganizationModel](c, GetOrganizationById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -55,11 +55,11 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(OrganizationInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 	result, err := utils.QueryRow[OrganizationModel](c, UpdateOrganization, map[string]any{"name": payload.Name, "id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -68,7 +68,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[OrganizationModel](c, DeleteOrganization, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }

--- a/delegator/reporter/controller.go
+++ b/delegator/reporter/controller.go
@@ -39,17 +39,17 @@ type OrganizationName struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ReporterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, InsertReporter, map[string]any{"address": strings.ToLower(payload.Address), "organizationId": payload.OrganizationId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -58,19 +58,19 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	reporters, err := utils.QueryRows[ReporterModel](c, GetReporter, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	results := make([]ReporterDetailModel, len(reporters))
 	for i, reporter := range reporters {
 		organizationName, err := utils.QueryRow[OrganizationName](c, GetOrganizationName, map[string]any{"organizationId": reporter.OrganizationId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		contracts, err := utils.QueryRows[ContractModel](c, GetConnectedContracts, map[string]any{"reporterId": reporter.ReporterId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		contractAddresses := make([]string, len(contracts))
@@ -93,16 +93,16 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	reporter, err := utils.QueryRow[ReporterModel](c, GetReporterById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	organizationName, err := utils.QueryRow[OrganizationName](c, GetOrganizationName, map[string]any{"organizationId": reporter.OrganizationId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	contracts, err := utils.QueryRows[ContractModel](c, GetConnectedContracts, map[string]any{"reporterId": reporter.ReporterId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	contractAddresses := make([]string, len(contracts))
@@ -124,17 +124,17 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ReporterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, UpdateReporterById, map[string]any{"id": id, "address": payload.Address, "organizationId": payload.OrganizationId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -144,7 +144,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ReporterModel](c, DeleteReporterById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }

--- a/delegator/sign/controller.go
+++ b/delegator/sign/controller.go
@@ -92,11 +92,11 @@ func initialize(c *fiber.Ctx) error {
 	if pk == "" {
 		pgx, err := utils.GetPgx(c)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		err = utils.InitFeePayerPK(c.Context(), pgx)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		return c.SendString("Initialized")
 	}
@@ -109,12 +109,12 @@ func initialize(c *fiber.Ctx) error {
 func insert(c *fiber.Ctx) error {
 	payload := new(SignInsertPayload)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	payload.Timestamp = &utils.CustomDateTime{Time: time.Now()}
@@ -123,21 +123,21 @@ func insert(c *fiber.Ctx) error {
 
 	tx, err := insertTransaction(c, payload)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = validateTransaction(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = signTxByFeePayer(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := updateTransaction(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -145,21 +145,21 @@ func insert(c *fiber.Ctx) error {
 func onlySign(c *fiber.Ctx) error {
 	payload := new(SignInsertPayload)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 	transaction, err := HashToTx(payload.RawTx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	signedTransaction, err := signTxByFeePayerV2(c, transaction)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	signedRawTx := TxToHash(signedTransaction)
@@ -170,12 +170,12 @@ func onlySign(c *fiber.Ctx) error {
 func insertV2(c *fiber.Ctx) error {
 	payload := new(SignInsertPayload)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	payload.Timestamp = &utils.CustomDateTime{Time: time.Now()}
@@ -184,21 +184,21 @@ func insertV2(c *fiber.Ctx) error {
 
 	tx, err := insertTransaction(c, payload)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = validateContractAddress(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = signTxByFeePayer(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result, err := updateTransaction(c, tx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -207,7 +207,7 @@ func insertV2(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	transactions, err := utils.QueryRows[SignModel](c, GetTransactions, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(transactions)
@@ -217,7 +217,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	transaction, err := utils.QueryRow[SignModel](c, GetTransactionById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(transaction)
 }


### PR DESCRIPTION
# Description

On returning error, it now uses custom error handler which returns in form of 
```
return c.Status(code).SendString(err.Error())
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling across various functions by replacing abrupt termination (`panic`) with error returns, enhancing system stability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->