### PR TITLE
Remove proxy from `FeedRouter`

### DIFF
--- a/contracts/v0.2/src/FeedRouter.sol
+++ b/contracts/v0.2/src/FeedRouter.sol
@@ -185,7 +185,8 @@ contract FeedRouter is Ownable, IFeedRouter {
 	bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
 	bool found = false;
 
-	for (uint256 i = 0; i < feedNames.length; i++) {
+	uint256 feedNamesLength = feedNames.length;
+	for (uint256 i = 0; i < feedNamesLength; i++) {
 	    if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
 		found = true;
 		break;
@@ -213,7 +214,8 @@ contract FeedRouter is Ownable, IFeedRouter {
 	feedToProxies[_feedName] = address(0);
 	bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
 
-	for (uint256 i = 0; i < feedNames.length; i++) {
+	uint256 feedNamesLength = feedNames.length;
+	for (uint256 i = 0; i < feedNamesLength; i++) {
 	    if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
 		feedNames[i] = feedNames[feedNames.length - 1];
 		feedNames.pop();

--- a/contracts/v0.2/src/FeedRouter.sol
+++ b/contracts/v0.2/src/FeedRouter.sol
@@ -188,6 +188,7 @@ contract FeedRouter is Ownable, IFeedRouter {
 	for (uint256 i = 0; i < feedNames.length; i++) {
 	    if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
 		found = true;
+		break;
 	    }
 	}
 

--- a/contracts/v0.2/src/FeedRouter.sol
+++ b/contracts/v0.2/src/FeedRouter.sol
@@ -19,7 +19,7 @@ contract FeedRouter is Ownable, IFeedRouter {
     mapping(string => address) public feedProxies;
 
     event RouterProxyAddressUpdated(string feedName, address indexed proxyAddress);
-    event RouterProxyAddressBulkUpdated(string[] feedNames, address[] proxyAddresses);
+    event RouterProxyAddressesRemoved(string[] feedNames);
 
     error InvalidProxyAddress();
 
@@ -43,8 +43,19 @@ contract FeedRouter is Ownable, IFeedRouter {
         for (uint256 i = 0; i < _feedNames.length; i++) {
             updateProxy(_feedNames[i], _proxyAddresses[i]);
         }
+    }
 
-        emit RouterProxyAddressBulkUpdated(_feedNames, _proxyAddresses);
+    /**
+     * @inheritdoc IFeedRouter
+     */
+    function removeProxyBulk(string[] calldata _feedNames) external onlyOwner {
+	require(_feedNames.length > 0, "invalid input");
+
+	for (uint256 i = 0; i < _feedNames.length; i++) {
+	    feedProxies[_feedNames[i]] = address(0);
+	}
+
+	emit RouterProxyAddressesRemoved(_feedNames);
     }
 
     /**
@@ -154,9 +165,11 @@ contract FeedRouter is Ownable, IFeedRouter {
     }
 
     /**
-     * @inheritdoc IFeedRouter
+     * @notice Update the feed proxy address of given a feed name.
+     * @param _feedName The feed name.
+     * @param _proxyAddress The address of the feed proxy.
      */
-    function updateProxy(string calldata _feedName, address _proxyAddress) public onlyOwner {
+    function updateProxy(string calldata _feedName, address _proxyAddress) private {
         if (_proxyAddress == address(0)) {
             revert InvalidProxyAddress();
         }

--- a/contracts/v0.2/src/FeedRouter.sol
+++ b/contracts/v0.2/src/FeedRouter.sol
@@ -19,9 +19,9 @@ contract FeedRouter is Ownable, IFeedRouter {
     mapping(string => address) public feedToProxies;
     string[] public feedNames;
 
-    event ProxyAddressAdded(string feedName, address indexed proxyAddress);
-    event ProxyAddressRemoved(string feedName, address indexed proxyAddress);
-    event ProxyAddressUpdated(string feedName, address indexed proxyAddress);
+    event ProxyAdded(string feedName, address indexed proxyAddress);
+    event ProxyRemoved(string feedName, address indexed proxyAddress);
+    event ProxyUpdated(string feedName, address indexed proxyAddress);
 
     error InvalidProxyAddress();
 
@@ -194,9 +194,9 @@ contract FeedRouter is Ownable, IFeedRouter {
 
 	if (!found) {
 	    feedNames.push(_feedName);
-	    emit ProxyAddressAdded(_feedName, _proxyAddress);
+	    emit ProxyAdded(_feedName, _proxyAddress);
 	} else {
-	    emit ProxyAddressUpdated(_feedName, _proxyAddress);
+	    emit ProxyUpdated(_feedName, _proxyAddress);
 	}
     }
 
@@ -221,6 +221,6 @@ contract FeedRouter is Ownable, IFeedRouter {
 	    }
 	}
 
-	emit ProxyAddressRemoved(_feedName, _proxyAddress);
+	emit ProxyRemoved(_feedName, _proxyAddress);
     }
 }

--- a/contracts/v0.2/src/FeedRouter.sol
+++ b/contracts/v0.2/src/FeedRouter.sol
@@ -51,11 +51,11 @@ contract FeedRouter is Ownable, IFeedRouter {
      * @inheritdoc IFeedRouter
      */
     function removeProxyBulk(string[] calldata _feedNames) external onlyOwner {
-	require(_feedNames.length > 0, "invalid input");
+        require(_feedNames.length > 0, "invalid input");
 
-	for (uint256 i = 0; i < _feedNames.length; i++) {
-	    removeProxy(_feedNames[i], feedToProxies[_feedNames[i]]);
-	}
+        for (uint256 i = 0; i < _feedNames.length; i++) {
+            removeProxy(_feedNames[i], feedToProxies[_feedNames[i]]);
+        }
     }
 
     /**
@@ -102,7 +102,8 @@ contract FeedRouter is Ownable, IFeedRouter {
         uint256 _latestUpdatedAtTolerance,
         int256 _minCount
     ) external view returns (int256) {
-        return IFeedProxy(feedToProxies[_feedName]).twapFromProposedFeed(_interval, _latestUpdatedAtTolerance, _minCount);
+        return
+            IFeedProxy(feedToProxies[_feedName]).twapFromProposedFeed(_interval, _latestUpdatedAtTolerance, _minCount);
     }
 
     /**
@@ -168,7 +169,7 @@ contract FeedRouter is Ownable, IFeedRouter {
      * @inheritdoc IFeedRouter
      */
     function getFeedNames() external view returns (string[] memory) {
-	return feedNames;
+        return feedNames;
     }
 
     /**
@@ -182,23 +183,23 @@ contract FeedRouter is Ownable, IFeedRouter {
         }
 
         feedToProxies[_feedName] = _proxyAddress;
-	bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
-	bool found = false;
+        bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
+        bool found = false;
 
-	uint256 feedNamesLength = feedNames.length;
-	for (uint256 i = 0; i < feedNamesLength; i++) {
-	    if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
-		found = true;
-		break;
-	    }
-	}
+        uint256 feedNamesLength = feedNames.length;
+        for (uint256 i = 0; i < feedNamesLength; i++) {
+            if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
+                found = true;
+                break;
+            }
+        }
 
-	if (!found) {
-	    feedNames.push(_feedName);
-	    emit ProxyAdded(_feedName, _proxyAddress);
-	} else {
-	    emit ProxyUpdated(_feedName, _proxyAddress);
-	}
+        if (!found) {
+            feedNames.push(_feedName);
+            emit ProxyAdded(_feedName, _proxyAddress);
+        } else {
+            emit ProxyUpdated(_feedName, _proxyAddress);
+        }
     }
 
     /**
@@ -211,18 +212,18 @@ contract FeedRouter is Ownable, IFeedRouter {
             revert InvalidProxyAddress();
         }
 
-	feedToProxies[_feedName] = address(0);
-	bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
+        feedToProxies[_feedName] = address(0);
+        bytes32 feedNameHash = keccak256(abi.encodePacked(_feedName));
 
-	uint256 feedNamesLength = feedNames.length;
-	for (uint256 i = 0; i < feedNamesLength; i++) {
-	    if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
-		feedNames[i] = feedNames[feedNames.length - 1];
-		feedNames.pop();
-		break;
-	    }
-	}
+        uint256 feedNamesLength = feedNames.length;
+        for (uint256 i = 0; i < feedNamesLength; i++) {
+            if (keccak256(abi.encodePacked(feedNames[i])) == feedNameHash) {
+                feedNames[i] = feedNames[feedNames.length - 1];
+                feedNames.pop();
+                break;
+            }
+        }
 
-	emit ProxyRemoved(_feedName, _proxyAddress);
+        emit ProxyRemoved(_feedName, _proxyAddress);
     }
 }

--- a/contracts/v0.2/src/interfaces/IFeedRouter.sol
+++ b/contracts/v0.2/src/interfaces/IFeedRouter.sol
@@ -10,17 +10,6 @@ interface IFeedRouter {
     function feedProxies(string calldata feedName) external view returns (address);
 
     /**
-     * @notice Update the feed proxy address of given a feed name.
-     * @dev This function is restricted to the owner. If null address
-     * is passed as proxy address, the function will revert with
-     * `InvalidProxyAddress` error. If the proxy has sucessfully been
-     * updated, the `RouterProxyAddressUpdated` event will be emitted.
-     * @param feedName The feed name.
-     * @param proxyAddress The address of the feed proxy.
-     */
-    function updateProxy(string calldata feedName, address proxyAddress) external;
-
-    /**
      * @notice Update the feed proxy addresses in bulk.
      * @dev This function is restricted to the owner. Internally, this
      * function uses `updateProxy` to update the proxy addresses.
@@ -28,6 +17,14 @@ interface IFeedRouter {
      * @param proxyAddresses The addresses of the feed proxies.
      */
     function updateProxyBulk(string[] calldata feedNames, address[] calldata proxyAddresses) external;
+
+    /**
+     * @notice Remove the feed proxy addresses in bulk.
+     * @dev This function is restricted to the owner. Internally, this
+     * function uses `removeProxy` to remove the proxy addresses.
+     * @param feedNames The feed names.
+     */
+    function removeProxyBulk(string[] calldata feedNames) external;
 
     /**
      * @notice Get the round data given a a feedd name and round ID.

--- a/contracts/v0.2/src/interfaces/IFeedRouter.sol
+++ b/contracts/v0.2/src/interfaces/IFeedRouter.sol
@@ -7,7 +7,7 @@ interface IFeedRouter {
      * @param feedName The feed name.
      * @return The address of the feed proxy.
      */
-    function feedProxies(string calldata feedName) external view returns (address);
+    function feedToProxies(string calldata feedName) external view returns (address);
 
     /**
      * @notice Update the feed proxy addresses in bulk.
@@ -140,4 +140,10 @@ interface IFeedRouter {
      * @return description The description of the feed.
      */
     function description(string calldata feedName) external view returns (string memory);
+
+    /**
+     * @notice Get supported feed names.
+     * @return The feed names.
+     */
+    function getFeedNames() external view returns (string[] memory);
 }

--- a/contracts/v0.2/test/FeedRouter.t.sol
+++ b/contracts/v0.2/test/FeedRouter.t.sol
@@ -16,109 +16,109 @@ contract FeedRouterTest is Test {
     }
 
     function test_AddProxy() public {
-	string[] memory feedNames_ = new string[](2);
-	address[] memory proxyAddresses_ = new address[](2);
+        string[] memory feedNames_ = new string[](2);
+        address[] memory proxyAddresses_ = new address[](2);
 
-	address btcUsdt = makeAddr("btc-usdt");
-	address ethUsdt = makeAddr("eth-usdt");
+        address btcUsdt = makeAddr("btc-usdt");
+        address ethUsdt = makeAddr("eth-usdt");
 
-	feedNames_[0] = "btc-usdt";
-	feedNames_[1] = "eth-usdt";
+        feedNames_[0] = "btc-usdt";
+        feedNames_[1] = "eth-usdt";
 
-	proxyAddresses_[0] = btcUsdt;
-	proxyAddresses_[1] = ethUsdt;
+        proxyAddresses_[0] = btcUsdt;
+        proxyAddresses_[1] = ethUsdt;
 
-	vm.expectEmit(true, true, true, true);
-	emit ProxyAdded(feedNames_[0], proxyAddresses_[0]);
-	vm.expectEmit(true, true, true, true);
-	emit ProxyAdded(feedNames_[1], proxyAddresses_[1]);
-	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+        vm.expectEmit(true, true, true, true);
+        emit ProxyAdded(feedNames_[0], proxyAddresses_[0]);
+        vm.expectEmit(true, true, true, true);
+        emit ProxyAdded(feedNames_[1], proxyAddresses_[1]);
+        feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
 
-	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdt);
-	assertEq(feedRouter.feedToProxies(feedNames_[1]), ethUsdt);
-	assertEq(true, compareArrays(feedNames_, feedRouter.getFeedNames()));
+        assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdt);
+        assertEq(feedRouter.feedToProxies(feedNames_[1]), ethUsdt);
+        assertEq(true, compareArrays(feedNames_, feedRouter.getFeedNames()));
     }
 
     function test_UpdateProxy() public {
-	string[] memory feedNames_ = new string[](1);
-	address[] memory proxyAddressesOld_ = new address[](1);
-	address[] memory proxyAddressesNew_ = new address[](1);
+        string[] memory feedNames_ = new string[](1);
+        address[] memory proxyAddressesOld_ = new address[](1);
+        address[] memory proxyAddressesNew_ = new address[](1);
 
-	address btcUsdtOld = makeAddr("btc-usdt-old");
-	address btcUsdtNew = makeAddr("btc-usdt-new");
-	feedNames_[0] = "btc-usdt";
+        address btcUsdtOld = makeAddr("btc-usdt-old");
+        address btcUsdtNew = makeAddr("btc-usdt-new");
+        feedNames_[0] = "btc-usdt";
 
-	proxyAddressesOld_[0] = btcUsdtOld;
-	proxyAddressesNew_[0] = btcUsdtNew;
+        proxyAddressesOld_[0] = btcUsdtOld;
+        proxyAddressesNew_[0] = btcUsdtNew;
 
-	vm.expectEmit(true, true, true, true);
-	emit ProxyAdded(feedNames_[0], proxyAddressesOld_[0]);
-	feedRouter.updateProxyBulk(feedNames_, proxyAddressesOld_);
-	assertEq(btcUsdtOld, feedRouter.feedToProxies(feedNames_[0]));
-	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtOld);
+        vm.expectEmit(true, true, true, true);
+        emit ProxyAdded(feedNames_[0], proxyAddressesOld_[0]);
+        feedRouter.updateProxyBulk(feedNames_, proxyAddressesOld_);
+        assertEq(btcUsdtOld, feedRouter.feedToProxies(feedNames_[0]));
+        assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtOld);
 
-	vm.expectEmit(true, true, true, true);
-	emit ProxyUpdated(feedNames_[0], proxyAddressesNew_[0]);
-	feedRouter.updateProxyBulk(feedNames_, proxyAddressesNew_);
-	assertEq(btcUsdtNew, feedRouter.feedToProxies(feedNames_[0]));
-	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtNew);
+        vm.expectEmit(true, true, true, true);
+        emit ProxyUpdated(feedNames_[0], proxyAddressesNew_[0]);
+        feedRouter.updateProxyBulk(feedNames_, proxyAddressesNew_);
+        assertEq(btcUsdtNew, feedRouter.feedToProxies(feedNames_[0]));
+        assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtNew);
     }
 
     function test_UpdateNotEqualLength() public {
-	string[] memory feedNames_ = new string[](2);
-	address[] memory proxyAddresses_ = new address[](1);
+        string[] memory feedNames_ = new string[](2);
+        address[] memory proxyAddresses_ = new address[](1);
 
-	// feedNames_ is longer than proxyAddresses_ -> FAIL
-	vm.expectRevert("invalid input");
-	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+        // feedNames_ is longer than proxyAddresses_ -> FAIL
+        vm.expectRevert("invalid input");
+        feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
     }
 
     function test_UpdateInvalidProxy() public {
-	string[] memory feedNames_ = new string[](1);
-	address[] memory proxyAddresses_ = new address[](1);
+        string[] memory feedNames_ = new string[](1);
+        address[] memory proxyAddresses_ = new address[](1);
 
-	feedNames_[0] = "btc-usdt";
-	proxyAddresses_[0] = address(0);
+        feedNames_[0] = "btc-usdt";
+        proxyAddresses_[0] = address(0);
 
-	// proxy address is 0 -> FAIL
-	vm.expectRevert(FeedRouter.InvalidProxyAddress.selector);
-	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+        // proxy address is 0 -> FAIL
+        vm.expectRevert(FeedRouter.InvalidProxyAddress.selector);
+        feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
     }
 
     function test_RemoveProxy() public {
-	string[] memory feedNamesAdd_ = new string[](2);
-	address[] memory proxyAddresses_ = new address[](2);
+        string[] memory feedNamesAdd_ = new string[](2);
+        address[] memory proxyAddresses_ = new address[](2);
 
-	address btcUsdt = makeAddr("btc-usdt");
-	address ethUsdt = makeAddr("eth-usdt");
+        address btcUsdt = makeAddr("btc-usdt");
+        address ethUsdt = makeAddr("eth-usdt");
 
-	feedNamesAdd_[0] = "btc-usdt";
-	feedNamesAdd_[1] = "eth-usdt";
+        feedNamesAdd_[0] = "btc-usdt";
+        feedNamesAdd_[1] = "eth-usdt";
 
-	proxyAddresses_[0] = btcUsdt;
-	proxyAddresses_[1] = ethUsdt;
+        proxyAddresses_[0] = btcUsdt;
+        proxyAddresses_[1] = ethUsdt;
 
-	// add proxies
-	vm.expectEmit(true, true, true, true);
-	emit ProxyAdded(feedNamesAdd_[0], proxyAddresses_[0]);
-	feedRouter.updateProxyBulk(feedNamesAdd_, proxyAddresses_);
-	assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), btcUsdt);
-	assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
+        // add proxies
+        vm.expectEmit(true, true, true, true);
+        emit ProxyAdded(feedNamesAdd_[0], proxyAddresses_[0]);
+        feedRouter.updateProxyBulk(feedNamesAdd_, proxyAddresses_);
+        assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), btcUsdt);
+        assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
 
