### PR TITLE
(OraklNode) Reimplement gas price multiplier

### DIFF
--- a/node/pkg/chain/helper/helper.go
+++ b/node/pkg/chain/helper/helper.go
@@ -190,10 +190,10 @@ func (t *ChainHelper) MakeDirectTx(ctx context.Context, contractAddressHex strin
 	return result, err
 }
 
-func (t *ChainHelper) MakeFeeDelegatedTx(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (*types.Transaction, error) {
+func (t *ChainHelper) MakeFeeDelegatedTx(ctx context.Context, contractAddressHex string, functionString string, gasMultiplier float64, args ...interface{}) (*types.Transaction, error) {
 	var result *types.Transaction
 	job := func(c utils.ClientInterface) error {
-		tmp, err := utils.MakeFeeDelegatedTx(ctx, c, contractAddressHex, t.NextReporter(), functionString, t.chainID, args...)
+		tmp, err := utils.MakeFeeDelegatedTx(ctx, c, contractAddressHex, t.NextReporter(), functionString, t.chainID, gasMultiplier, args...)
 		if err == nil {
 			result = tmp
 		}
@@ -219,16 +219,7 @@ func (t *ChainHelper) SubmitRawTxString(ctx context.Context, rawTx string) error
 
 // SignTxByFeePayer: used for testing purpose
 func (t *ChainHelper) SignTxByFeePayer(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
-	var result *types.Transaction
-	job := func(c utils.ClientInterface) error {
-		tmp, err := utils.SignTxByFeePayer(ctx, c, tx, t.chainID)
-		if err == nil {
-			result = tmp
-		}
-		return err
-	}
-	err := t.retryOnJsonRpcFailure(ctx, job)
-	return result, err
+	return utils.SignTxByFeePayer(ctx, tx, t.chainID)
 }
 
 func (t *ChainHelper) ReadContract(ctx context.Context, contractAddressHex string, functionString string, args ...interface{}) (interface{}, error) {

--- a/node/pkg/chain/tests/chain_test.go
+++ b/node/pkg/chain/tests/chain_test.go
@@ -191,7 +191,7 @@ func TestMakeFeeDelegatedTx(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		feeDelegatedTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, test.contractAddress, test.functionString)
+		feeDelegatedTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, test.contractAddress, test.functionString, 0)
 		if err != nil {
 			assert.ErrorIs(t, err, test.expectedError)
 		}
@@ -211,7 +211,7 @@ func TestTxToHashToTx(t *testing.T) {
 	}
 	defer klaytnHelper.Close()
 
-	rawTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, "0x93120927379723583c7a0dd2236fcb255e96949f", "increment()")
+	rawTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, "0x93120927379723583c7a0dd2236fcb255e96949f", "increment()", 0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestSubmitRawTxString(t *testing.T) {
 	}
 	defer klaytnHelper.Close()
 
-	rawTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, "0x93120927379723583c7a0dd2236fcb255e96949f", "increment()")
+	rawTx, err := klaytnHelper.MakeFeeDelegatedTx(ctx, "0x93120927379723583c7a0dd2236fcb255e96949f", "increment()", 0)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/node/pkg/error/sentinel.go
+++ b/node/pkg/error/sentinel.go
@@ -117,6 +117,7 @@ var (
 	ErrChainEmptyChainIdParam                = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty chain id param"}
 	ErrChainEmptyToAddress                   = &CustomError{Service: Others, Code: InvalidInputError, Message: "to address is empty"}
 	ErrChainEmptyGasPrice                    = &CustomError{Service: Others, Code: InvalidInputError, Message: "gas price is empty"}
+	ErrChainGasMultiplierTooHigh             = &CustomError{Service: Others, Code: InvalidInputError, Message: "gas multiplier too high"}
 
 	ErrDbDatabaseUrlNotFound            = &CustomError{Service: Others, Code: InternalError, Message: "DATABASE_URL not found"}
 	ErrDbEmptyTableNameParam            = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty table name"}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -3,7 +3,6 @@ package reporter
 import (
 	"context"
 	"encoding/json"
-	"math/big"
 	"strconv"
 	"time"
 
@@ -280,26 +279,15 @@ func (r *Reporter) reportDirect(ctx context.Context, functionString string, args
 
 func (r *Reporter) reportDelegated(ctx context.Context, functionString string, args ...interface{}) error {
 	log.Debug().Str("Player", "Reporter").Msg("reporting delegated")
-	rawTx, err := r.KlaytnHelper.MakeFeeDelegatedTx(ctx, r.contractAddress, functionString, args...)
+	rawTx, err := r.KlaytnHelper.MakeFeeDelegatedTx(ctx, r.contractAddress, functionString, GAS_MULTIPLIER, args...)
 	if err != nil {
 		log.Error().Str("Player", "Reporter").Err(err).Msg("MakeFeeDelegatedTx")
 		return err
 	}
 
-	// update gas price by 20%
-	// check attributes here: https://docs.klaytn.foundation/docs/learn/transactions/fee-delegation/#txtypefeedelegatedsmartcontractexecution-
-	prevGas := rawTx.GasPrice().Int64()
-	increasedGasInt64 := int64(float64(prevGas) * 1.2)
-	increaseGasPrice := new(big.Int).SetInt64(increasedGasInt64)
-	increasedTx, err := chainUtils.UpdateGasPrice(rawTx, increaseGasPrice)
-	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("UpdateGasPrice")
-		return err
-	}
-
-	log.Debug().Str("Player", "Reporter").Str("RawTx", increasedTx.String()).Msg("delegated raw tx generated")
+	log.Debug().Str("Player", "Reporter").Str("RawTx", rawTx.String()).Msg("delegated raw tx generated")
 	delegatorRequestStart := time.Now()
-	signedTx, err := r.KlaytnHelper.GetSignedFromDelegator(increasedTx)
+	signedTx, err := r.KlaytnHelper.GetSignedFromDelegator(rawTx)
 	if err != nil {
 		log.Error().Str("Player", "Reporter").Err(err).Msg("GetSignedFromDelegator")
 		return err

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -31,6 +31,7 @@ const (
 	DEVIATION_THRESHOLD          = 0.05
 	DEVIATION_ABSOLUTE_THRESHOLD = 0.1
 	DECIMALS                     = 8
+	GAS_MULTIPLIER               = 1.2
 )
 
 type Config struct {

--- a/node/pkg/reporter/utils.go
+++ b/node/pkg/reporter/utils.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"math"
 	"math/big"
-	"time"
 
 	"bisonai.com/orakl/node/pkg/chain/helper"
 	chainUtils "bisonai.com/orakl/node/pkg/chain/utils"
@@ -222,7 +221,7 @@ func GetLatestGlobalAggregatesRdb(ctx context.Context, submissionPairs map[int32
 
 func ValidateAggregateTimestampValues(aggregates []GlobalAggregate) bool {
 	for _, agg := range aggregates {
-		if agg.Timestamp.IsZero() || agg.Timestamp.After(time.Now()) {
+		if agg.Timestamp.IsZero() {
 			return false
 		}
 	}

--- a/node/script/test_submission/main.go
+++ b/node/script/test_submission/main.go
@@ -1,3 +1,4 @@
+//nolint:all
 package main
 
 import (


### PR DESCRIPTION
# Description

From previous implementation, it has been attempted to only update gasPrice value from the transaction which lead to transaction failure. It has been revealed that gasPrice value is also referred on generating transaction sign.

This solves the issue by taking gasPrice multiplier from transaction generating function, so that updated gasPrice is included when signing the transaction

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
