### PR TITLE
(OraklNode) Vault integration

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -12,6 +12,12 @@ ENCRYPT_PASSWORD=
 # `baobab` or `cypress`, defaults to baobab
 CHAIN=
 
+# use vault to get signer pk, will use SIGNER_PK if not set
+VAULT_ADDR=
+JWT_PATH=
+VAULT_ROLE=
+VAULT_SECRET_PATH=
+VAULT_KEY_NAME=
 
 # (optional) required if wallets table is empty
 KLAYTN_REPORTER_PK=
@@ -37,3 +43,4 @@ POR_CHAIN=
 POR_PROVIDER_URL=
 # (optional) defaults to 3000
 POR_PORT=
+

--- a/node/pkg/chain/helper/helper.go
+++ b/node/pkg/chain/helper/helper.go
@@ -10,6 +10,7 @@ import (
 
 	"bisonai.com/orakl/node/pkg/chain/utils"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
+	"bisonai.com/orakl/node/pkg/secrets"
 	"bisonai.com/orakl/node/pkg/utils/request"
 	"github.com/klaytn/klaytn/blockchain/types"
 	"github.com/klaytn/klaytn/common"
@@ -29,7 +30,7 @@ func setProviderAndReporter(config *ChainHelperConfig, blockchainType Blockchain
 		}
 
 		if config.ReporterPk == "" {
-			config.ReporterPk = os.Getenv(KlaytnReporterPk)
+			config.ReporterPk = secrets.GetSecret(KlaytnReporterPk)
 			if config.ReporterPk == "" {
 				log.Warn().Msg("reporter pk not set")
 			}
@@ -44,7 +45,7 @@ func setProviderAndReporter(config *ChainHelperConfig, blockchainType Blockchain
 		}
 
 		if config.ReporterPk == "" {
-			config.ReporterPk = os.Getenv(EthReporterPk)
+			config.ReporterPk = secrets.GetSecret(EthReporterPk)
 			if config.ReporterPk == "" {
 				log.Warn().Msg("reporter pk not set")
 			}
@@ -280,7 +281,7 @@ func (t *ChainHelper) retryOnJsonRpcFailure(ctx context.Context, job func(c util
 
 func NewSignHelper(pk string) (*SignHelper, error) {
 	if pk == "" {
-		pk = os.Getenv(SignerPk)
+		pk = secrets.GetSecret(SignerPk)
 		if pk == "" {
 			log.Error().Msg("signer pk not set")
 			return nil, errorSentinel.ErrChainSignerPKNotFound

--- a/node/pkg/db/pgsql.go
+++ b/node/pkg/db/pgsql.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
+	"bisonai.com/orakl/node/pkg/secrets"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
@@ -46,7 +46,7 @@ func connectToPgsql(ctx context.Context, connectionString string) (*pgxpool.Pool
 }
 
 func loadPgsqlConnectionString() string {
-	return os.Getenv("DATABASE_URL")
+	return secrets.GetSecret("DATABASE_URL")
 }
 
 func QueryWithoutResult(ctx context.Context, queryString string, args map[string]any) error {

--- a/node/pkg/libp2p/setup/setup.go
+++ b/node/pkg/libp2p/setup/setup.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"bisonai.com/orakl/node/pkg/libp2p/utils"
+	"bisonai.com/orakl/node/pkg/secrets"
 	"bisonai.com/orakl/node/pkg/utils/request"
 
 	"github.com/libp2p/go-libp2p"
@@ -111,7 +112,7 @@ func makeHost(listenPort int, priv crypto.PrivKey) (host.Host, error) {
 		opts = append(opts, libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort)))
 	}
 
-	secretString := os.Getenv("PRIVATE_NETWORK_SECRET")
+	secretString := secrets.GetSecret("PRIVATE_NETWORK_SECRET")
 	if secretString != "" {
 		hash := sha256.Sum256([]byte(secretString))
 		protector := pnet.PSK(hash[:])

--- a/node/pkg/por/app.go
+++ b/node/pkg/por/app.go
@@ -12,6 +12,7 @@ import (
 	"bisonai.com/orakl/node/pkg/chain/helper"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"bisonai.com/orakl/node/pkg/fetcher"
+	"bisonai.com/orakl/node/pkg/secrets"
 	"bisonai.com/orakl/node/pkg/utils/request"
 	"bisonai.com/orakl/node/pkg/utils/retrier"
 	"github.com/rs/zerolog/log"
@@ -61,7 +62,7 @@ func New(ctx context.Context) (*App, error) {
 		submitInterval = time.Duration(*aggregator.Heartbeat) * time.Millisecond
 	}
 
-	porReporterPk := os.Getenv("POR_REPORTER_PK")
+	porReporterPk := secrets.GetSecret("POR_REPORTER_PK")
 	if porReporterPk == "" {
 		return nil, errorSentinel.ErrPorReporterPkNotFound
 	}

--- a/node/pkg/secrets/secrets.go
+++ b/node/pkg/secrets/secrets.go
@@ -1,0 +1,79 @@
+package secrets
+
+import (
+	"context"
+	"os"
+
+	vault "github.com/hashicorp/vault/api"
+	auth "github.com/hashicorp/vault/api/auth/kubernetes"
+	"github.com/rs/zerolog/log"
+)
+
+var secretData map[string]interface{}
+var initialized bool = false
+
+func init() {
+
+	ctx := context.Background()
+
+	vaultRole := os.Getenv("VAULT_ROLE")
+	jwtPath := os.Getenv("JWT_PATH")
+	vaultSecretPath := os.Getenv("VAULT_SECRET_PATH")
+	vaultKeyName := os.Getenv("VAULT_KEY_NAME")
+
+	if vaultRole == "" || jwtPath == "" || vaultSecretPath == "" || vaultKeyName == "" {
+		log.Error().Msg("Missing required environment variables for Vault initialization")
+		return
+	}
+
+	config := vault.DefaultConfig()
+	client, err := vault.NewClient(config)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to initialize Vault client")
+		return
+	}
+
+	k8sAuth, err := auth.NewKubernetesAuth(
+		vaultRole,
+		auth.WithServiceAccountTokenPath(jwtPath),
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to initialize Kubernetes auth method")
+		return
+	}
+
+	authInfo, err := client.Auth().Login(ctx, k8sAuth)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to log in with Kubernetes auth")
+		return
+	}
+	if authInfo == nil {
+		log.Error().Err(err).Msg("no auth info was returned after login")
+		return
+	}
+
+	secrets, err := client.KVv2(vaultSecretPath).Get(ctx, vaultKeyName)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to read secret")
+		return
+	}
+
+	secretData = secrets.Data
+	initialized = true
+
+}
+
+func GetSecret(key string) string {
+	if !initialized {
+		return os.Getenv(key)
+	}
+	value, ok := secretData[key]
+	if !ok {
+		return os.Getenv(key)
+	}
+	result, ok := value.(string)
+	if !ok || result == "" {
+		return os.Getenv(key)
+	}
+	return result
+}

--- a/node/pkg/utils/encryptor/encryptor.go
+++ b/node/pkg/utils/encryptor/encryptor.go
@@ -5,13 +5,13 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/hex"
-	"os"
 
+	"bisonai.com/orakl/node/pkg/secrets"
 	"golang.org/x/crypto/scrypt"
 )
 
 func EncryptText(textToEncrypt string) (string, error) {
-	password := os.Getenv("ENCRYPT_PASSWORD")
+	password := secrets.GetSecret("ENCRYPT_PASSWORD")
 	if password == "" {
 		password = "anything"
 	}
@@ -52,7 +52,7 @@ func EncryptText(textToEncrypt string) (string, error) {
 }
 
 func DecryptText(encryptedText string) (string, error) {
-	password := os.Getenv("ENCRYPT_PASSWORD")
+	password := secrets.GetSecret("ENCRYPT_PASSWORD")
 	if password == "" {
 		password = "anything"
 	}


### PR DESCRIPTION
# Description

First tries to load settings from vault, fallbacks to environment variable if not exists in vault. use `sync.Once` to load vault secrets only once on package load

### Vault secrets (OraklNode)

- `KLAYTN_REPORTER_PK`
- `SIGNER_PK`
- `ETH_REPORTER_PK` (but not utilized at the moment)
- `PRIVATE_NETWORK_SECRET`
- `ENCRYPT_PASSWORD`
- `DATABASE_URL`

### Vault secrets (POR)

- `POR_REPORTER_PK`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