-	// remove btc-usdt proxy
-	string[] memory feedNamesRemove_ = new string[](1);
-	feedNamesRemove_[0] = feedNamesAdd_[0];
-	vm.expectEmit(true, true, true, true);
-	emit ProxyRemoved(feedNamesRemove_[0], proxyAddresses_[0]);
-	feedRouter.removeProxyBulk(feedNamesRemove_);
+        // remove btc-usdt proxy
+        string[] memory feedNamesRemove_ = new string[](1);
+        feedNamesRemove_[0] = feedNamesAdd_[0];
+        vm.expectEmit(true, true, true, true);
+        emit ProxyRemoved(feedNamesRemove_[0], proxyAddresses_[0]);
+        feedRouter.removeProxyBulk(feedNamesRemove_);
 
-	// expect that only eth-usdt is left
-	string[] memory expectedFeedNames_ = new string[](1);
-	expectedFeedNames_[0] = feedNamesAdd_[1];
-	assertEq(true, compareArrays(expectedFeedNames_, feedRouter.getFeedNames()));
+        // expect that only eth-usdt is left
+        string[] memory expectedFeedNames_ = new string[](1);
+        expectedFeedNames_[0] = feedNamesAdd_[1];
+        assertEq(true, compareArrays(expectedFeedNames_, feedRouter.getFeedNames()));
 
