### PR TITLE
(OraklNode) Refactor reporter, set deviation intervals

### DIFF
--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const InsertGlobalAggregateQuery = `INSERT INTO global_aggregates (config_id, value, round, timestamp) VALUES (@config_id, @value, @round, @timestamp) RETURNING *`
-const InsertConfigQuery = `INSERT INTO configs (name, address, fetch_interval, aggregate_interval, submit_interval) VALUES (@name, @address, @fetch_interval, @aggregate_interval, @submit_interval) RETURNING name, id, submit_interval, address;`
+const InsertConfigQuery = `INSERT INTO configs (name, address, fetch_interval, aggregate_interval, submit_interval) VALUES (@name, @address, @fetch_interval, @aggregate_interval, @submit_interval) RETURNING name, id, submit_interval, aggregate_interval, address;`
 const TestInterval = 15000
 
 type TestItems struct {
@@ -33,7 +33,7 @@ type TestItems struct {
 }
 type TmpData struct {
 	globalAggregate GlobalAggregate
-	reporterConfig  ReporterConfig
+	config          Config
 	proofBytes      []byte
 	proofTime       time.Time
 }
@@ -47,12 +47,12 @@ func insertSampleData(ctx context.Context) (*TmpData, error) {
 	}
 	proofTime := time.Now()
 
-	tmpConfig, err := db.QueryRow[ReporterConfig](ctx, InsertConfigQuery, map[string]any{"name": "test-aggregate", "address": "0x1234", "submit_interval": TestInterval, "fetch_interval": TestInterval, "aggregate_interval": TestInterval})
+	tmpConfig, err := db.QueryRow[Config](ctx, InsertConfigQuery, map[string]any{"name": "test-aggregate", "address": "0x1234", "submit_interval": TestInterval, "fetch_interval": TestInterval, "aggregate_interval": TestInterval})
 	if err != nil {
 		log.Error().Err(err).Msg("error inserting config 0")
 		return nil, err
 	}
-	tmpData.reporterConfig = tmpConfig
+	tmpData.config = tmpConfig
 
 	err = db.QueryWithoutResult(ctx, InsertConfigQuery, map[string]any{"name": "test-aggregate-2", "address": "0xabcd", "submit_interval": TestInterval * 2, "fetch_interval": TestInterval, "aggregate_interval": TestInterval})
 	if err != nil {

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -12,62 +12,55 @@ import (
 	"bisonai.com/orakl/node/pkg/raft"
 
 	"github.com/klaytn/klaytn/common"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
 )
 
-func NewReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub, reporterConfigs []ReporterConfig, interval int, contractAddress string, cachedWhitelist []common.Address) (*Reporter, error) {
-	topicString := TOPIC_STRING + "-" + strconv.Itoa(interval)
-	groupInterval := time.Duration(interval) * time.Millisecond
-
-	reporter, err := newReporter(ctx, h, ps, reporterConfigs, groupInterval, topicString, contractAddress, cachedWhitelist)
-	if err != nil {
-		return nil, err
+func NewReporter(ctx context.Context, opts ...ReporterOption) (*Reporter, error) {
+	config := &ReporterConfig{
+		JobType: ReportJob,
 	}
 
-	reporter.Raft.LeaderJob = reporter.leaderJob
-	return reporter, nil
-}
-
-func NewDeviationReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub, reporterConfigs []ReporterConfig, contractAddress string, cachedWhitelist []common.Address) (*Reporter, error) {
-	topicString := TOPIC_STRING + "-deviation"
-
-	reporter, err := newReporter(ctx, h, ps, reporterConfigs, DEVIATION_TIMEOUT, topicString, contractAddress, cachedWhitelist)
-	if err != nil {
-		return nil, err
+	for _, opt := range opts {
+		opt(config)
 	}
 
-	reporter.Raft.LeaderJob = reporter.deviationJob
-	return reporter, nil
-}
-
-func newReporter(ctx context.Context, h host.Host, ps *pubsub.PubSub, reporterConfigs []ReporterConfig, interval time.Duration, topicString string, contractAddress string, cachedWhitelist []common.Address) (*Reporter, error) {
-	if len(reporterConfigs) == 0 {
+	if len(config.Configs) == 0 {
 		log.Error().Str("Player", "Reporter").Err(errors.New("no submission pairs")).Msg("no submission pairs to make new reporter")
 		return nil, errors.New("no submission pairs")
 	}
 
-	topic, err := ps.Join(topicString)
+	topicString := TOPIC_STRING + "-"
+	if config.JobType == DeviationJob {
+		topicString += "deviation-" + strconv.Itoa(config.Interval)
+	} else {
+		topicString += strconv.Itoa(config.Interval)
+	}
+
+	groupInterval := time.Duration(config.Interval) * time.Millisecond
+
+	topic, err := config.Ps.Join(topicString)
 	if err != nil {
 		log.Error().Str("Player", "Reporter").Err(err).Msg("Failed to join topic")
 		return nil, err
 	}
 
-	raft := raft.NewRaftNode(h, ps, topic, MESSAGE_BUFFER, interval)
-
+	raft := raft.NewRaftNode(config.Host, config.Ps, topic, MESSAGE_BUFFER, groupInterval)
 	reporter := &Reporter{
 		Raft:               raft,
-		contractAddress:    contractAddress,
-		SubmissionInterval: interval,
-		CachedWhitelist:    cachedWhitelist,
+		contractAddress:    config.ContractAddress,
+		SubmissionInterval: groupInterval,
+		CachedWhitelist:    config.CachedWhitelist,
 	}
-
 	reporter.SubmissionPairs = make(map[int32]SubmissionPair)
-	for _, sa := range reporterConfigs {
+	for _, sa := range config.Configs {
 		reporter.SubmissionPairs[sa.ID] = SubmissionPair{LastSubmission: 0, Address: common.HexToAddress(sa.Address)}
 	}
 	reporter.Raft.HandleCustomMessage = reporter.handleCustomMessage
+	if config.JobType == DeviationJob {
+		reporter.Raft.LeaderJob = reporter.deviationJob
+	} else {
+		reporter.Raft.LeaderJob = reporter.leaderJob
+	}
 
 	return reporter, nil
 }

--- a/node/pkg/reporter/utils_test.go
+++ b/node/pkg/reporter/utils_test.go
@@ -240,9 +240,9 @@ func TestUpdateProofs(t *testing.T) {
 		}
 	}()
 
-	tmpConfigs := []ReporterConfig{}
+	tmpConfigs := []Config{}
 	for i := 0; i < 3; i++ {
-		tmpConfig, err := db.QueryRow[ReporterConfig](ctx, InsertConfigQuery, map[string]any{
+		tmpConfig, err := db.QueryRow[Config](ctx, InsertConfigQuery, map[string]any{
 			"name":               "test-aggregate-" + strconv.Itoa(i),
 			"address":            "0x1234" + strconv.Itoa(i),
 			"submit_interval":    TestInterval,


### PR DESCRIPTION
# Description

- Deviation Intervals used to have fixed value which was 5 seconds, now will follow aggregate interval
- Update Reporter initialize function to use functional options pattern
- Rename `ReporterConfig` -> `Config`. Now `ReporterConfig` stand for the configuration used on initializing reporter object. `Config` will stand for value returned from `configs` table which derives from orakl-config 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
