### PR TITLE
(OraklNode) Rename function, `StopHeartbeatTicker` -> `ResignLeader`

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -172,8 +172,7 @@ func (n *Aggregator) HandleSyncReplyMessage(ctx context.Context, msg raft.Messag
 			return n.PublishTriggerMessage(syncReplyMessage.RoundID)
 		} else {
 			log.Warn().Str("Player", "Aggregator").Int("agreeCount", agreeCount).Int("requiredAgreements", requiredAgreements).Msg("not enough agreements, resigning as leader")
-			n.Raft.StopHeartbeatTicker()
-			n.Raft.UpdateRole(raft.Follower)
+			n.Raft.ResignLeader()
 			return nil
 		}
 	}

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -139,8 +139,7 @@ func (r *Raft) handleHeartbeat(msg Message) error {
 	}
 
 	if currentRole == Leader {
-		r.StopHeartbeatTicker()
-		r.UpdateRole(Follower)
+		r.ResignLeader()
 	} else if currentRole == Candidate {
 		r.UpdateRole(Follower)
 	}
@@ -295,10 +294,14 @@ func (r *Raft) sendRequestVote() error {
 
 // utility functions
 
-func (r *Raft) StopHeartbeatTicker() {
+func (r *Raft) ResignLeader() {
 	if r.Resign != nil {
 		close(r.Resign)
 		r.Resign = nil
+
+		r.UpdateRole(Follower)
+		r.UpdateLeader("")
+		r.startElectionTimer()
 	}
 }
 

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -126,8 +126,8 @@ func (r *Reporter) leaderJob() error {
 
 	err = r.retry(reportJob)
 	if err != nil {
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to report, resigning from leader")
 		r.resignLeader()
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to report")
 		return errors.New("failed to report")
 	}
 
@@ -230,8 +230,7 @@ func (r *Reporter) orderProofs(ctx context.Context, proofMap map[int32][]byte, a
 }
 
 func (r *Reporter) resignLeader() {
-	r.Raft.StopHeartbeatTicker()
-	r.Raft.UpdateRole(raft.Follower)
+	r.Raft.ResignLeader()
 }
 
 func (r *Reporter) handleCustomMessage(ctx context.Context, msg raft.Message) error {
@@ -347,8 +346,8 @@ func (r *Reporter) deviationJob() error {
 
 	err = r.retry(reportJob)
 	if err != nil {
+		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to report deviation, resigning from leader")
 		r.resignLeader()
-		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to report deviation")
 		return errors.New("failed to report deviation")
 	}
 


### PR DESCRIPTION
# Description

Previously, `StopHeartbeatTicker` function has been called to resign as leader, this renames the function and add few more missing steps to smoothly resign from raft leader

- Updates own role into `follower`
- Updates saved leader into empty string
- Starts ElectionTimer

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
