### PR TITLE
(OraklNode) Track peers manually

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -15,7 +15,6 @@ FEED_DATA_STREAM_INTERVAL=
 # (optional) designate external ip to be used if required
 HOST_IP=
 
-
 # `baobab` or `cypress`, defaults to baobab
 CHAIN=
 

--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -30,8 +30,7 @@ func main() {
 
 	listenPort, err := strconv.Atoi(os.Getenv("LISTEN_PORT"))
 	if err != nil {
-		log.Error().Err(err).Msg("Error parsing LISTEN_PORT")
-		return
+		log.Warn().Msg("LISTEN_PORT missing, using random port for libp2p")
 	}
 
 	host, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(listenPort))

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -57,7 +57,7 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	}
 	testItems.admin = admin
 
-	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(10001))
+	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -159,7 +159,8 @@ func aggregatorCleanup(ctx context.Context, admin *fiber.App, app *App) func() e
 		if err != nil {
 			return err
 		}
-		return nil
+
+		return app.Host.Close()
 	}
 
 }

--- a/node/pkg/boot/tests/peer_test.go
+++ b/node/pkg/boot/tests/peer_test.go
@@ -75,12 +75,12 @@ func TestSync(t *testing.T) {
 	}
 	defer cleanup()
 
-	mockHost1, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithQuic())
+	mockHost1, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch())
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}
 
-	mockHost2, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithQuic())
+	mockHost2, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch())
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestRefresh(t *testing.T) {
 	}
 	defer cleanup()
 
-	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithQuic(), libp2pSetup.WithPort(10010))
+	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(10010))
 	if err != nil {
 		t.Fatalf("error making host: %v", err)
 	}

--- a/node/pkg/libp2p/setup/setup.go
+++ b/node/pkg/libp2p/setup/setup.go
@@ -22,6 +22,15 @@ func ConnectThroughBootApi(ctx context.Context, h host.Host) error {
 		return err
 	}
 
+	externalIp := os.Getenv("HOST_IP")
+	if externalIp != "" {
+		url, err = utils.ReplaceIpFromUrl(url, externalIp)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to replace ip")
+			return err
+		}
+	}
+
 	apiEndpoint := os.Getenv("BOOT_API_URL")
 	if apiEndpoint == "" {
 		log.Info().Msg("boot api endpoint not set, using default url: http://localhost:8089")

--- a/node/pkg/libp2p/setup/type.go
+++ b/node/pkg/libp2p/setup/type.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"os"
-	"strconv"
 
 	"bisonai.com/orakl/node/pkg/secrets"
 
@@ -23,7 +21,7 @@ type HostConfig struct {
 	PrivateKey   crypto.PrivKey
 	SecretString string
 	HolePunch    bool
-	Quic         bool
+	Tcp          bool
 }
 
 type HostOption func(*HostConfig)
@@ -52,28 +50,19 @@ func WithHolePunch() HostOption {
 	}
 }
 
