### PR TITLE
Update rdb pkg structure

### DIFF
--- a/node/pkg/db/redis.go
+++ b/node/pkg/db/redis.go
@@ -44,6 +44,7 @@ func getRedisConn(ctx context.Context) (*redis.Conn, error) {
 		if err == nil {
 			return rdb, nil
 		}
+		_ = rdb.Close()
 	}
 
 	reconnectJob := func() error {


### PR DESCRIPTION
# Description

## AS-IS
Load rdb connection pool once on application start and reuse forever

## TO-BE
Whenever getting redis pool try to ping the connection, if fails, try reinitialize connection

## Why?
RDB ip can change unexpectedly during k8s pod operation and cached pool fails to connect to new redis ip address

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