-	assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), address(0));
-	assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
+        assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), address(0));
+        assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
     }
 
     function compareArrays(string[] memory array1, string[] memory array2) private pure returns (bool) {
@@ -126,9 +126,9 @@ contract FeedRouterTest is Test {
             return false;
         }
 
-        for (uint i = 0; i < array1.length; i++) {
+        for (uint256 i = 0; i < array1.length; i++) {
             bool found = false;
-            for (uint j = 0; j < array2.length; j++) {
+            for (uint256 j = 0; j < array2.length; j++) {
                 if (keccak256(abi.encodePacked(array1[i])) == keccak256(abi.encodePacked(array2[j]))) {
                     found = true;
                     break;

--- a/contracts/v0.2/test/FeedRouter.t.sol
+++ b/contracts/v0.2/test/FeedRouter.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test, console} from "forge-std/Test.sol";
+import {FeedRouter} from "../src/FeedRouter.sol";
+
+contract FeedRouterTest is Test {
+    FeedRouter public feedRouter;
+
+    function setUp() public {
+        feedRouter = new FeedRouter();
+    }
+
+    function test_AddProxy() public {
+	string[] memory feedNames_ = new string[](2);
+	address[] memory proxyAddresses_ = new address[](2);
+
+	address btcUsdt = makeAddr("btc-usdt");
+	address ethUsdt = makeAddr("eth-usdt");
+
+	feedNames_[0] = "btc-usdt";
+	feedNames_[1] = "eth-usdt";
+
+	proxyAddresses_[0] = btcUsdt;
+	proxyAddresses_[1] = ethUsdt;
+
+	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+
+	assertEq(true, compareArrays(feedNames_, feedRouter.getFeedNames()));
+    }
+
+    function test_UpdateProxy() public {
+	string[] memory feedNames_ = new string[](1);
+	address[] memory proxyAddressesOld_ = new address[](1);
+	address[] memory proxyAddressesNew_ = new address[](1);
+
+	address btcUsdtOld = makeAddr("btc-usdt-old");
+	address btcUsdtNew = makeAddr("btc-usdt-new");
+	feedNames_[0] = "btc-usdt";
+
+	proxyAddressesOld_[0] = btcUsdtOld;
+	proxyAddressesNew_[0] = btcUsdtNew;
+
+	feedRouter.updateProxyBulk(feedNames_, proxyAddressesOld_);
+	assertEq(btcUsdtOld, feedRouter.feedToProxies(feedNames_[0]));
+
+	feedRouter.updateProxyBulk(feedNames_, proxyAddressesNew_);
+	assertEq(btcUsdtNew, feedRouter.feedToProxies(feedNames_[0]));
+    }
+
+    function test_UpdateNotEqualLength() public {
+	string[] memory feedNames_ = new string[](2);
+	address[] memory proxyAddresses_ = new address[](1);
+
+	// feedNames_ is longer than proxyAddresses_ -> FAIL
+	vm.expectRevert("invalid input");
+	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+    }
+
+    function test_UpdateInvalidProxy() public {
+	string[] memory feedNames_ = new string[](1);
+	address[] memory proxyAddresses_ = new address[](1);
+
+	feedNames_[0] = "btc-usdt";
+	proxyAddresses_[0] = address(0);
+
+	// proxy address is 0 -> FAIL
+	vm.expectRevert(FeedRouter.InvalidProxyAddress.selector);
+	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
+    }
+
+    function test_RemoveProxy() public {
+	string[] memory feedNamesAdd_ = new string[](2);
+	address[] memory proxyAddresses_ = new address[](2);
+
+	address btcUsdt = makeAddr("btc-usdt");
+	address ethUsdt = makeAddr("eth-usdt");
+
+	feedNamesAdd_[0] = "btc-usdt";
+	feedNamesAdd_[1] = "eth-usdt";
+
+	proxyAddresses_[0] = btcUsdt;
+	proxyAddresses_[1] = ethUsdt;
+
+	// add proxies
+	feedRouter.updateProxyBulk(feedNamesAdd_, proxyAddresses_);
+
+	// remove btc-usdt proxy
+	string[] memory feedNamesRemove_ = new string[](1);
+	feedNamesRemove_[0] = "btc-usdt";
+	feedRouter.removeProxyBulk(feedNamesRemove_);
+
+	// expect that only eth-usdt is left
+	string[] memory expectedFeedNames_ = new string[](1);
+	expectedFeedNames_[0] = "eth-usdt";
+	assertEq(true, compareArrays(expectedFeedNames_, feedRouter.getFeedNames()));
+    }
+
+    function compareArrays(string[] memory array1, string[] memory array2) private pure returns (bool) {
+        if (array1.length != array2.length) {
+            return false;
+        }
+
+        for (uint i = 0; i < array1.length; i++) {
+            bool found = false;
+            for (uint j = 0; j < array2.length; j++) {
+                if (keccak256(abi.encodePacked(array1[i])) == keccak256(abi.encodePacked(array2[j]))) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/contracts/v0.2/test/FeedRouter.t.sol
+++ b/contracts/v0.2/test/FeedRouter.t.sol
@@ -34,6 +34,8 @@ contract FeedRouterTest is Test {
 	emit ProxyAdded(feedNames_[1], proxyAddresses_[1]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
 
+	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdt);
+	assertEq(feedRouter.feedToProxies(feedNames_[1]), ethUsdt);
 	assertEq(true, compareArrays(feedNames_, feedRouter.getFeedNames()));
     }
 
@@ -53,11 +55,13 @@ contract FeedRouterTest is Test {
 	emit ProxyAdded(feedNames_[0], proxyAddressesOld_[0]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddressesOld_);
 	assertEq(btcUsdtOld, feedRouter.feedToProxies(feedNames_[0]));
+	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtOld);
 
 	vm.expectEmit(true, true, true, true);
 	emit ProxyUpdated(feedNames_[0], proxyAddressesNew_[0]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddressesNew_);
 	assertEq(btcUsdtNew, feedRouter.feedToProxies(feedNames_[0]));
+	assertEq(feedRouter.feedToProxies(feedNames_[0]), btcUsdtNew);
     }
 
     function test_UpdateNotEqualLength() public {
@@ -98,18 +102,23 @@ contract FeedRouterTest is Test {
 	vm.expectEmit(true, true, true, true);
 	emit ProxyAdded(feedNamesAdd_[0], proxyAddresses_[0]);
 	feedRouter.updateProxyBulk(feedNamesAdd_, proxyAddresses_);
+	assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), btcUsdt);
+	assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
 
 	// remove btc-usdt proxy
 	string[] memory feedNamesRemove_ = new string[](1);
-	feedNamesRemove_[0] = "btc-usdt";
+	feedNamesRemove_[0] = feedNamesAdd_[0];
 	vm.expectEmit(true, true, true, true);
 	emit ProxyRemoved(feedNamesRemove_[0], proxyAddresses_[0]);
 	feedRouter.removeProxyBulk(feedNamesRemove_);
 
 	// expect that only eth-usdt is left
 	string[] memory expectedFeedNames_ = new string[](1);
-	expectedFeedNames_[0] = "eth-usdt";
+	expectedFeedNames_[0] = feedNamesAdd_[1];
 	assertEq(true, compareArrays(expectedFeedNames_, feedRouter.getFeedNames()));
+
+	assertEq(feedRouter.feedToProxies(feedNamesAdd_[0]), address(0));
+	assertEq(feedRouter.feedToProxies(feedNamesAdd_[1]), ethUsdt);
     }
 
     function compareArrays(string[] memory array1, string[] memory array2) private pure returns (bool) {

--- a/contracts/v0.2/test/FeedRouter.t.sol
+++ b/contracts/v0.2/test/FeedRouter.t.sol
@@ -7,6 +7,10 @@ import {FeedRouter} from "../src/FeedRouter.sol";
 contract FeedRouterTest is Test {
     FeedRouter public feedRouter;
 
+    event ProxyAdded(string feedName, address indexed proxyAddress);
+    event ProxyRemoved(string feedName, address indexed proxyAddress);
+    event ProxyUpdated(string feedName, address indexed proxyAddress);
+
     function setUp() public {
         feedRouter = new FeedRouter();
     }
@@ -24,6 +28,10 @@ contract FeedRouterTest is Test {
 	proxyAddresses_[0] = btcUsdt;
 	proxyAddresses_[1] = ethUsdt;
 
+	vm.expectEmit(true, true, true, true);
+	emit ProxyAdded(feedNames_[0], proxyAddresses_[0]);
+	vm.expectEmit(true, true, true, true);
+	emit ProxyAdded(feedNames_[1], proxyAddresses_[1]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddresses_);
 
 	assertEq(true, compareArrays(feedNames_, feedRouter.getFeedNames()));
@@ -41,9 +49,13 @@ contract FeedRouterTest is Test {
 	proxyAddressesOld_[0] = btcUsdtOld;
 	proxyAddressesNew_[0] = btcUsdtNew;
 
+	vm.expectEmit(true, true, true, true);
+	emit ProxyAdded(feedNames_[0], proxyAddressesOld_[0]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddressesOld_);
 	assertEq(btcUsdtOld, feedRouter.feedToProxies(feedNames_[0]));
 
+	vm.expectEmit(true, true, true, true);
+	emit ProxyUpdated(feedNames_[0], proxyAddressesNew_[0]);
 	feedRouter.updateProxyBulk(feedNames_, proxyAddressesNew_);
 	assertEq(btcUsdtNew, feedRouter.feedToProxies(feedNames_[0]));
     }
@@ -83,11 +95,15 @@ contract FeedRouterTest is Test {
 	proxyAddresses_[1] = ethUsdt;
 
 	// add proxies
+	vm.expectEmit(true, true, true, true);
+	emit ProxyAdded(feedNamesAdd_[0], proxyAddresses_[0]);
 	feedRouter.updateProxyBulk(feedNamesAdd_, proxyAddresses_);
 
 	// remove btc-usdt proxy
 	string[] memory feedNamesRemove_ = new string[](1);
 	feedNamesRemove_[0] = "btc-usdt";
+	vm.expectEmit(true, true, true, true);
+	emit ProxyRemoved(feedNamesRemove_[0], proxyAddresses_[0]);
 	feedRouter.removeProxyBulk(feedNamesRemove_);
 
 	// expect that only eth-usdt is left


### PR DESCRIPTION
# Description

* Function to remove (`removeProxyBulk`) proxy address from `FeedRouter`
* Keep track of registered feeds (`feedNames`) in `FeedRouter`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced feed management in the application with the ability to add, update, and remove proxy addresses for different feed names.
  - Introduced a new array, `feedNames`, for better organization and retrieval of feed information.

- **Refactor**
  - Improved event management by replacing a single event with more specific events for proxy address additions, removals, and updates.

- **Tests**
  - Added comprehensive test cases to validate the functionality of adding, updating, and removing proxy addresses, ensuring robust feed management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->