### PR TITLE
(API) Use custom err handler instead of panic

### DIFF
--- a/api/adapter/controller.go
+++ b/api/adapter/controller.go
@@ -56,17 +56,17 @@ type FeedIdModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(AdapterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	err := computeAdapterHashForInsertRoute(payload, true)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		return err
 	}
 
 	row, err := utils.QueryRow[AdapterIdModel](c, InsertAdapter, map[string]any{
@@ -74,7 +74,7 @@ func insert(c *fiber.Ctx) error {
 		"name":         payload.Name,
 		"decimals":     payload.Decimals})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for _, item := range payload.Feeds {
@@ -84,7 +84,7 @@ func insert(c *fiber.Ctx) error {
 			"definition": item.Definition,
 			"adapter_id": item.AdapterId})
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -97,23 +97,23 @@ func hash(c *fiber.Ctx) error {
 	verifyRaw := c.Query("verify")
 	verify, err := strconv.ParseBool(verifyRaw)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	var payload HashInsertModel
 
 	if err := c.BodyParser(&payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	err = computeAdapterHashForHashRoute(&payload, verify)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		return err
 	}
 	return c.JSON(payload)
 }
@@ -121,7 +121,7 @@ func hash(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[AdapterModel](c, GetAdapter, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -131,7 +131,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AdapterModel](c, GetAdpaterById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -141,7 +141,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AdapterModel](c, RemoveAdapter, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/aggregator/controller.go
+++ b/api/aggregator/controller.go
@@ -89,22 +89,22 @@ type AggregatorIdModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(AggregatorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	adapter_result, err := utils.QueryRow[adapter.AdapterModel](c, adapter.GetAdapterByHash, map[string]any{"adapter_hash": payload.AdapterHash})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	hashComputeParam := AggregatorHashComputeInputModel{
@@ -119,7 +119,7 @@ func insert(c *fiber.Ctx) error {
 	}
 	err = computeAggregatorHash(&hashComputeParam, true)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		return err
 	}
 
 	insertParam := _AggregatorInsertModel{
@@ -158,7 +158,7 @@ func insert(c *fiber.Ctx) error {
 		"fetcher_type":       insertParam.FetcherType,
 	})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result := AggregatorResultModel{
@@ -182,17 +182,17 @@ func hash(c *fiber.Ctx) error {
 	verifyRaw := c.Query("verify")
 	verify, err := strconv.ParseBool(verifyRaw)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	payload := new(AggregatorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.StructExcept(payload, "Chain"); err != nil {
-		panic(err)
+		return err
 	}
 
 	hashComputeParam := AggregatorHashComputeInputModel{
@@ -208,7 +208,7 @@ func hash(c *fiber.Ctx) error {
 
 	err = computeAggregatorHash(&hashComputeParam, verify)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		return err
 	}
 
 	return c.JSON(hashComputeParam)
@@ -223,12 +223,12 @@ func get(c *fiber.Ctx) error {
 	}
 	queryString, err := GenerateGetAggregatorQuery(queryParam)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	results, err := utils.QueryRows[AggregatorResultModel](c, queryString, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -241,7 +241,7 @@ func getByHashAndChain(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": _chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.AggregatorResultModel, err = utils.QueryRow[AggregatorResultModel](c, GetAggregatorByChainAndHash, map[string]any{
@@ -249,17 +249,17 @@ func getByHashAndChain(c *fiber.Ctx) error {
 		"chain_id":        chain_result.ChainId,
 	})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.Adapter.AdapterModel, err = utils.QueryRow[adapter.AdapterModel](c, adapter.GetAdpaterById, map[string]any{"id": result.AggregatorResultModel.AdapterId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.Adapter.Feeds, err = utils.QueryRows[feed.FeedModel](c, feed.GetFeedsByAdapterId, map[string]any{"id": result.AggregatorResultModel.AdapterId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -268,7 +268,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[AggregatorResultModel](c, RemoveAggregator, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -278,14 +278,14 @@ func updateByHash(c *fiber.Ctx) error {
 	hash := c.Params("hash")
 	_payload := new(WrappedUpdateModel)
 	if err := c.BodyParser(_payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	payload := _payload.Data
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	if payload.Active == nil {
@@ -295,7 +295,7 @@ func updateByHash(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[AggregatorResultModel](c, UpdateAggregatorByHash, map[string]any{
@@ -303,7 +303,7 @@ func updateByHash(c *fiber.Ctx) error {
 		"hash":     hash,
 		"chain_id": chain_result.ChainId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/apierr/controller.go
+++ b/api/apierr/controller.go
@@ -1,8 +1,9 @@
 package apierr
 
 import (
-	"bisonai.com/orakl/api/utils"
 	"fmt"
+
+	"bisonai.com/orakl/api/utils"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
@@ -28,12 +29,12 @@ type ErrorModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ErrorInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ErrorModel](c, InsertError, map[string]any{
@@ -44,7 +45,7 @@ func insert(c *fiber.Ctx) error {
 		"stack":      payload.Stack})
 
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -53,7 +54,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ErrorModel](c, GetError, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(results)
 }
@@ -62,7 +63,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ErrorModel](c, GetErrorById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -75,7 +76,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ErrorModel](c, RemoveErrorById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/chain/controller.go
+++ b/api/chain/controller.go
@@ -20,17 +20,17 @@ func insert(c *fiber.Ctx) error {
 	payload := new(ChainInsertModel)
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ChainModel](c, InsertChain, map[string]any{"name": payload.Name})
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to insert chain: " + err.Error())
+		return err
 	}
 
 	return c.JSON(result)
@@ -39,7 +39,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ChainModel](c, GetChain, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -49,7 +49,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ChainModel](c, GetChainByID, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -60,12 +60,12 @@ func patchById(c *fiber.Ctx) error {
 	payload := new(ChainInsertModel)
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ChainModel](c, UpdateChain, map[string]any{"name": payload.Name, "id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -76,7 +76,7 @@ func deleteById(c *fiber.Ctx) error {
 
 	result, err := utils.QueryRow[ChainModel](c, RemoveChain, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/data/controller.go
+++ b/api/data/controller.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"bisonai.com/orakl/api/utils"
 	"fmt"
+
+	"bisonai.com/orakl/api/utils"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -33,17 +34,17 @@ type BulkInsertResultModel struct {
 func bulkInsert(c *fiber.Ctx) error {
 	payload := new(BulkInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	query, err := GenerateBulkInsertQuery(payload.Data)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = utils.RawQueryWithoutReturn(c, query, nil)
 
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	countResult := BulkInsertResultModel{Count: len(payload.Data)}
@@ -54,7 +55,7 @@ func bulkInsert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[DataResultModel](c, GetData, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -64,7 +65,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[DataResultModel](c, GetDataById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -77,7 +78,7 @@ func getByFeedId(c *fiber.Ctx) error {
 	id := c.Params("id")
 	results, err := utils.QueryRows[DataResultModel](c, GetDataByFeedId, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -90,7 +91,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[DataResultModel](c, DeleteDataById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/feed/controller.go
+++ b/api/feed/controller.go
@@ -1,8 +1,9 @@
 package feed
 
 import (
-	"bisonai.com/orakl/api/utils"
 	"fmt"
+
+	"bisonai.com/orakl/api/utils"
 
 	"encoding/json"
 
@@ -30,7 +31,7 @@ type FeedModel struct {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[FeedModel](c, GetFeed, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -40,7 +41,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[FeedModel](c, GetFeedById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -53,7 +54,7 @@ func getByAdpaterId(c *fiber.Ctx) error {
 	id := c.Params("id")
 	results, err := utils.QueryRows[FeedModel](c, GetFeedsByAdapterId, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(results)
 }
@@ -65,7 +66,7 @@ func removeById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[FeedModel](c, DeleteFeedById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/l2aggregator/controller.go
+++ b/api/l2aggregator/controller.go
@@ -21,12 +21,12 @@ func get(c *fiber.Ctx) error {
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": _chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[l2agregatorPairModel](c, GetL2AggregatorPair, map[string]any{"l1_aggregator_address": l1Address, "chain_id": chain_result.ChainId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/listener/controller.go
+++ b/api/listener/controller.go
@@ -37,22 +37,22 @@ type ListenerInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ListenerInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ListenerModel](c, InsertListener, map[string]any{
@@ -61,7 +61,7 @@ func insert(c *fiber.Ctx) error {
 		"chain_id":   chain_result.ChainId,
 		"service_id": service_result.ServiceId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -74,20 +74,20 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[ListenerModel](c, GenerateGetListenerQuery(params), nil)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		return c.JSON(results)
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -95,14 +95,14 @@ func get(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ListenerModel](c, GenerateGetListenerQuery(params), nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -112,7 +112,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ListenerModel](c, GetListenerById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -122,12 +122,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ListenerUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ListenerModel](c, UpdateListenerById, map[string]any{
@@ -135,7 +135,7 @@ func updateById(c *fiber.Ctx) error {
 		"address":    payload.Address,
 		"event_name": payload.EventName})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -146,7 +146,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ListenerModel](c, DeleteListenerById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/proxy/controller.go
+++ b/api/proxy/controller.go
@@ -25,12 +25,12 @@ type ProxyInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ProxyInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ProxyModel](c, InsertProxy, map[string]any{
@@ -39,7 +39,7 @@ func insert(c *fiber.Ctx) error {
 		"port":     payload.Port,
 		"location": &payload.Location})
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to insert proxy: " + err.Error())
+		return err
 	}
 
 	return c.JSON(result)
@@ -48,7 +48,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ProxyModel](c, GetProxy, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -58,7 +58,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ProxyModel](c, GetProxyById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -69,12 +69,12 @@ func updateById(c *fiber.Ctx) error {
 
 	payload := new(ProxyInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ProxyModel](c, UpdateProxyById, map[string]any{
@@ -84,7 +84,7 @@ func updateById(c *fiber.Ctx) error {
 		"port":     payload.Port,
 		"location": &payload.Location})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -94,7 +94,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ProxyModel](c, DeleteProxyById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/reporter/controller.go
+++ b/api/reporter/controller.go
@@ -46,27 +46,27 @@ type ReporterSearchByOracleAddressModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ReporterInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	encrypted, err := utils.EncryptText(payload.PrivateKey)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, InsertReporter, map[string]any{
@@ -76,7 +76,7 @@ func insert(c *fiber.Ctx) error {
 		"chain_id":      chain_result.ChainId,
 		"service_id":    service_result.ServiceId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.PrivateKey = payload.PrivateKey
@@ -91,12 +91,12 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		for i := range results {
 			decrypted, err := utils.DecryptText(results[i].PrivateKey)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			results[i].PrivateKey = decrypted
 		}
@@ -105,13 +105,13 @@ func get(c *fiber.Ctx) error {
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -119,20 +119,20 @@ func get(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for i := range results {
 		decrypted, err := utils.DecryptText(results[i].PrivateKey)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		results[i].PrivateKey = decrypted
 	}
@@ -146,7 +146,7 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	params := GetReporterQueryParams{}
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	params.OracleAddress = oracleAddress
@@ -154,7 +154,7 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	if payload.Chain != "" {
 		chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ChainId = chain_result.ChainId.String()
 	}
@@ -162,20 +162,20 @@ func getByOracleAddress(c *fiber.Ctx) error {
 	if payload.Service != "" {
 		service_result, err := utils.QueryRow[service.ServiceModel](c, service.GetServiceByName, map[string]any{"name": payload.Service})
 		if err != nil {
-			panic(err)
+			return err
 		}
 		params.ServiceId = service_result.ServiceId.String()
 	}
 
 	results, err := utils.QueryRows[ReporterModel](c, GenerateGetReporterQuery(params), nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for i := range results {
 		decrypted, err := utils.DecryptText(results[i].PrivateKey)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		results[i].PrivateKey = decrypted
 	}
@@ -187,12 +187,12 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ReporterModel](c, GetReporterById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	decrypted, err := utils.DecryptText(result.PrivateKey)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result.PrivateKey = decrypted
 
@@ -203,17 +203,17 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ReporterUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	encrypted, err := utils.EncryptText(payload.PrivateKey)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ReporterModel](c, UpdateReporterById, map[string]any{
@@ -223,7 +223,7 @@ func updateById(c *fiber.Ctx) error {
 		"oracleAddress": payload.OracleAddress})
 
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result.PrivateKey = payload.PrivateKey
@@ -235,12 +235,12 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ReporterModel](c, DeleteReporterById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	decrypted, err := utils.DecryptText(result.PrivateKey)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	result.PrivateKey = decrypted
 

--- a/api/service/controller.go
+++ b/api/service/controller.go
@@ -19,17 +19,17 @@ type ServiceInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(ServiceInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ServiceModel](c, InsertService, map[string]any{"name": payload.Name})
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to insert service: " + err.Error())
+		return err
 	}
 
 	return c.JSON(result)
@@ -38,7 +38,7 @@ func insert(c *fiber.Ctx) error {
 func get(c *fiber.Ctx) error {
 	results, err := utils.QueryRows[ServiceModel](c, GetService, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(results)
 }
@@ -47,7 +47,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ServiceModel](c, GetServiceById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return c.JSON(result)
 }
@@ -56,12 +56,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(ServiceInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[ServiceModel](c, UpdateServiceById, map[string]any{"id": id, "name": payload.Name})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -71,7 +71,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[ServiceModel](c, DeleteServiceById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)

--- a/api/vrf/controller.go
+++ b/api/vrf/controller.go
@@ -38,17 +38,17 @@ type VrfInsertModel struct {
 func insert(c *fiber.Ctx) error {
 	payload := new(VrfInsertModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.Chain})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[VrfModel](c, InsertVrf, map[string]any{
@@ -59,7 +59,7 @@ func insert(c *fiber.Ctx) error {
 		"key_hash": payload.KeyHash,
 		"chain_id": chain_result.ChainId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -73,23 +73,23 @@ func get(c *fiber.Ctx) error {
 	if len(c.Body()) == 0 {
 		results, err := utils.QueryRows[VrfModel](c, GetVrfWithoutChainId, nil)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		return c.JSON(results)
 	}
 
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	chain_result, err := utils.QueryRow[chain.ChainModel](c, chain.GetChainByName, map[string]any{"name": payload.CHAIN})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	results, err := utils.QueryRows[VrfModel](c, GetVrf, map[string]any{"chain_id": chain_result.ChainId})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(results)
@@ -99,7 +99,7 @@ func getById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[VrfModel](c, GetVrfById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -109,12 +109,12 @@ func updateById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	payload := new(VrfUpdateModel)
 	if err := c.BodyParser(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(payload); err != nil {
-		panic(err)
+		return err
 	}
 
 	result, err := utils.QueryRow[VrfModel](c, UpdateVrfById, map[string]any{
@@ -125,7 +125,7 @@ func updateById(c *fiber.Ctx) error {
 		"pk_y":     payload.PkY,
 		"key_hash": payload.KeyHash})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)
@@ -135,7 +135,7 @@ func deleteById(c *fiber.Ctx) error {
 	id := c.Params("id")
 	result, err := utils.QueryRow[VrfModel](c, DeleteVrfById, map[string]any{"id": id})
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return c.JSON(result)


### PR DESCRIPTION
# Description

On returning error, it now uses custom error handler which returns in form of
```
return c.Status(code).SendString(err.Error())
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling across various API controllers by replacing panic responses with error returns, enhancing system stability and error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->