### PR TITLE
(OraklNode) Remove underscored naming for named imports

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -14,7 +14,7 @@ import (
 	"bisonai.com/orakl/node/pkg/aggregator"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/fetcher"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"bisonai.com/orakl/node/pkg/reporter"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -41,7 +41,7 @@ func main() {
 		return
 	}
 
-	host, ps, err := libp2p_setup.SetupFromBootApi(ctx, listenPort)
+	host, ps, err := libp2pSetup.SetupFromBootApi(ctx, listenPort)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to setup libp2p")
 		return

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -14,7 +14,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/db"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
 )
@@ -57,12 +57,12 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	}
 	testItems.admin = admin
 
-	h, err := libp2p_setup.MakeHost(10001)
+	h, err := libp2pSetup.MakeHost(10001)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ps, err := libp2p_setup.MakePubsub(ctx, h)
+	ps, err := libp2pSetup.MakePubsub(ctx, h)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -2,7 +2,6 @@ package boot
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -10,9 +9,9 @@ import (
 	"bisonai.com/orakl/node/pkg/boot/peer"
 	"bisonai.com/orakl/node/pkg/boot/utils"
 	"bisonai.com/orakl/node/pkg/db"
-	errorSentinel "bisonai.com/orakl/node/pkg/error"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
-	libp2p_utils "bisonai.com/orakl/node/pkg/libp2p/utils"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
+    errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
 )
@@ -84,7 +83,7 @@ func RefreshJob(ctx context.Context) error {
 		return nil
 	}
 
-	h, err := libp2p_setup.MakeHost(0)
+	h, err := libp2pSetup.MakeHost(0)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to make host")
 		return err
