### PR TITLE
(OraklNode) Add Huobi and Mexc websocket fetchers

### DIFF
--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -15,8 +15,10 @@ import (
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/coinone"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/crypto"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/gateio"
+	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/huobi"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/korbit"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/kucoin"
+	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/mexc"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/upbit"
 	"github.com/rs/zerolog/log"
 )
@@ -92,6 +94,8 @@ func (a *App) Init(ctx context.Context, opts ...AppOption) error {
 		"bithumb":  bithumb.New,
 		"gateio":   gateio.New,
 		"coinex":   coinex.New,
+		"huobi":    huobi.New,
+		"mexc":     mexc.New,
 	}
 
 	appConfig := &AppConfig{

--- a/node/pkg/websocketfetcher/common/utils.go
+++ b/node/pkg/websocketfetcher/common/utils.go
@@ -1,8 +1,11 @@
 package common
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -88,4 +91,14 @@ func MessageToStruct[T any](message map[string]any) (T, error) {
 	}
 
 	return result, nil
+}
+
+func DecompressGzip(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	return io.ReadAll(r)
 }

--- a/node/pkg/websocketfetcher/providers/huobi/huobi.go
+++ b/node/pkg/websocketfetcher/providers/huobi/huobi.go
@@ -50,9 +50,13 @@ func (f *HuobiFetcher) handleMessage(ctx context.Context, message map[string]any
 			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage")
 			return err
 		}
