### PR TITLE
POR Docker image & github action file

### DIFF
--- a/.github/workflows/por.image+upload.yaml
+++ b/.github/workflows/por.image+upload.yaml
@@ -1,0 +1,75 @@
+name: POR Deploy to Amazon ECR
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "node/pkg/por/**"
+      - "node/cmd/por/**"
+  workflow_dispatch:
+
+env:
+  ecr_url: public.ecr.aws/bisonai/orakl-por
+
+jobs:
+  prepare:
+    name: Prepare Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get time TAG
+        id: tag
+        run: |
+          echo "date=$(date -u +'%Y%m%d.%H%M')" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      tag_date: ${{ steps.tag.outputs.date }}
+      tag_git_hash: ${{ steps.tag.outputs.git_hash }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.5"
+          check-latest: true
+          cache-dependency-path: |
+            ./node/go.sum
+            ./node/go.mod
+      - name: Docker build orakl-por
+        run: SERVICE_NAME=orakl-por docker compose -f docker-compose.build.yaml build
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+
+      - name: Publish Image to ECR(por)
+        run: |
+          docker tag  orakl-por ${{ env.ecr_url }}:latest
+          docker push ${{ env.ecr_url }}:latest
+          docker tag ${{ env.ecr_url }}:latest ${{ env.ecr_url }}:v0.0.1.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}
+          docker push ${{ env.ecr_url }}:v0.0.1.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }}

--- a/dockerfiles/orakl-por.Dockerfile
+++ b/dockerfiles/orakl-por.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.21.5-bullseye as builder
+
+RUN apt-get update && apt-get install -y curl g++-x86-64-linux-gnu libc6-dev-amd64-cross
+
+WORKDIR /app
+
+COPY node node
+
+WORKDIR /app/node
+
+RUN CGO_ENABLED=1 CC=x86_64-linux-gnu-gcc GOOS=linux GOARCH=amd64 go build -o porbin -ldflags="-w -s" ./cmd/por/main.go
+
+# debian:bullseye-slim
+FROM debian@sha256:4b48997afc712259da850373fdbc60315316ee72213a4e77fc5a66032d790b2a
+
+RUN apt-get update && apt-get install -y curl
+
+WORKDIR /app
+
+COPY --from=builder /app/node/porbin /usr/bin
+
+CMD ["porbin"]

--- a/dockerfiles/orakl-por.Dockerfile
+++ b/dockerfiles/orakl-por.Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.21.5-bullseye as builder
 
-RUN apt-get update && apt-get install -y curl g++-x86-64-linux-gnu libc6-dev-amd64-cross
+RUN apt-get update && apt-get install -y curl g++-x86-64-linux-gnu libc6-dev-amd64-cross && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=1 CC=x86_64-linux-gnu-gcc GOOS=linux GOARCH=amd64 go build -o po
 # debian:bullseye-slim
 FROM debian@sha256:4b48997afc712259da850373fdbc60315316ee72213a4e77fc5a66032d790b2a
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description

New POR runs in live pod rather than as cronjob, and requires image to be built and run from k9s. This PR adds dockerfile and github action file for the reason

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a deployment workflow for automatically building and publishing Docker images to Amazon ECR upon changes to the master branch.
	- Added a Dockerfile for creating a lightweight, deployable Docker image of the "porbin" application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->