### PR TITLE
Migrate listener observed block from redis to db

### DIFF
--- a/api/listener/controller.go
+++ b/api/listener/controller.go
@@ -34,7 +34,7 @@ type ListenerInsertModel struct {
 	Chain     string `db:"chain_name" json:"chain" validate:"required"`
 }
 
-type ListenerObservedBlockModel struct {
+type ObservedBlockModel struct {
 	BlockKey	string 	`db:"block_key" json:"blockKey" validate:"required"`
 	BlockNumber	int64 	`db:"block_number" json:"blockNumber" validate:"blockNumberValidator"`
 }
@@ -158,7 +158,7 @@ func deleteById(c *fiber.Ctx) error {
 }
 
 func upsertObservedBlock(c *fiber.Ctx) error {
-	payload := new(ListenerObservedBlockModel)
+	payload := new(ObservedBlockModel)
 	if err := c.BodyParser(payload); err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func upsertObservedBlock(c *fiber.Ctx) error {
 		return err
 	}
 
-	result, err := utils.QueryRow[ListenerObservedBlockModel](c, UpsertObservedBlock, map[string]any{"block_key": payload.BlockKey, "block_number": payload.BlockNumber})
+	result, err := utils.QueryRow[ObservedBlockModel](c, UpsertObservedBlock, map[string]any{"block_key": payload.BlockKey, "block_number": payload.BlockNumber})
 	if err != nil {
 		return err
 	}
@@ -179,8 +179,8 @@ func upsertObservedBlock(c *fiber.Ctx) error {
 }
 
 func getObservedBlock(c *fiber.Ctx) error {
-	block_key := c.Query("blockKey")
-	result, err := utils.QueryRow[ListenerObservedBlockModel](c, GetObservedBlock, map[string]any{"block_key": block_key})
+	blockKey := c.Query("blockKey")
+	result, err := utils.QueryRow[ObservedBlockModel](c, GetObservedBlock, map[string]any{"block_key": blockKey})
 	if err != nil {
 		return err
 	}

--- a/api/listener/controller.go
+++ b/api/listener/controller.go
@@ -34,6 +34,11 @@ type ListenerInsertModel struct {
 	Chain     string `db:"chain_name" json:"chain" validate:"required"`
 }
 
+type ListenerObservedBlockModel struct {
+	BlockKey	string `db:"block_key" json:"blockKey" validate:"required"`
+	BlockNumber	int64 `db:"block_number" json:"blockNumber" validate:"required"`
+}
+
 func insert(c *fiber.Ctx) error {
 	payload := new(ListenerInsertModel)
 	if err := c.BodyParser(payload); err != nil {
@@ -149,5 +154,23 @@ func deleteById(c *fiber.Ctx) error {
 		return err
 	}
 
+	return c.JSON(result)
+}
+
+func insertUpdateObservedBlock(c *fiber.Ctx) error {
+	payload := new(ListenerObservedBlockModel)
+	if err := c.BodyParser(payload); err != nil {
+		return err
+	}
+
+	validate := validator.New()
+	if err := validate.Struct(payload); err != nil {
+		return err
+	}
+
+	result, err := utils.QueryRow[ListenerObservedBlockModel](c, InsertUpdateObservedBlock, map[string]any{"block_key": payload.BlockKey, "block_number": payload.BlockNumber})
+	if err != nil {
+		return err
+	}
 	return c.JSON(result)
 }

--- a/api/listener/queries.go
+++ b/api/listener/queries.go
@@ -44,13 +44,13 @@ const (
 		`
 
 	GetObservedBlock = `
-		SELECT * FROM observed_block
+		SELECT * FROM observed_blocks
 		WHERE block_key = @block_key
 		LIMIT 1;
 	`
 	
 	UpsertObservedBlock = `
-		INSERT INTO observed_block (block_key, block_number)
+		INSERT INTO observed_blocks (block_key, block_number)
 		VALUES (@block_key, @block_number)
 		ON CONFLICT (block_key) 
 		DO UPDATE SET block_number = @block_number

--- a/api/listener/queries.go
+++ b/api/listener/queries.go
@@ -43,7 +43,13 @@ const (
 		(SELECT name from services WHERE service_id = listeners.service_id) AS service_name;
 		`
 
-	InsertUpdateObservedBlock = `
+	GetObservedBlock = `
+		SELECT * FROM observed_block
+		WHERE block_key = @block_key
+		LIMIT 1;
+	`
+	
+	UpsertObservedBlock = `
 		INSERT INTO observed_block (block_key, block_number)
 		VALUES (@block_key, @block_number)
 		ON CONFLICT (block_key) 

--- a/api/listener/queries.go
+++ b/api/listener/queries.go
@@ -42,6 +42,14 @@ const (
 		(SELECT name from chains WHERE chain_id = listeners.chain_id) AS chain_name,
 		(SELECT name from services WHERE service_id = listeners.service_id) AS service_name;
 		`
+
+	InsertUpdateObservedBlock = `
+		INSERT INTO observed_block (block_key, block_number)
+		VALUES (@block_key, @block_number)
+		ON CONFLICT (block_key) 
+		DO UPDATE SET block_number = @block_number
+		RETURNING *;
+	`
 )
 
 func GenerateGetListenerQuery(params GetListenerQueryParams) string {

--- a/api/listener/route.go
+++ b/api/listener/route.go
@@ -12,4 +12,5 @@ func Routes(router fiber.Router) {
 	listener.Get("/:id", getById)
 	listener.Patch("/:id", updateById)
 	listener.Delete("/:id", deleteById)
+	listener.Post("/observed-block", insertUpdateObservedBlock)
 }

--- a/api/listener/route.go
+++ b/api/listener/route.go
@@ -9,8 +9,9 @@ func Routes(router fiber.Router) {
 
 	listener.Post("", insert)
 	listener.Get("", get)
+	listener.Post("/observed-block", upsertObservedBlock)
+	listener.Get("/observed-block", getObservedBlock)
 	listener.Get("/:id", getById)
 	listener.Patch("/:id", updateById)
 	listener.Delete("/:id", deleteById)
-	listener.Post("/observed-block", insertUpdateObservedBlock)
 }

--- a/api/migrations/000002_add_observed_block.down.sql
+++ b/api/migrations/000002_add_observed_block.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "observed_block";

--- a/api/migrations/000002_add_observed_block.down.sql
+++ b/api/migrations/000002_add_observed_block.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS "observed_block";
+DROP TABLE IF EXISTS "observed_blocks";

--- a/api/migrations/000002_add_observed_block.up.sql
+++ b/api/migrations/000002_add_observed_block.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS "observed_block" (
+    block_key TEXT NOT NULL,
+    block_number BIGINT NOT NULL,
+    CONSTRAINT "observed_block_key" UNIQUE ("block_key")
+)

--- a/api/migrations/000002_add_observed_block.up.sql
+++ b/api/migrations/000002_add_observed_block.up.sql
@@ -1,5 +1,5 @@
-CREATE TABLE IF NOT EXISTS "observed_block" (
+CREATE TABLE IF NOT EXISTS "observed_blocks" (
     block_key TEXT NOT NULL,
     block_number BIGINT NOT NULL,
-    CONSTRAINT "observed_block_key" UNIQUE ("block_key")
+    CONSTRAINT "observed_blocks_key" UNIQUE ("block_key")
 )

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -73,5 +73,6 @@ export enum OraklErrorCode {
   AxiosCanceledByUser,
   AxiosNotSupported,
   AxiosInvalidUrl,
-  FailedToConnectAPI
+  FailedToConnectAPI,
+  UpsertListenerObservedBlockFailed
 }

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -74,6 +74,6 @@ export enum OraklErrorCode {
   AxiosNotSupported,
   AxiosInvalidUrl,
   FailedToConnectAPI,
-  UpsertListenerObservedBlockFailed,
-  GetListenerObservedBlockFailed
+  UpsertObservedBlockFailed,
+  GetObservedBlockFailed
 }

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -74,5 +74,6 @@ export enum OraklErrorCode {
   AxiosNotSupported,
   AxiosInvalidUrl,
   FailedToConnectAPI,
-  UpsertListenerObservedBlockFailed
+  UpsertListenerObservedBlockFailed,
+  GetListenerObservedBlockFailed
 }

--- a/core/src/listener/api.ts
+++ b/core/src/listener/api.ts
@@ -60,7 +60,15 @@ export async function getListener({
   }
 }
 
-export async function getListenerObservedBlock({
+/**
+ * Get observed block number from the Orakl Network API for a given contract address
+ *
+ * @param {string} blockKey
+ * @param {pino.Logger} logger
+ * @return {Promise<IObservedBlock>}
+ * @exception {OraklErrorCode.GetObservedBlockFailed}
+ */
+export async function getObservedBlock({
   blockKey,
   logger
 }: {
@@ -71,8 +79,8 @@ export async function getListenerObservedBlock({
     const endpoint = buildUrl(ORAKL_NETWORK_API_URL, `listener/observed-block?blockKey=${blockKey}`)
     return (await axios.get(endpoint))?.data
   } catch (e) {
-    logger?.error({ name: 'getListenerObservedBlock', file: FILE_NAME, ...e }, 'error')
-    throw new OraklError(OraklErrorCode.GetListenerObservedBlockFailed)
+    logger?.error({ name: 'getObservedBlock', file: FILE_NAME, ...e }, 'error')
+    throw new OraklError(OraklErrorCode.GetObservedBlockFailed)
   }
 }
 
@@ -82,10 +90,10 @@ export async function getListenerObservedBlock({
  * @param {string} blockKey
  * @param {number} blockNumber
  * @param {pino.Logger} logger
- * @return {Promise<IListenerObservedBlock>}
- * @exception {UpsertListenerObservedBlockFailed}
+ * @return {Promise<IObservedBlock>}
+ * @exception {OraklErrorCode.UpsertObservedBlockFailed}
  */
-export async function upsertListenerObservedBlock({
+export async function upsertObservedBlock({
   blockKey,
   blockNumber,
   logger
@@ -98,7 +106,7 @@ export async function upsertListenerObservedBlock({
     const endpoint = buildUrl(ORAKL_NETWORK_API_URL, 'listener/observed-block')
     return (await axios.post(endpoint, { blockKey, blockNumber }))?.data
   } catch (e) {
-    logger?.error({ name: 'upsertListenerObservedBlock', file: FILE_NAME, ...e }, 'error')
-    throw new OraklError(OraklErrorCode.UpsertListenerObservedBlockFailed)
+    logger?.error({ name: 'upsertObservedBlock', file: FILE_NAME, ...e }, 'error')
+    throw new OraklError(OraklErrorCode.UpsertObservedBlockFailed)
   }
 }

--- a/core/src/listener/api.ts
+++ b/core/src/listener/api.ts
@@ -2,8 +2,9 @@ import axios from 'axios'
 import { Logger } from 'pino'
 import { OraklError, OraklErrorCode } from '../errors'
 import { ORAKL_NETWORK_API_URL } from '../settings'
-import { IListenerObservedBlock, IListenerRawConfig } from '../types'
+import { IListenerRawConfig } from '../types'
 import { buildUrl } from '../utils'
+import { IObservedBlock } from './types'
 
 const FILE_NAME = import.meta.url
 
@@ -59,27 +60,43 @@ export async function getListener({
   }
 }
 
+export async function getListenerObservedBlock({
+  blockKey,
+  logger
+}: {
+  blockKey: string
+  logger?: Logger
+}): Promise<IObservedBlock> {
+  try {
+    const endpoint = buildUrl(ORAKL_NETWORK_API_URL, `listener/observed-block?blockKey=${blockKey}`)
+    return (await axios.get(endpoint))?.data
+  } catch (e) {
+    logger?.error({ name: 'getListenerObservedBlock', file: FILE_NAME, ...e }, 'error')
+    throw new OraklError(OraklErrorCode.GetListenerObservedBlockFailed)
+  }
+}
+
 /**
  * Upsert listener observed block number to the Orakl Network API for a given contract address
  *
  * @param {string} blockKey
- * @param {number} blockValue
+ * @param {number} blockNumber
  * @param {pino.Logger} logger
  * @return {Promise<IListenerObservedBlock>}
  * @exception {UpsertListenerObservedBlockFailed}
  */
 export async function upsertListenerObservedBlock({
   blockKey,
-  blockValue,
+  blockNumber,
   logger
 }: {
   blockKey: string
-  blockValue: number
+  blockNumber: number
   logger?: Logger
-}): Promise<IListenerObservedBlock> {
+}): Promise<IObservedBlock> {
   try {
     const endpoint = buildUrl(ORAKL_NETWORK_API_URL, 'listener/observed-block')
-    return (await axios.post(endpoint, { blockKey, blockValue }))?.data
+    return (await axios.post(endpoint, { blockKey, blockNumber }))?.data
   } catch (e) {
     logger?.error({ name: 'upsertListenerObservedBlock', file: FILE_NAME, ...e }, 'error')
     throw new OraklError(OraklErrorCode.UpsertListenerObservedBlockFailed)

--- a/core/src/listener/api.ts
+++ b/core/src/listener/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { Logger } from 'pino'
 import { OraklError, OraklErrorCode } from '../errors'
 import { ORAKL_NETWORK_API_URL } from '../settings'
-import { IListenerRawConfig } from '../types'
+import { IListenerObservedBlock, IListenerRawConfig } from '../types'
 import { buildUrl } from '../utils'
 
 const FILE_NAME = import.meta.url
@@ -56,5 +56,32 @@ export async function getListener({
   } catch (e) {
     logger?.error({ name: 'getListener', file: FILE_NAME, ...e }, 'error')
     throw new OraklError(OraklErrorCode.GetListenerRequestFailed)
+  }
+}
+
+/**
+ * Upsert listener observed block number to the Orakl Network API for a given contract address
+ *
+ * @param {string} blockKey
+ * @param {number} blockValue
+ * @param {pino.Logger} logger
+ * @return {Promise<IListenerObservedBlock>}
+ * @exception {UpsertListenerObservedBlockFailed}
+ */
+export async function upsertListenerObservedBlock({
+  blockKey,
+  blockValue,
+  logger
+}: {
+  blockKey: string
+  blockValue: number
+  logger?: Logger
+}): Promise<IListenerObservedBlock> {
+  try {
+    const endpoint = buildUrl(ORAKL_NETWORK_API_URL, 'listener/observed-block')
+    return (await axios.post(endpoint, { blockKey, blockValue }))?.data
+  } catch (e) {
+    logger?.error({ name: 'upsertListenerObservedBlock', file: FILE_NAME, ...e }, 'error')
+    throw new OraklError(OraklErrorCode.UpsertListenerObservedBlockFailed)
   }
 }

--- a/core/src/listener/data-feed-L2.ts
+++ b/core/src/listener/data-feed-L2.ts
@@ -48,7 +48,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/data-feed-L2.ts
+++ b/core/src/listener/data-feed-L2.ts
@@ -10,7 +10,6 @@ import {
   L2_DATA_FEED_SERVICE_NAME,
   L2_LISTENER_DATA_FEED_HISTORY_QUEUE_NAME,
   L2_LISTENER_DATA_FEED_LATEST_QUEUE_NAME,
-  L2_LISTENER_DATA_FEED_PROCESS_EVENT_QUEUE_NAME,
   L2_WORKER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { IAnswerUpdated, IDataFeedListenerWorkerL2, IListenerConfig } from '../types'
@@ -30,7 +29,6 @@ export async function buildListener(
   const eventName = 'AnswerUpdated'
   const latestQueueName = L2_LISTENER_DATA_FEED_LATEST_QUEUE_NAME
   const historyQueueName = L2_LISTENER_DATA_FEED_HISTORY_QUEUE_NAME
-  const processEventQueueName = L2_LISTENER_DATA_FEED_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = L2_WORKER_AGGREGATOR_QUEUE_NAME
   const abi = Aggregator__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -44,7 +42,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -57,7 +57,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/data-feed.ts
+++ b/core/src/listener/data-feed.ts
@@ -61,7 +61,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/listener.ts
+++ b/core/src/listener/listener.ts
@@ -217,6 +217,8 @@ function latestJob({
                 ...queueSettings
               })
               logger.debug(`Listener submitted job [${jobId}] for [${jobName}]`)
+            } else {
+              throw new Error(`jobMetadata is not defined for an event in block ${blockNumber}`)
             }
           }
           await upsertObservedBlock({
@@ -304,6 +306,8 @@ function historyJob({
             ...queueSettings
           })
           logger.debug(`Listener submitted job [${jobId}] for [${jobName}]`)
+        } else {
+          throw new Error(`jobMetadata is not defined for an event in block ${blockNumber}`)
         }
       }
 

--- a/core/src/listener/listener.ts
+++ b/core/src/listener/listener.ts
@@ -9,7 +9,6 @@ import {
   IHistoryListenerJob,
   ILatestListenerJob,
   IProcessEventListenerJob,
-  ListenerInitType,
   ProcessEventOutputType
 } from './types'
 import { watchman } from './watchman'
@@ -40,7 +39,6 @@ const FILE_NAME = import.meta.url
  * @param {string} name of [worker] queue
  * @param {(log: ethers.Event) => Promise<ProcessEventOutputType>} event processing function
  * @param {RedisClientType} redis client
- * @params {ListenerInitType} listener initialization type
  * @param {Logger} pino logger
  */
 export async function listenerService({
@@ -56,7 +54,6 @@ export async function listenerService({
   workerQueueName,
   processFn,
   redisClient,
-  listenerInitType,
   logger
 }: {
   config: IListenerConfig[]
@@ -71,7 +68,6 @@ export async function listenerService({
   workerQueueName: string
   processFn: (log: ethers.Event) => Promise<ProcessEventOutputType | undefined>
   redisClient: RedisClientType
-  listenerInitType: ListenerInitType
   logger: Logger
 }) {
   const latestListenerQueue = new Queue(latestQueueName, BULLMQ_CONNECTION)
@@ -88,7 +84,6 @@ export async function listenerService({
     chain,
     eventName,
     abi,
-    listenerInitType,
     logger
   })
   await state.clear()

--- a/core/src/listener/listener.ts
+++ b/core/src/listener/listener.ts
@@ -4,7 +4,7 @@ import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import { BULLMQ_CONNECTION, getObservedBlockRedisKey, LISTENER_JOB_SETTINGS } from '../settings'
 import { IListenerConfig } from '../types'
-import { upsertListenerObservedBlock } from './api'
+import { upsertObservedBlock } from './api'
 import { State } from './state'
 import { IHistoryListenerJob, ILatestListenerJob, ProcessEventOutputType } from './types'
 import { watchman } from './watchman'
@@ -155,8 +155,8 @@ function latestJob({
 }: {
   state: State
   historyListenerQueue: Queue
-  redisClient: RedisClientType
   workerQueue: Queue
+  redisClient: RedisClientType
   processFn: (log: ethers.Event) => Promise<ProcessEventOutputType | undefined>
   logger: Logger
 }) {
@@ -219,7 +219,7 @@ function latestJob({
               logger.debug(`Listener submitted job [${jobId}] for [${jobName}]`)
             }
           }
-          await upsertListenerObservedBlock({
+          await upsertObservedBlock({
             blockKey: observedBlockRedisKey,
             blockNumber,
             logger: this.logger
@@ -308,7 +308,7 @@ function historyJob({
       }
 
       if (blockNumber > observedBlock) {
-        await upsertListenerObservedBlock({
+        await upsertObservedBlock({
           blockKey: observedBlockRedisKey,
           blockNumber,
           logger

--- a/core/src/listener/request-response-L2-fulfill.ts
+++ b/core/src/listener/request-response-L2-fulfill.ts
@@ -52,7 +52,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/request-response-L2-fulfill.ts
+++ b/core/src/listener/request-response-L2-fulfill.ts
@@ -7,7 +7,6 @@ import {
   L1_ENDPOINT,
   L2_LISTENER_REQUEST_RESPONSE_FULFILL_HISTORY_QUEUE_NAME,
   L2_LISTENER_REQUEST_RESPONSE_FULFILL_LATEST_QUEUE_NAME,
-  L2_LISTENER_REQUEST_RESPONSE_FULFILL_PROCESS_EVENT_QUEUE_NAME,
   L2_REQUEST_RESPONSE_FULFILL_LISTENER_STATE_NAME,
   L2_REQUEST_RESPONSE_FULFILL_SERVICE_NAME,
   L2_WORKER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME
@@ -34,7 +33,6 @@ export async function buildListener(
   const eventName = 'DataRequestFulfilled'
   const latestQueueName = L2_LISTENER_REQUEST_RESPONSE_FULFILL_LATEST_QUEUE_NAME
   const historyQueueName = L2_LISTENER_REQUEST_RESPONSE_FULFILL_HISTORY_QUEUE_NAME
-  const processEventQueueName = L2_LISTENER_REQUEST_RESPONSE_FULFILL_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = L2_WORKER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME
   const abi = L1Endpoint__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -48,7 +46,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/request-response-L2-request.ts
+++ b/core/src/listener/request-response-L2-request.ts
@@ -47,7 +47,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/request-response-L2-request.ts
+++ b/core/src/listener/request-response-L2-request.ts
@@ -7,7 +7,6 @@ import {
   L1_ENDPOINT,
   L2_LISTENER_REQUEST_RESPONSE_REQUEST_HISTORY_QUEUE_NAME,
   L2_LISTENER_REQUEST_RESPONSE_REQUEST_LATEST_QUEUE_NAME,
-  L2_LISTENER_REQUEST_RESPONSE_REQUEST_PROCESS_EVENT_QUEUE_NAME,
   L2_REQUEST_RESPONSE_REQUEST_LISTENER_STATE_NAME,
   L2_REQUEST_RESPONSE_REQUEST_SERVICE_NAME,
   L2_WORKER_REQUEST_RESPONSE_REQUEST_QUEUE_NAME
@@ -29,7 +28,6 @@ export async function buildListener(
   const eventName = 'DataRequested'
   const latestQueueName = L2_LISTENER_REQUEST_RESPONSE_REQUEST_LATEST_QUEUE_NAME
   const historyQueueName = L2_LISTENER_REQUEST_RESPONSE_REQUEST_HISTORY_QUEUE_NAME
-  const processEventQueueName = L2_LISTENER_REQUEST_RESPONSE_REQUEST_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = L2_WORKER_REQUEST_RESPONSE_REQUEST_QUEUE_NAME
   const abi = L2Endpoint__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -43,7 +41,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/request-response.ts
+++ b/core/src/listener/request-response.ts
@@ -6,7 +6,6 @@ import {
   CHAIN,
   LISTENER_REQUEST_RESPONSE_HISTORY_QUEUE_NAME,
   LISTENER_REQUEST_RESPONSE_LATEST_QUEUE_NAME,
-  LISTENER_REQUEST_RESPONSE_PROCESS_EVENT_QUEUE_NAME,
   REQUEST_RESPONSE_LISTENER_STATE_NAME,
   REQUEST_RESPONSE_SERVICE_NAME,
   WORKER_REQUEST_RESPONSE_QUEUE_NAME
@@ -28,7 +27,6 @@ export async function buildListener(
   const eventName = 'DataRequested'
   const latestQueueName = LISTENER_REQUEST_RESPONSE_LATEST_QUEUE_NAME
   const historyQueueName = LISTENER_REQUEST_RESPONSE_HISTORY_QUEUE_NAME
-  const processEventQueueName = LISTENER_REQUEST_RESPONSE_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = WORKER_REQUEST_RESPONSE_QUEUE_NAME
   const abi = RequestResponseCoordinator__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -42,7 +40,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/request-response.ts
+++ b/core/src/listener/request-response.ts
@@ -46,7 +46,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -10,7 +10,7 @@ import {
   PROVIDER_URL
 } from '../settings'
 import { IListenerConfig, IListenerRawConfig } from '../types'
-import { getListenerObservedBlock, getListeners, upsertListenerObservedBlock } from './api'
+import { getListeners, getObservedBlock, upsertObservedBlock } from './api'
 import { IContracts, ILatestListenerJob } from './types'
 import { postprocessListeners } from './utils'
 
@@ -175,7 +175,7 @@ export class State {
     const contractAddress = toAddListener.address
     const observedBlockRedisKey = getObservedBlockRedisKey(contractAddress)
     const latestBlock = await this.latestBlockNumber()
-    const { blockKey: observedBlockKey } = await getListenerObservedBlock({
+    const { blockKey: observedBlockKey } = await getObservedBlock({
       blockKey: observedBlockRedisKey,
       logger: this.logger
     })
@@ -188,7 +188,7 @@ export class State {
       * it does not exist -> upsert latestBlock
      */
     if (observedBlockKey === '') {
-      await upsertListenerObservedBlock({
+      await upsertObservedBlock({
         blockKey: observedBlockRedisKey,
         blockNumber: Math.max(latestBlock - 1, 0),
         logger: this.logger

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -186,12 +186,12 @@ export class State {
       update observedBlock to latestBlock - 1 since all blocks in between will be handled
       by history queue and worker
     */
-    upsertListenerObservedBlock({
+    await upsertListenerObservedBlock({
       blockKey: observedBlockRedisKey,
       blockNumber: Math.max(latestBlock - 1, 0),
       logger: this.logger
     })
-    this.redisClient.set(observedBlockRedisKey, Math.max(latestBlock - 1, 0))
+    await this.redisClient.set(observedBlockRedisKey, Math.max(latestBlock - 1, 0))
 
     for (let blockNumber = observedBlock; blockNumber < latestBlock; ++blockNumber) {
       const historyOutData: IHistoryListenerJob = {

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -242,10 +242,10 @@ export class State {
     )
 
     if (jobs.length != 1) {
-      // throw new OraklError(
-      //   OraklErrorCode.UnexpectedNumberOfJobsInQueue,
-      //   `Number of jobs ${jobs.length}`
-      // )
+      throw new OraklError(
+        OraklErrorCode.UnexpectedNumberOfJobsInQueue,
+        `Number of jobs ${jobs.length}`
+      )
     } else {
       const delayedJob = jobs[0]
       await this.latestListenerQueue.removeRepeatableByKey(delayedJob.key)

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -11,7 +11,7 @@ import {
 } from '../settings'
 import { IListenerConfig, IListenerRawConfig } from '../types'
 import { getListeners, getObservedBlock, upsertObservedBlock } from './api'
-import { IContracts, ILatestListenerJob } from './types'
+import { IContracts, IHistoryListenerJob, ILatestListenerJob } from './types'
 import { postprocessListeners } from './utils'
 
 const FILE_NAME = import.meta.url
@@ -175,26 +175,32 @@ export class State {
     const contractAddress = toAddListener.address
     const observedBlockRedisKey = getObservedBlockRedisKey(contractAddress)
     const latestBlock = await this.latestBlockNumber()
-    const { blockKey: observedBlockKey } = await getObservedBlock({
+    const { blockKey: observedBlockKey, blockNumber } = await getObservedBlock({
       blockKey: observedBlockRedisKey,
       logger: this.logger
     })
+    const observedBlockNumber = observedBlockKey === '' ? latestBlock : blockNumber
 
-    /**
-     when listener starts, there are two options:
-      * latest observedBlock (key) exists -> do nothing 
-        (start latest job, it'll handle multiple blocks 
-        between observedBlock and latestBlock)
-      * it does not exist -> upsert latestBlock
-     */
-    if (observedBlockKey === '') {
-      await upsertObservedBlock({
-        blockKey: observedBlockRedisKey,
-        blockNumber: Math.max(latestBlock - 1, 0),
-        logger: this.logger
+    // Insert history jobs if there are any unprocessed blocks
+    // observedBlockNumber is assumed to be already processed
+    // since we update observedBlock only after processing all events from that block
+    for (let blockNumber = observedBlockNumber + 1; blockNumber < latestBlock; ++blockNumber) {
+      const historyOutData: IHistoryListenerJob = {
+        contractAddress,
+        blockNumber
+      }
+      await this.historyListenerQueue.add('history', historyOutData, {
+        ...LISTENER_JOB_SETTINGS
       })
-      await this.redisClient.set(observedBlockRedisKey, Math.max(latestBlock - 1, 0))
     }
+
+    // Update observed block in db and redis
+    await upsertObservedBlock({
+      blockKey: observedBlockRedisKey,
+      blockNumber: Math.max(latestBlock - 1, 0),
+      logger: this.logger
+    })
+    await this.redisClient.set(observedBlockRedisKey, Math.max(latestBlock - 1, 0))
 
     // Insert listener jobs
     const outData: ILatestListenerJob = {

--- a/core/src/listener/state.ts
+++ b/core/src/listener/state.ts
@@ -186,11 +186,12 @@ export class State {
       update observedBlock to latestBlock - 1 since all blocks in between will be handled
       by history queue and worker
     */
-    await upsertListenerObservedBlock({
+    upsertListenerObservedBlock({
       blockKey: observedBlockRedisKey,
       blockNumber: Math.max(latestBlock - 1, 0),
       logger: this.logger
     })
+    this.redisClient.set(observedBlockRedisKey, Math.max(latestBlock - 1, 0))
 
     for (let blockNumber = observedBlock; blockNumber < latestBlock; ++blockNumber) {
       const historyOutData: IHistoryListenerJob = {

--- a/core/src/listener/types.ts
+++ b/core/src/listener/types.ts
@@ -77,3 +77,8 @@ export interface IProcessEventListenerJob {
 export interface IContracts {
   [key: string]: ethers.Contract
 }
+
+export interface IObservedBlock {
+  blockNumber: number
+  blockKey: string
+}

--- a/core/src/listener/vrf-L2-fulfill.ts
+++ b/core/src/listener/vrf-L2-fulfill.ts
@@ -7,7 +7,6 @@ import {
   L2_ENDPOINT,
   L2_LISTENER_VRF_FULFILL_HISTORY_QUEUE_NAME,
   L2_LISTENER_VRF_FULFILL_LATEST_QUEUE_NAME,
-  L2_LISTENER_VRF_FULFILL_PROCESS_EVENT_QUEUE_NAME,
   L2_VRF_FULFILL_LISTENER_STATE_NAME,
   L2_VRF_FULFILL_SERVICE_NAME,
   L2_WORKER_VRF_FULFILL_QUEUE_NAME
@@ -29,7 +28,6 @@ export async function buildListener(
   const eventName = 'RandomWordFulfilled'
   const latestQueueName = L2_LISTENER_VRF_FULFILL_LATEST_QUEUE_NAME
   const historyQueueName = L2_LISTENER_VRF_FULFILL_HISTORY_QUEUE_NAME
-  const processEventQueueName = L2_LISTENER_VRF_FULFILL_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = L2_WORKER_VRF_FULFILL_QUEUE_NAME
   const abi = L1Endpoint__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -43,7 +41,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/vrf-L2-fulfill.ts
+++ b/core/src/listener/vrf-L2-fulfill.ts
@@ -47,7 +47,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/vrf-L2-request.ts
+++ b/core/src/listener/vrf-L2-request.ts
@@ -8,7 +8,6 @@ import {
   L1_ENDPOINT,
   L2_LISTENER_VRF_REQUEST_HISTORY_QUEUE_NAME,
   L2_LISTENER_VRF_REQUEST_LATEST_QUEUE_NAME,
-  L2_LISTENER_VRF_REQUEST_PROCESS_EVENT_QUEUE_NAME,
   L2_VRF_REQUEST_LISTENER_STATE_NAME,
   L2_VRF_REQUEST_SERVICE_NAME,
   L2_WORKER_VRF_REQUEST_QUEUE_NAME
@@ -30,7 +29,6 @@ export async function buildListener(
   const eventName = 'RandomWordsRequested'
   const latestQueueName = L2_LISTENER_VRF_REQUEST_LATEST_QUEUE_NAME
   const historyQueueName = L2_LISTENER_VRF_REQUEST_HISTORY_QUEUE_NAME
-  const processEventQueueName = L2_LISTENER_VRF_REQUEST_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = L2_WORKER_VRF_REQUEST_QUEUE_NAME
   const abi = L2Endpoint__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -44,7 +42,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/listener/vrf-L2-request.ts
+++ b/core/src/listener/vrf-L2-request.ts
@@ -48,7 +48,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/vrf.ts
+++ b/core/src/listener/vrf.ts
@@ -47,7 +47,6 @@ export async function buildListener(
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,
-    listenerInitType: 'latest',
     logger
   })
 }

--- a/core/src/listener/vrf.ts
+++ b/core/src/listener/vrf.ts
@@ -7,7 +7,6 @@ import {
   CHAIN,
   LISTENER_VRF_HISTORY_QUEUE_NAME,
   LISTENER_VRF_LATEST_QUEUE_NAME,
-  LISTENER_VRF_PROCESS_EVENT_QUEUE_NAME,
   VRF_LISTENER_STATE_NAME,
   VRF_SERVICE_NAME,
   WORKER_VRF_QUEUE_NAME
@@ -29,7 +28,6 @@ export async function buildListener(
   const eventName = 'RandomWordsRequested'
   const latestQueueName = LISTENER_VRF_LATEST_QUEUE_NAME
   const historyQueueName = LISTENER_VRF_HISTORY_QUEUE_NAME
-  const processEventQueueName = LISTENER_VRF_PROCESS_EVENT_QUEUE_NAME
   const workerQueueName = WORKER_VRF_QUEUE_NAME
   const abi = VRFCoordinator__factory.abi
   const iface = new ethers.utils.Interface(abi)
@@ -43,7 +41,6 @@ export async function buildListener(
     eventName,
     latestQueueName,
     historyQueueName,
-    processEventQueueName,
     workerQueueName,
     processFn: await processEvent({ iface, logger }),
     redisClient,

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -317,11 +317,6 @@ export interface IListenerGroupConfig {
   [key: string]: IListenerConfig[]
 }
 
-export interface IListenerObservedBlock {
-  blockKey: string
-  blockValue: number
-}
-
 // Reporter
 export interface IReporterConfig {
   id: string

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -317,6 +317,11 @@ export interface IListenerGroupConfig {
   [key: string]: IListenerConfig[]
 }
 
+export interface IListenerObservedBlock {
+  blockKey: string
+  blockValue: number
+}
+
 // Reporter
 export interface IReporterConfig {
   id: string


### PR DESCRIPTION
# Description

_Requires extra attention:_ Refactor listener to merge processEventQ with latestQ and historyQ (i.e. add event jobs to workerQ in latestWorker and historyWorker)

Add listener observed block to both redis and db. Read from db only when listener is initialized and read from redis in other cases:
- write migrate up & down sql files for a new table to keep track of observed block
- write query, controller function, and add route in api/listener
- write wrapper api function in core/listener
- integrate wrapper api into listener code
- test

Implement nodemon for having hot reload running services (listener, worker, reporter):
- Note: hot reload in this case means recompile and restart the service

Tests Performed after implementation. All tests have been performed end to end, consumer to service, for both services, VRF and RR:
- Single request and read operation ✅ 
- Multiple request and read operations ✅ 
- Kill listener, make multiple requests, start listener ✅ 
- Kill listener, make multiple requests, start listener, throw manual error in latestWorker after processing half of unprocessed blocks (to test historyQ and worker) ✅ 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