-		f.Ws.Write(ctx, HeartbeatResponse{
+		err = f.Ws.Write(ctx, HeartbeatResponse{
 			Pong: heartbeat.Ping,
 		})
+		if err != nil {
+			log.Error().Str("Player", "Huobi").Err(err).Msg("failed to resond to heartbeat")
+			return err
+		}
 	} else {
 		response, err := common.MessageToStruct[Response](message)
 		if err != nil {

--- a/node/pkg/websocketfetcher/providers/huobi/huobi.go
+++ b/node/pkg/websocketfetcher/providers/huobi/huobi.go
@@ -47,25 +47,25 @@ func (f *HuobiFetcher) handleMessage(ctx context.Context, message map[string]any
 	if _, exists := message["ping"]; exists {
 		heartbeat, err := common.MessageToStruct[Heartbeat](message)
 		if err != nil {
-			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage")
+			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage, failed to parse heartbeat")
 			return err
 		}
 		err = f.Ws.Write(ctx, HeartbeatResponse{
 			Pong: heartbeat.Ping,
 		})
 		if err != nil {
-			log.Error().Str("Player", "Huobi").Err(err).Msg("failed to resond to heartbeat")
+			log.Error().Str("Player", "Huobi").Err(err).Msg("failed to resond to heartbeat, failed to write to websocket")
 			return err
 		}
 	} else {
 		response, err := common.MessageToStruct[Response](message)
 		if err != nil {
-			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage")
+			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage, failed to parse response")
 			return err
 		}
 		feedData, err := ResponseToFeedData(response, f.FeedMap)
 		if err != nil {
-			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage")
+			log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.handleMessage, failed to convert response to feed data")
 			return err
 		}
 
@@ -83,19 +83,19 @@ func (f *HuobiFetcher) customReadFunc(ctx context.Context, conn *websocket.Conn)
 	var result map[string]interface{}
 	_, data, err := conn.Read(ctx)
 	if err != nil {
-		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc")
+		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc, failed to read from websocket")
 		return nil, err
 	}
 
 	decompressed, err := common.DecompressGzip(data)
 	if err != nil {
-		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc")
+		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc, failed to decompress data")
 		return nil, err
 	}
 
 	err = json.Unmarshal(decompressed, &result)
 	if err != nil {
-		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc")
+		log.Error().Str("Player", "Huobi").Err(err).Msg("error in huobi.customReadFunc, failed to unmarshal data")
 		return nil, err
 	}
 

--- a/node/pkg/websocketfetcher/providers/huobi/type.go
+++ b/node/pkg/websocketfetcher/providers/huobi/type.go
@@ -1,0 +1,37 @@
+package huobi
+
+const URL = "wss://api.huobi.pro/ws"
+
+type Subscription struct {
+	Sub string `json:"sub"`
+}
+
+type Ticker struct {
+	Amount    float64 `json:"amount"`
+	Count     int64   `json:"count"`
+	Open      float64 `json:"open"`
+	Close     float64 `json:"close"`
+	Low       float64 `json:"low"`
+	High      float64 `json:"high"`
+	Vol       float64 `json:"vol"`
+	Bid       float64 `json:"bid"`
+	BidSize   float64 `json:"bidSize"`
+	Ask       float64 `json:"ask"`
+	AskSize   float64 `json:"askSize"`
+	LastPrice float64 `json:"lastPrice"`
+	LastSize  float64 `json:"lastSize"`
+}
+
+type Response struct {
+	Ch   string `json:"ch"`
+	Ts   int64  `json:"ts"`
+	Tick Ticker `json:"tick"`
+}
+
+type Heartbeat struct {
+	Ping int64 `json:"ping"`
+}
+
+type HeartbeatResponse struct {
+	Pong int64 `json:"pong"`
+}

--- a/node/pkg/websocketfetcher/providers/huobi/utils.go
+++ b/node/pkg/websocketfetcher/providers/huobi/utils.go
@@ -1,0 +1,35 @@
+package huobi
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
+	"github.com/rs/zerolog/log"
+)
+
+func ResponseToFeedData(response Response, feedMap map[string]int32) (*common.FeedData, error) {
+	feedData := new(common.FeedData)
+
+	timestamp := time.Unix(response.Ts/1000, 0)
+	price := common.FormatFloat64Price(response.Tick.LastPrice)
+
+	splitted := strings.Split(response.Ch, ".")
+	if len(splitted) < 3 || splitted[2] != "ticker" {
+		log.Error().Str("Ch", response.Ch).Msg("invalid response")
+		return feedData, fmt.Errorf("invalid response")
+	}
+
+	rawSymbol := splitted[1]
+	symbol := strings.ToUpper(rawSymbol)
+
+	id, exists := feedMap[symbol]
+	if !exists {
+		return feedData, fmt.Errorf("feed not found")
+	}
+	feedData.FeedID = id
+	feedData.Value = price
+	feedData.Timestamp = &timestamp
+	return feedData, nil
+}

--- a/node/pkg/websocketfetcher/providers/mexc/mexc.go
+++ b/node/pkg/websocketfetcher/providers/mexc/mexc.go
@@ -47,13 +47,13 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 func (f *MexcFetcher) handleMessage(ctx context.Context, message map[string]any) error {
 	response, err := common.MessageToStruct[Response](message)
 	if err != nil {
-		log.Error().Str("Player", "Mexc").Err(err).Msg("error in mexc.handleMessage")
+		log.Error().Str("Player", "Mexc").Err(err).Msg("failed to parse message to response")
 		return err
 	}
 
 	feedData, err := ResponseToFeedData(response, f.FeedMap)
 	if err != nil {
-		log.Error().Str("Player", "Mexc").Err(err).Msg("error in mexc.handleMessage")
+		log.Error().Str("Player", "Mexc").Err(err).Msg("failed to extract feedData from response")
 		return err
 	}
 

--- a/node/pkg/websocketfetcher/providers/mexc/mexc.go
+++ b/node/pkg/websocketfetcher/providers/mexc/mexc.go
@@ -1,0 +1,66 @@
+package mexc
+
+import (
+	"context"
+
+	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
+	"bisonai.com/orakl/node/pkg/wss"
+	"github.com/rs/zerolog/log"
+)
+
+type MexcFetcher common.Fetcher
+
+func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInterface, error) {
+	config := &common.FetcherConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	fetcher := &MexcFetcher{}
+	fetcher.FeedMap = config.FeedMaps.Combined
+	fetcher.FeedDataBuffer = config.FeedDataBuffer
+
+	params := []string{}
+
+	for feed := range fetcher.FeedMap {
+		param := "spot@public.miniTicker.v3.api@" + feed + "@UTC+0"
+		params = append(params, param)
+	}
+
+	subscription := Subscription{
+		Method: "SUBSCRIPTION",
+		Params: params,
+	}
+
+	ws, err := wss.NewWebsocketHelper(ctx,
+		wss.WithEndpoint(URL),
+		wss.WithSubscriptions([]any{subscription}),
+		wss.WithProxyUrl(config.Proxy))
+	if err != nil {
+		log.Error().Str("Player", "Mexc").Err(err).Msg("error in mexc.New")
+		return nil, err
+	}
+	fetcher.Ws = ws
+	return fetcher, nil
+}
+
+func (f *MexcFetcher) handleMessage(ctx context.Context, message map[string]any) error {
+	response, err := common.MessageToStruct[Response](message)
+	if err != nil {
+		log.Error().Str("Player", "Mexc").Err(err).Msg("error in mexc.handleMessage")
+		return err
+	}
+
+	feedData, err := ResponseToFeedData(response, f.FeedMap)
+	if err != nil {
+		log.Error().Str("Player", "Mexc").Err(err).Msg("error in mexc.handleMessage")
+		return err
+	}
+
+	f.FeedDataBuffer <- *feedData
+	return nil
+}
+
+func (f *MexcFetcher) Run(ctx context.Context) {
+	f.Ws.Run(ctx, f.handleMessage)
+}

--- a/node/pkg/websocketfetcher/providers/mexc/type.go
+++ b/node/pkg/websocketfetcher/providers/mexc/type.go
@@ -1,0 +1,28 @@
+package mexc
+
+const URL = "wss://wbs.mexc.com/ws"
+
+type Subscription struct {
+	Method string   `json:"method"`
+	Params []string `json:"params"`
+}
+
+type Ticker struct {
+	Symbol                string `json:"s"`
+	Price                 string `json:"p"`
+	PercentChange         string `json:"r"`
+	TimezonePercentChange string `json:"tr"`
+	HighPrice             string `json:"h"`
+	LowPrice              string `json:"l"`
+	Volume                string `json:"v"`
+	QuoteVolume           string `json:"q"`
+	LastRT                string `json:"lastRT"`
+	MergeTimes            string `json:"MT"`
+	NetValue              string `json:"NV"`
+	Time                  string `json:"t"`
+}
+
+type Response struct {
+	Channel string `json:"c"`
+	Data    Ticker `json:"d"`
+}

--- a/node/pkg/websocketfetcher/providers/mexc/utils.go
+++ b/node/pkg/websocketfetcher/providers/mexc/utils.go
@@ -1,0 +1,33 @@
+package mexc
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
+)
+
+func ResponseToFeedData(response Response, feedMap map[string]int32) (*common.FeedData, error) {
+	feedData := new(common.FeedData)
+
+	timestampRaw, err := strconv.ParseInt(response.Data.Time, 10, 64)
+	if err != nil {
+		return feedData, err
+	}
+
+	timestamp := time.Unix(timestampRaw/1000, 0)
+	value, err := common.PriceStringToFloat64(response.Data.Price)
+	if err != nil {
+		return feedData, err
+	}
+
+	id, exists := feedMap[response.Data.Symbol]
+	if !exists {
+		return feedData, fmt.Errorf("feed not found")
+	}
+	feedData.FeedID = id
+	feedData.Value = value
+	feedData.Timestamp = &timestamp
+	return feedData, nil
+}


### PR DESCRIPTION
# Description

Include missing price provider
- Huobi
- Mexc

### Custom Message Read for Huobi

Different from other data providers, Huobi returns data in gzip compressed format. To handle the case, a new option has been added to WebsocketHelper.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