-func WithQuic() HostOption {
+func WithTcp() HostOption {
 	return func(hc *HostConfig) {
-		hc.Quic = true
+		hc.Tcp = true
 	}
 }
 
 func NewHost(ctx context.Context, opts ...HostOption) (host.Host, error) {
-	defaultPort := 0
-	defaultPortStr := os.Getenv("LISTEN_PORT")
-	if defaultPortStr != "" {
-		tmp, err := strconv.Atoi(defaultPortStr)
-		if err == nil {
-			defaultPort = tmp
-		}
-	}
-
 	config := &HostConfig{
-		Port:         defaultPort,
+		Port:         0,
 		PrivateKey:   nil,
 		SecretString: secrets.GetSecret("PRIVATE_NETWORK_SECRET"),
 		HolePunch:    false,
-		Quic:         false,
+		Tcp:          false,
 	}
 	for _, opt := range opts {
 		opt(config)
@@ -88,10 +77,10 @@ func NewHost(ctx context.Context, opts ...HostOption) (host.Host, error) {
 	}
 
 	listenStr := ""
-	if config.Quic {
-		listenStr = fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", config.Port)
-	} else {
+	if config.Tcp {
 		listenStr = fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", config.Port)
+	} else {
+		listenStr = fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", config.Port)
 	}
 
 	libp2pOpts := []libp2p.Option{

--- a/node/pkg/libp2p/tests/libp2p_test.go
+++ b/node/pkg/libp2p/tests/libp2p_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMakeHost(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch(), setup.WithPort(10001))
+	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
 	if err != nil {
 		t.Errorf("Failed to make host: %v", err)
 	}
@@ -18,7 +18,7 @@ func TestMakeHost(t *testing.T) {
 }
 
 func TestMakePubsub(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch(), setup.WithPort(10001))
+	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
 	if err != nil {
 		t.Fatalf("Failed to make host: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestMakePubsub(t *testing.T) {
 }
 
 func TestGetHostAddress(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch(), setup.WithPort(10001))
+	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
 	if err != nil {
 		t.Fatalf("Failed to make host: %v", err)
 	}
@@ -39,5 +39,27 @@ func TestGetHostAddress(t *testing.T) {
 	_, err = utils.GetHostAddress(h)
 	if err != nil {
 		t.Errorf("Failed to get host address: %v", err)
+	}
+}
+
+func TestReplaceIp(t *testing.T) {
+	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
+	if err != nil {
+		t.Fatalf("Failed to make host: %v", err)
+	}
+	defer h.Close()
+
+	url, err := utils.ExtractConnectionUrl(h)
+	if err != nil {
+		t.Fatalf("Failed to extract connection url: %v", err)
+	}
+
+	result, err := utils.ReplaceIpFromUrl(url, "127.0.0.1")
+	if err != nil {
+		t.Errorf("Failed to replace ip: %v", err)
+	}
+
+	if url == result {
+		t.Errorf("Failed to replace ip: %v", err)
 	}
 }

--- a/node/pkg/libp2p/utils/utils.go
+++ b/node/pkg/libp2p/utils/utils.go
@@ -100,3 +100,12 @@ func ConnectionUrl2AddrInfo(url string) (*peer.AddrInfo, error) {
 
 	return info, nil
 }
+
+func ReplaceIpFromUrl(url string, ip string) (string, error) {
+	parts := strings.Split(url, "/")
+	if len(parts) < 5 || parts[1] != "ip4" {
+		return "", fmt.Errorf("invalid URL format")
+	}
+	parts[2] = ip
+	return strings.Join(parts, "/"), nil
+}

--- a/node/pkg/raft/accessors.go
+++ b/node/pkg/raft/accessors.go
@@ -1,7 +1,5 @@
 package raft
 
-import "github.com/libp2p/go-libp2p/core/peer"
-
 func (r *Raft) IncreaseTerm() {
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
@@ -75,11 +73,7 @@ func (r *Raft) UpdateVotedFor(votedFor string) {
 }
 
 func (r *Raft) SubscribersCount() int {
-	return len(r.Subscribers())
-}
-
-func (r *Raft) Subscribers() []peer.ID {
-	return r.Ps.ListPeers(r.Topic.String())
+	return r.Peers.Size()
 }
 
 func (r *Raft) GetHostId() string {

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
+	"bisonai.com/orakl/node/pkg/utils/set"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 )
@@ -40,6 +41,9 @@ func NewRaftNode(
 		HeartbeatTimeout: HEARTBEAT_TIMEOUT,
 
 		LeaderJobTimeout: leaderJobTimeout,
+
+		PrevPeers: *set.NewSet[string](),
+		Peers:     *set.NewSet[string](),
 	}
 	return r
 }
@@ -104,12 +108,17 @@ func (r *Raft) handleMessage(ctx context.Context, msg Message) error {
 		return r.handleRequestVote(msg)
 	case ReplyVote:
 		return r.handleReplyVote(ctx, msg)
+	case ReplyHeartbeat:
+		return r.handleReplyHeartbeat(msg)
 	default:
 		return r.HandleCustomMessage(ctx, msg)
 	}
 }
 
 func (r *Raft) handleHeartbeat(msg Message) error {
+	r.Peers = r.PrevPeers
+	r.PrevPeers = *set.NewSet[string]()
+
 	if msg.SentFrom == r.GetHostId() {
 		return nil
 	}
@@ -151,7 +160,7 @@ func (r *Raft) handleHeartbeat(msg Message) error {
 		r.UpdateLeader(heartbeatMessage.LeaderID)
 	}
 
-	return nil
+	return r.sendReplyHeartbeat(heartbeatMessage.Term)
 }
 
 func (r *Raft) handleRequestVote(msg Message) error {
@@ -216,6 +225,17 @@ func (r *Raft) handleReplyVote(ctx context.Context, msg Message) error {
 	return nil
 }
 
+func (r *Raft) handleReplyHeartbeat(msg Message) error {
+	var replyHeartbeatMessage ReplyHeartbeatMessage
+	err := json.Unmarshal(msg.Data, &replyHeartbeatMessage)
+	if err != nil {
+		return err
+	}
+
+	r.PrevPeers.Add(msg.SentFrom)
+	return nil
+}
+
 // publishing messages
 
 func (r *Raft) PublishMessage(msg Message) error {
@@ -227,6 +247,7 @@ func (r *Raft) PublishMessage(msg Message) error {
 }
 
 func (r *Raft) sendHeartbeat() error {
+
 	heartbeatMessage := HeartbeatMessage{
 		LeaderID: r.GetHostId(),
 		Term:     r.GetCurrentTerm(),
@@ -245,6 +266,26 @@ func (r *Raft) sendHeartbeat() error {
 	err = r.PublishMessage(message)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to send heartbeat")
+		return err
+	}
+	return nil
+}
+
+func (r *Raft) sendReplyHeartbeat(term int) error {
+	replyHeartbeatMessage := ReplyHeartbeatMessage{
+		Term: term,
+	}
+	marshalledReplyHeartbeatMsg, err := json.Marshal(replyHeartbeatMessage)
+	if err != nil {
+		return err
+	}
+	message := Message{
+		Type:     ReplyHeartbeat,
+		SentFrom: r.GetHostId(),
+		Data:     json.RawMessage(marshalledReplyHeartbeatMsg),
+	}
+	err = r.PublishMessage(message)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -160,7 +160,7 @@ func (r *Raft) handleHeartbeat(msg Message) error {
 		r.UpdateLeader(heartbeatMessage.LeaderID)
 	}
 
-	return r.sendReplyHeartbeat(heartbeatMessage.Term)
+	return r.sendReplyHeartbeat()
 }
 
 func (r *Raft) handleRequestVote(msg Message) error {
@@ -271,10 +271,8 @@ func (r *Raft) sendHeartbeat() error {
 	return nil
 }
 
-func (r *Raft) sendReplyHeartbeat(term int) error {
-	replyHeartbeatMessage := ReplyHeartbeatMessage{
-		Term: term,
-	}
+func (r *Raft) sendReplyHeartbeat() error {
+	replyHeartbeatMessage := ReplyHeartbeatMessage{}
 	marshalledReplyHeartbeatMsg, err := json.Marshal(replyHeartbeatMessage)
 	if err != nil {
 		return err

--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"bisonai.com/orakl/node/pkg/utils/set"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 )
@@ -20,6 +21,7 @@ const (
 	ReplyVote          MessageType = "replyVote"
 	AppendEntries      MessageType = "appendEntries"
 	ReplyAppendEntries MessageType = "replyAppendEntries"
+	ReplyHeartbeat     MessageType = "replyHeartbeat"
 
 	Leader    RoleType = "leader"
 	Candidate RoleType = "candidate"
@@ -39,6 +41,10 @@ type RequestVoteMessage struct {
 type HeartbeatMessage struct {
 	LeaderID string `json:"leaderID"`
 	Term     int    `json:"term"`
+}
+
+type ReplyHeartbeatMessage struct {
+	Term int `json:"term"`
 }
 
 type ReplyRequestVoteMessage struct {
@@ -68,4 +74,7 @@ type Raft struct {
 	LeaderJobTicker     *time.Ticker
 	HandleCustomMessage func(context.Context, Message) error
 	LeaderJob           func() error
+
+	PrevPeers set.Set[string]
+	Peers     set.Set[string]
 }

--- a/node/pkg/raft/types.go
+++ b/node/pkg/raft/types.go
@@ -43,9 +43,7 @@ type HeartbeatMessage struct {
 	Term     int    `json:"term"`
 }
 
-type ReplyHeartbeatMessage struct {
-	Term int `json:"term"`
-}
+type ReplyHeartbeatMessage struct{}
 
 type ReplyRequestVoteMessage struct {
 	VoteGranted bool   `json:"voteGranted"`

--- a/node/pkg/reporter/main_test.go
+++ b/node/pkg/reporter/main_test.go
@@ -119,7 +119,7 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 
 	testItems.admin = admin
 
-	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(10001))
+	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,7 +171,7 @@ func reporterCleanup(ctx context.Context, admin *fiber.App, app *App) func() err
 		if err != nil {
 			return err
 		}
-		return nil
+		return app.Host.Close()
 	}
 }
 

--- a/node/pkg/utils/set/set.go
+++ b/node/pkg/utils/set/set.go
@@ -1,0 +1,26 @@
+package set
+
+type Set[T comparable] struct {
+	data map[T]struct{}
+}
+
+func NewSet[T comparable]() *Set[T] {
+	return &Set[T]{data: make(map[T]struct{})}
+}
+
+func (s *Set[T]) Add(element T) {
+	s.data[element] = struct{}{}
+}
+
+func (s *Set[T]) Remove(element T) {
+	delete(s.data, element)
+}
+
+func (s *Set[T]) Contains(element T) bool {
+	_, exists := s.data[element]
+	return exists
+}
+
+func (s *Set[T]) Size() int {
+	return len(s.data)
+}

--- a/node/pkg/utils/tests/set_test.go
+++ b/node/pkg/utils/tests/set_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/utils/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetBasicOperations(t *testing.T) {
+	s := set.NewSet[int]()
+	assert.Equal(t, 0, s.Size())
+
+	s.Add(1)
+	assert.Equal(t, 1, s.Size())
+	assert.True(t, s.Contains(1))
+	assert.False(t, s.Contains(2))
+
+	s.Remove(1)
+	assert.Equal(t, 0, s.Size())
+	assert.False(t, s.Contains(1))
+}

--- a/node/pkg/utils/tests/set_test.go
+++ b/node/pkg/utils/tests/set_test.go
@@ -20,3 +20,18 @@ func TestSetBasicOperations(t *testing.T) {
 	assert.Equal(t, 0, s.Size())
 	assert.False(t, s.Contains(1))
 }
+
+func TestSetAddDuplicates(t *testing.T) {
+	s := set.NewSet[int]()
+	s.Add(1)
+	s.Add(1) // Attempt to add duplicate
+	assert.Equal(t, 1, s.Size(), "Set should not allow duplicates")
+	assert.True(t, s.Contains(1))
+}
+
+func TestSetOperationsOnEmpty(t *testing.T) {
+	s := set.NewSet[int]()
+	assert.False(t, s.Contains(1), "Empty set should not contain any element")
+	s.Remove(1) // Attempt to remove from empty set
+	assert.Equal(t, 0, s.Size(), "Size should remain 0 after remove operation on empty set")
+}


### PR DESCRIPTION
# Description

Track cluster peers manually instead of using built in function [pubsub.ListPeers](https://pkg.go.dev/github.com/libp2p/go-libp2p-pubsub#PubSub.ListPeers)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
