### PR TITLE
(OraklNode) Infinite wait on libp2p node fail

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -41,7 +41,7 @@ func main() {
 	host, ps, err := libp2pSetup.SetupFromBootApi(ctx, listenPort)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to setup libp2p")
-		return
+		select {}
 	}
 
 	wg.Add(1)


### PR DESCRIPTION
# Description

For easier node connection bug fix, don't exit but wait after failure on setting libp2p node from boot api

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