@@ -92,7 +91,7 @@ func RefreshJob(ctx context.Context) error {
 
 	for _, p := range peers {
 		connectionUrl := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", p.Ip, p.Port, p.HostId)
-		isAlive, liveCheckErr := libp2p_utils.IsHostAlive(ctx, h, connectionUrl)
+		isAlive, liveCheckErr := libp2pUtils.IsHostAlive(ctx, h, connectionUrl)
 		if liveCheckErr != nil {
 			log.Error().Err(liveCheckErr).Msg("Failed to check peer")
 			if !errors.Is(liveCheckErr, errorSentinel.ErrLibP2pFailToConnectPeer) {

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -2,6 +2,7 @@ package boot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -9,9 +10,9 @@ import (
 	"bisonai.com/orakl/node/pkg/boot/peer"
 	"bisonai.com/orakl/node/pkg/boot/utils"
 	"bisonai.com/orakl/node/pkg/db"
+	errorSentinel "bisonai.com/orakl/node/pkg/error"
 	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
-    errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
 )

--- a/node/pkg/boot/peer/controller.go
+++ b/node/pkg/boot/peer/controller.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"bisonai.com/orakl/node/pkg/db"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
-	libp2p_utils "bisonai.com/orakl/node/pkg/libp2p/utils"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
 	"github.com/go-playground/validator"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
@@ -71,14 +71,14 @@ func sync(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString("Failed to validate request")
 	}
 
-	h, err := libp2p_setup.MakeHost(0)
+	h, err := libp2pSetup.MakeHost(0)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to make host")
 		return c.Status(fiber.StatusInternalServerError).SendString("Failed to make host")
 	}
 
 	connectionUrl := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", payload.Ip, payload.Port, payload.HostId)
-	isAlive, _ := libp2p_utils.IsHostAlive(c.Context(), h, connectionUrl)
+	isAlive, _ := libp2pUtils.IsHostAlive(c.Context(), h, connectionUrl)
 	if !isAlive {
 		log.Info().Str("peer", connectionUrl).Msg("invalid peer")
 		err = h.Close()

--- a/node/pkg/boot/tests/peer_test.go
+++ b/node/pkg/boot/tests/peer_test.go
@@ -11,8 +11,8 @@ import (
 	"bisonai.com/orakl/node/pkg/boot"
 	"bisonai.com/orakl/node/pkg/boot/peer"
 	"bisonai.com/orakl/node/pkg/db"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
-	libp2p_utils "bisonai.com/orakl/node/pkg/libp2p/utils"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
 
 	_peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -81,21 +81,21 @@ func TestSync(t *testing.T) {
 	}
 	defer cleanup()
 
-	mockHost1, err := libp2p_setup.MakeHost(0)
+	mockHost1, err := libp2pSetup.MakeHost(0)
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}
 
-	mockHost2, err := libp2p_setup.MakeHost(0)
+	mockHost2, err := libp2pSetup.MakeHost(0)
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}
 
-	ip1, port1, hostId1, err := libp2p_utils.ExtractPayloadFromHost(mockHost1)
+	ip1, port1, hostId1, err := libp2pUtils.ExtractPayloadFromHost(mockHost1)
 	if err != nil {
 		t.Fatalf("error extracting payload from host: %v", err)
 	}
-	ip2, port2, hostId2, err := libp2p_utils.ExtractPayloadFromHost(mockHost2)
+	ip2, port2, hostId2, err := libp2pUtils.ExtractPayloadFromHost(mockHost2)
 	if err != nil {
 		t.Fatalf("error extracting payload from host: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestRefresh(t *testing.T) {
 	}
 	defer cleanup()
 
-	h, err := libp2p_setup.MakeHost(10011)
+	h, err := libp2pSetup.MakeHost(10011)
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}

--- a/node/pkg/fetcher/app.go
+++ b/node/pkg/fetcher/app.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/bus"
-	chain_helper "bisonai.com/orakl/node/pkg/chain/helper"
+	chainHelper "bisonai.com/orakl/node/pkg/chain/helper"
 	"bisonai.com/orakl/node/pkg/db"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"github.com/rs/zerolog/log"
@@ -283,7 +283,7 @@ func (a *App) getChainHelpers(ctx context.Context) (map[string]ChainHelper, erro
 		cypressProviderUrl = "https://public-en-cypress.klaytn.net"
 	}
 
-	cypressHelper, err := chain_helper.NewChainHelper(ctx, chain_helper.WithProviderUrl(cypressProviderUrl))
+	cypressHelper, err := chainHelper.NewChainHelper(ctx, chainHelper.WithProviderUrl(cypressProviderUrl))
 	if err != nil {
 		log.Error().Err(err).Msg("failed to create cypress helper")
 		return nil, err
@@ -295,7 +295,7 @@ func (a *App) getChainHelpers(ctx context.Context) (map[string]ChainHelper, erro
 		ethereumProviderUrl = "https://ethereum-mainnet-rpc.allthatnode.com"
 	}
 
-	ethereumHelper, err := chain_helper.NewChainHelper(ctx, chain_helper.WithBlockchainType(chain_helper.Ethereum), chain_helper.WithProviderUrl(ethereumProviderUrl))
+	ethereumHelper, err := chainHelper.NewChainHelper(ctx, chainHelper.WithBlockchainType(chainHelper.Ethereum), chainHelper.WithProviderUrl(ethereumProviderUrl))
 	if err != nil {
 		log.Error().Err(err).Msg("failed to create ethereum helper")
 		return nil, err

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -15,7 +15,7 @@ import (
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/chain/helper"
 	"bisonai.com/orakl/node/pkg/db"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -119,12 +119,12 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 
 	testItems.admin = admin
 
-	h, err := libp2p_setup.MakeHost(10001)
+	h, err := libp2pSetup.MakeHost(10001)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ps, err := libp2p_setup.MakePubsub(ctx, h)
+	ps, err := libp2pSetup.MakePubsub(ctx, h)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/chain/helper"
-	chain_utils "bisonai.com/orakl/node/pkg/chain/utils"
+	chainUtils "bisonai.com/orakl/node/pkg/chain/utils"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
+
 	"bisonai.com/orakl/node/pkg/raft"
 	"bisonai.com/orakl/node/pkg/utils/retrier"
 
@@ -153,7 +154,7 @@ func (r *Reporter) report(ctx context.Context, aggregates []GlobalAggregate) err
 
 func (r *Reporter) orderProof(ctx context.Context, proof []byte, aggregate GlobalAggregate) ([]byte, error) {
 	proof = RemoveDuplicateProof(proof)
-	hash := chain_utils.Value2HashForSign(aggregate.Value, aggregate.Timestamp.Unix())
+	hash := chainUtils.Value2HashForSign(aggregate.Value, aggregate.Timestamp.Unix())
 	proofChunks, err := SplitProofToChunk(proof)
 	if err != nil {
 		log.Error().Str("Player", "Reporter").Err(err).Msg("failed to split proof")

--- a/node/pkg/reporter/utils.go
+++ b/node/pkg/reporter/utils.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"bisonai.com/orakl/node/pkg/chain/helper"
-	chain_utils "bisonai.com/orakl/node/pkg/chain/utils"
+	chainUtils "bisonai.com/orakl/node/pkg/chain/utils"
 	"bisonai.com/orakl/node/pkg/db"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
 
@@ -295,7 +295,7 @@ func GetSignerMap(signers []common.Address, proofChunks [][]byte) map[common.Add
 func GetSignerListFromProofs(hash []byte, proofChunks [][]byte) ([]common.Address, error) {
 	signers := make([]common.Address, 0, len(proofChunks))
 	for _, p := range proofChunks {
-		signer, err := chain_utils.RecoverSigner(hash, p)
+		signer, err := chainUtils.RecoverSigner(hash, p)
 		if err != nil {
 			return nil, err
 		}

--- a/node/pkg/reporter/utils_test.go
+++ b/node/pkg/reporter/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	chain_utils "bisonai.com/orakl/node/pkg/chain/utils"
+	chainUtils "bisonai.com/orakl/node/pkg/chain/utils"
 	"bisonai.com/orakl/node/pkg/db"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"github.com/klaytn/klaytn/common"
@@ -134,23 +134,23 @@ func TestGetSignerListFromProofs(t *testing.T) {
 	testValue := int64(10)
 	testTimestamp := time.Now().Unix()
 
-	hash := chain_utils.Value2HashForSign(testValue, testTimestamp)
+	hash := chainUtils.Value2HashForSign(testValue, testTimestamp)
 	test_pk_0 := "737ea08c90c582aafdd7644ec492ee685df711df1ca055fd351938a493058217"
 	test_pk_1 := "c2235dcc40306325e1e060b066edb728a1734a377a9648461526101e5365ac56"
-	pk_0, err := chain_utils.StringToPk(test_pk_0)
+	pk_0, err := chainUtils.StringToPk(test_pk_0)
 	if err != nil {
 		t.Fatalf("Failed to convert string to pk: %v", err)
 	}
-	pk_1, err := chain_utils.StringToPk(test_pk_1)
+	pk_1, err := chainUtils.StringToPk(test_pk_1)
 	if err != nil {
 		t.Fatalf("Failed to convert string to pk: %v", err)
 	}
 
-	sig_0, err := chain_utils.MakeValueSignature(testValue, testTimestamp, pk_0)
+	sig_0, err := chainUtils.MakeValueSignature(testValue, testTimestamp, pk_0)
 	if err != nil {
 		t.Fatalf("Failed to make value signature: %v", err)
 	}
-	sig_1, err := chain_utils.MakeValueSignature(testValue, testTimestamp, pk_1)
+	sig_1, err := chainUtils.MakeValueSignature(testValue, testTimestamp, pk_1)
 	if err != nil {
 		t.Fatalf("Failed to make value signature: %v", err)
 	}

--- a/node/script/test_connection/main.go
+++ b/node/script/test_connection/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"time"
 
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"github.com/rs/zerolog/log"
 )
 
@@ -22,7 +22,7 @@ func main() {
 	}
 
 	startTime := time.Now()
-	_, ps, err := libp2p_setup.SetupFromBootApi(ctx, *port)
+	_, ps, err := libp2pSetup.SetupFromBootApi(ctx, *port)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to setup libp2p")
 	}

--- a/node/script/test_fetcher_and_aggregator/main.go
+++ b/node/script/test_fetcher_and_aggregator/main.go
@@ -12,7 +12,7 @@ import (
 	"bisonai.com/orakl/node/pkg/aggregator"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/fetcher"
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"github.com/rs/zerolog/log"
 )
 
@@ -73,7 +73,7 @@ func main() {
 			return
 		}
 
-		host, ps, err := libp2p_setup.SetupFromBootApi(ctx, listenPort)
+		host, ps, err := libp2pSetup.SetupFromBootApi(ctx, listenPort)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to setup libp2p")
 			return

--- a/node/script/test_raft/main.go
+++ b/node/script/test_raft/main.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"time"
 
-	libp2p_setup "bisonai.com/orakl/node/pkg/libp2p/setup"
+	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"bisonai.com/orakl/node/pkg/raft"
 	"github.com/rs/zerolog/log"
 )
@@ -20,7 +20,7 @@ func main() {
 
 	flag.Parse()
 
-	host, ps, err := libp2p_setup.SetupFromBootApi(ctx, *port)
+	host, ps, err := libp2pSetup.SetupFromBootApi(ctx, *port)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to setup libp2p")
 	}


### PR DESCRIPTION
# Description

In Go, it's generally recommended to avoid underscores in package names and aliases. This is because Go's naming conventions favor camelCase and all lowercase letters without underscores or hyphens.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
