### PR TITLE
(OraklNode) Customizable aggregator frequency

### DIFF
--- a/node/migrations/000017_aggregator_frequency.down.sql
+++ b/node/migrations/000017_aggregator_frequency.down.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'aggregators'
+        AND column_name = 'interval'
+    ) THEN
+        ALTER TABLE aggregators
+        DROP COLUMN interval;
+    END IF;
+END $$;

--- a/node/migrations/000017_aggregator_frequency.up.sql
+++ b/node/migrations/000017_aggregator_frequency.up.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'aggregators'
+        AND column_name = 'interval'
+    ) THEN
+        ALTER TABLE aggregators
+        ADD COLUMN interval INT4 DEFAULT 5000 NOT NULL;
+    END IF;
+END $$;

--- a/node/pkg/admin/aggregator/queries.go
+++ b/node/pkg/admin/aggregator/queries.go
@@ -7,6 +7,11 @@ const (
 	ON CONFLICT (name) DO UPDATE SET active = true
 	RETURNING *;`
 
+	UpsertAggregatorWithInterval = `INSERT INTO aggregators (name, interval) VALUES (@name, @interval)
+	ON CONFLICT (name) DO UPDATE SET active = true, interval = @interval
+	RETURNING *;
+	`
+
 	GetAggregator = `SELECT * FROM aggregators;`
 
 	GetAggregatorById = `SELECT * FROM aggregators WHERE id = @id;`

--- a/node/pkg/admin/aggregator/route.go
+++ b/node/pkg/admin/aggregator/route.go
@@ -14,7 +14,6 @@ func Routes(router fiber.Router) {
 	aggregator.Post("/stop", stop)
 	aggregator.Post("/refresh", refresh)
 
-	aggregator.Post("/sync/adapter", syncWithAdapter)
 	aggregator.Post("/sync/config", SyncFromOraklConfig)
 	aggregator.Post("/sync/config/:name", addFromOraklConfig)
 	aggregator.Get("/:id", getById)

--- a/node/pkg/admin/tests/aggregator_test.go
+++ b/node/pkg/admin/tests/aggregator_test.go
@@ -216,28 +216,6 @@ func TestAggregatorDeactivate(t *testing.T) {
 
 }
 
-func TestAggregatorSyncWithAdapter(t *testing.T) {
-	ctx := context.Background()
-	cleanup, testItems, err := setup(ctx)
-	if err != nil {
-		t.Fatalf("error setting up test: %v", err)
-	}
-	defer cleanup()
-
-	syncResult, err := PostRequest[[]aggregator.AggregatorModel](testItems.app, "/api/v1/aggregator/sync/adapter", nil)
-	if err != nil {
-		t.Fatalf("error syncing aggregator with adapter: %v", err)
-	}
-	assert.Greater(t, len(syncResult), 0, "expected to have at least one aggregator")
-	assert.Equal(t, syncResult[0].Name, testItems.tmpData.adapter.Name)
-
-	// cleanup
-	_, err = db.QueryRow[aggregator.AggregatorModel](context.Background(), aggregator.DeleteAggregatorById, map[string]any{"id": syncResult[0].Id})
-	if err != nil {
-		t.Fatalf("error cleaning up test: %v", err)
-	}
-}
-
 func TestAggregatorSyncWithOraklConfig(t *testing.T) {
 	ctx := context.Background()
 	cleanup, testItems, err := setup(ctx)

--- a/node/pkg/aggregator/aggregator_test.go
+++ b/node/pkg/aggregator/aggregator_test.go
@@ -23,14 +23,14 @@ func TestNewAggregator(t *testing.T) {
 		}
 	}()
 
-	_, err = NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	_, err = NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
 }
 
 func TestNewAggregator_Error(t *testing.T) {
-	_, err := NewAggregator(nil, nil, "")
+	_, err := NewAggregator(nil, nil, "", AggregatorModel{})
 	assert.NotNil(t, err, "Expected error when creating new aggregator with nil parameters")
 }
 
@@ -46,7 +46,7 @@ func TestLeaderJob(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -70,7 +70,7 @@ func TestGetLatestLocalAggregate(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 
 	if err != nil {
 		t.Fatal("error creating new node")
@@ -104,7 +104,7 @@ func TestGetLatestRoundId(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -131,7 +131,7 @@ func TestInsertGlobalAggregate(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -169,7 +169,7 @@ func TestInsertProof(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.aggregator)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"strconv"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
@@ -72,12 +73,11 @@ func (a *App) initializeLoadedAggregators(loadedAggregators []AggregatorModel, h
 			continue
 		}
 
-		topicString := aggregator.Name + "-global-aggregator-topic"
-		tmpNode, err := NewAggregator(h, ps, topicString)
+		topicString := aggregator.Name + "-global-aggregator-topic-" + strconv.Itoa(aggregator.Interval)
+		tmpNode, err := NewAggregator(h, ps, topicString, aggregator)
 		if err != nil {
 			return err
 		}
-		tmpNode.AggregatorModel = aggregator
 		a.Aggregators[aggregator.ID] = tmpNode
 
 	}

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	LEADER_TIMEOUT   = 5 * time.Second
 	AGREEMENT_QUORUM = 0.5
 
 	RoundSync raft.MessageType = "roundSync"
@@ -69,9 +68,10 @@ type App struct {
 }
 
 type AggregatorModel struct {
-	ID     int64  `db:"id"`
-	Name   string `db:"name"`
-	Active bool   `db:"active"`
+	ID       int64  `db:"id"`
+	Name     string `db:"name"`
+	Active   bool   `db:"active"`
+	Interval int    `db:"interval"`
 }
 
 type Aggregator struct {

--- a/node/pkg/aggregator/utils.go
+++ b/node/pkg/aggregator/utils.go
@@ -184,7 +184,3 @@ func getLatestGlobalAggregateFromRdb(ctx context.Context, name string) (GlobalAg
 	}
 	return aggregate, nil
 }
-
-func isTimeValid(timeToValidate time.Time, baseTime time.Time) bool {
-	return timeToValidate.After(baseTime.Add(-LEADER_TIMEOUT)) && timeToValidate.Before(baseTime)
-}


### PR DESCRIPTION
# Description

This PR implements customizable aggregator frequency.
On synchronizing from `orakl-config`, it'll try to read field `aggregateHeartbeat` from `aggregator`. If the field `aggregateHeartbeat` is not found, default interval 5000 (millisecond) will be set.
```
{
  "aggregatorHash": "0x9f09b00a7525c29679a8121f1a73f54dcfece55b3b8d9f9e80db8cd32d037b2d",
  "name": "ADA-USDT",
  "address": "0x70cDE6bE67486017C52215Ad5d6740ce8EaBC9b8",
  "aggregateHeartbeat": 5000,
  "heartbeat": 15000,
  "threshold": 0.05,
  "absoluteThreshold": 0.1,
  "adapterHash": "0xf15e595e641f1447b5ad1c128007574b329e00937e6db3857aff1487345ed5f6"
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an interval setting for aggregator configurations, allowing users to specify aggregation frequency.
  
- **Bug Fixes**
	- Improved reliability in aggregator synchronization and configuration processes.

- **Refactor**
	- Enhanced internal logic for aggregator time validation and insertion functions.

- **Documentation**
	- Updated internal route handling documentation related to aggregator synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->