### PR TITLE
(OraklNode) Wait longer to be mined (10secs)

### DIFF
--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DEFAULT_MINE_WAIT_TIME     = 10 * time.Second
 	DEFAULT_GAS_LIMIT          = uint64(6000000)
 	SELECT_WALLETS_QUERY       = "SELECT * FROM wallets;"
 	SELECT_PROVIDER_URLS_QUERY = "SELECT * FROM provider_urls WHERE chain_id = @chain_id ORDER BY priority;"

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"time"
 
 	"bisonai.com/orakl/node/pkg/db"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
@@ -369,7 +368,7 @@ func SubmitRawTx(ctx context.Context, client ClientInterface, tx *types.Transact
 	}
 	log.Debug().Str("Player", "ChainHelper").Str("tx", tx.Hash().String()).Msg("tx sent")
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, DEFAULT_MINE_WAIT_TIME)
 	defer cancel()
 
 	log.Debug().Str("Player", "ChainHelper").Str("tx", tx.Hash().String()).Msg("waiting for tx to be mined")


### PR DESCRIPTION
# Description

Slight delays from cypress assumed to be due to mine wait failure which is 5 seconds at the moment.
Increasing it into 10 seconds to see how it goes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
