### PR TITLE
Revamp reporter (1/2): Implement nonce manager mutex, queue, and worker

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -83,6 +83,7 @@
     "@bisonai/orakl-vrf": "*",
     "@ethersproject/experimental": "^5.7.0",
     "@slack/webhook": "^6.1.0",
+    "async-mutex": "^0.5.0",
     "axios": "^1.2.2",
     "bullmq": "^3.2.2",
     "caver-js": "^1.10.1",

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -78,5 +78,6 @@ export enum OraklErrorCode {
   FailedToGetObservedBlock,
   FailedUpsertObservedBlock,
   FailedInsertUnprocessedBlock,
-  FailedDeleteUnprocessedBlock
+  FailedDeleteUnprocessedBlock,
+  NonceNotFound
 }

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -79,5 +79,6 @@ export enum OraklErrorCode {
   FailedUpsertObservedBlock,
   FailedInsertUnprocessedBlock,
   FailedDeleteUnprocessedBlock,
-  NonceNotFound
+  NonceNotFound,
+  FailedToGetWalletTransactionCount
 }

--- a/core/src/reporter/data-feed-L2.ts
+++ b/core/src/reporter/data-feed-L2.ts
@@ -5,8 +5,7 @@ import {
   L2_DATA_FEED_REPORTER_STATE_NAME,
   L2_DATA_FEED_SERVICE_NAME,
   L2_PROVIDER_URL,
-  L2_REPORTER_AGGREGATOR_QUEUE_NAME,
-  NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME
+  L2_REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -14,7 +13,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_DATA_FEED_REPORTER_STATE_NAME,
-    nonceManagerQueueName: NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME,
+    nonceManagerQueueName: 'NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME',
     service: L2_DATA_FEED_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: 5,

--- a/core/src/reporter/data-feed-L2.ts
+++ b/core/src/reporter/data-feed-L2.ts
@@ -5,7 +5,8 @@ import {
   L2_DATA_FEED_REPORTER_STATE_NAME,
   L2_DATA_FEED_SERVICE_NAME,
   L2_PROVIDER_URL,
-  L2_REPORTER_AGGREGATOR_QUEUE_NAME
+  L2_REPORTER_AGGREGATOR_QUEUE_NAME,
+  NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -13,6 +14,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_DATA_FEED_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME,
     service: L2_DATA_FEED_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: 5,

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -8,7 +8,6 @@ import {
   DATA_FEED_REPORTER_CONCURRENCY,
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
-  NONCE_MANAGER_DATA_FEED_QUEUE_NAME,
   PROVIDER,
   REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
@@ -23,7 +22,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: DATA_FEED_REPORTER_STATE_NAME,
-    nonceManagerQueueName: NONCE_MANAGER_DATA_FEED_QUEUE_NAME,
+    nonceManagerQueueName: 'NONCE_MANAGER_DATA_FEED_QUEUE_NAME',
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: DATA_FEED_REPORTER_CONCURRENCY,

--- a/core/src/reporter/data-feed.ts
+++ b/core/src/reporter/data-feed.ts
@@ -8,6 +8,7 @@ import {
   DATA_FEED_REPORTER_CONCURRENCY,
   DATA_FEED_REPORTER_STATE_NAME,
   DATA_FEED_SERVICE_NAME,
+  NONCE_MANAGER_DATA_FEED_QUEUE_NAME,
   PROVIDER,
   REPORTER_AGGREGATOR_QUEUE_NAME
 } from '../settings'
@@ -22,6 +23,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: DATA_FEED_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_DATA_FEED_QUEUE_NAME,
     service: DATA_FEED_SERVICE_NAME,
     reporterQueueName: REPORTER_AGGREGATOR_QUEUE_NAME,
     concurrency: DATA_FEED_REPORTER_CONCURRENCY,

--- a/core/src/reporter/nonceManager.ts
+++ b/core/src/reporter/nonceManager.ts
@@ -1,0 +1,36 @@
+import { Job } from 'bullmq'
+import { Logger } from 'pino'
+import { NONCE_MANAGER_JOB_SETTINGS } from '../settings'
+import { ITransactionParameters, ITransactionParametersWithNonce, QueueType } from '../types'
+import { State } from './state'
+
+export function nonceManager(
+  reporterQueue: QueueType,
+  jobName: string,
+  state: State,
+  logger: Logger
+) {
+  async function wrapper(job: Job) {
+    const tx: ITransactionParameters = job.data
+    const { to } = tx
+
+    try {
+      const nonce = await state.getAndIncrementNonce(to)
+      logger.info(`-------------nonce: ${nonce}-----------------`)
+      const txWithNonce: ITransactionParametersWithNonce = { ...tx, nonce }
+      await reporterQueue.add(jobName, txWithNonce, {
+        jobId: job.id,
+        ...NONCE_MANAGER_JOB_SETTINGS
+      })
+    } catch (e) {
+      logger.error(
+        e,
+        `Failed to get and increment nonce for oracle with address ${to}. Retrying...`
+      )
+      throw e
+    }
+  }
+
+  logger.debug('Nonce Manager job build')
+  return wrapper
+}

--- a/core/src/reporter/nonceManager.ts
+++ b/core/src/reporter/nonceManager.ts
@@ -22,10 +22,7 @@ export function nonceManager(
         ...NONCE_MANAGER_JOB_SETTINGS
       })
     } catch (e) {
-      logger.error(
-        e,
-        `Failed to get and increment nonce for oracle with address ${to}. Retrying...`
-      )
+      logger.error(`Failed to get and increment nonce for oracle with address ${to}. Retrying...`)
       throw e
     }
   }

--- a/core/src/reporter/nonceManager.ts
+++ b/core/src/reporter/nonceManager.ts
@@ -16,7 +16,6 @@ export function nonceManager(
 
     try {
       const nonce = await state.getAndIncrementNonce(to)
-      logger.info(`-------------nonce: ${nonce}-----------------`)
       const txWithNonce: ITransactionParametersWithNonce = { ...tx, nonce }
       await reporterQueue.add(jobName, txWithNonce, {
         jobId: job.id,

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -1,16 +1,16 @@
 import { Job } from 'bullmq'
 import { Logger } from 'pino'
 import { OraklError, OraklErrorCode } from '../errors'
-import { ITransactionParameters } from '../types'
+import { ITransactionParametersWithNonce } from '../types'
 import { State } from './state'
 import { sendTransaction, sendTransactionCaver, sendTransactionDelegatedFee } from './utils'
 
 export function reporter(state: State, logger: Logger) {
   async function wrapper(job: Job) {
-    const inData: ITransactionParameters = job.data
+    const inData: ITransactionParametersWithNonce = job.data
     logger.debug(inData, 'inData')
 
-    const { payload, gasLimit, to } = inData
+    const { payload, gasLimit, to, nonce } = inData
 
     const wallet = state.wallets[to]
     if (!wallet) {
@@ -21,7 +21,6 @@ export function reporter(state: State, logger: Logger) {
 
     let delegatorOkay = true
     const NUM_TRANSACTION_TRIALS = 3
-    const nonce = await state.getAndIncrementNonce(to)
     const txParams = { wallet, to, payload, gasLimit, logger, nonce }
 
     for (let i = 0; i < NUM_TRANSACTION_TRIALS; ++i) {

--- a/core/src/reporter/reporter.ts
+++ b/core/src/reporter/reporter.ts
@@ -21,7 +21,8 @@ export function reporter(state: State, logger: Logger) {
 
     let delegatorOkay = true
     const NUM_TRANSACTION_TRIALS = 3
-    const txParams = { wallet, to, payload, gasLimit, logger }
+    const nonce = await state.getAndIncrementNonce(to)
+    const txParams = { wallet, to, payload, gasLimit, logger, nonce }
 
     for (let i = 0; i < NUM_TRANSACTION_TRIALS; ++i) {
       if (state.delegatedFee && delegatorOkay) {

--- a/core/src/reporter/request-response-L2-fulfill.ts
+++ b/core/src/reporter/request-response-L2-fulfill.ts
@@ -3,7 +3,8 @@ import type { RedisClientType } from 'redis'
 import {
   L2_REPORTER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME,
   L2_REQUEST_RESPONSE_FULFILL_REPORTER_STATE_NAME,
-  L2_REQUEST_RESPONSE_FULFILL_SERVICE_NAME
+  L2_REQUEST_RESPONSE_FULFILL_SERVICE_NAME,
+  NONCE_MANAGER_L2_REQUEST_RESPONSE_FUFILL_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -11,6 +12,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_REQUEST_RESPONSE_FULFILL_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_L2_REQUEST_RESPONSE_FUFILL_QUEUE_NAME,
     service: L2_REQUEST_RESPONSE_FULFILL_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME,
     concurrency: 1,

--- a/core/src/reporter/request-response-L2-request.ts
+++ b/core/src/reporter/request-response-L2-request.ts
@@ -3,7 +3,8 @@ import type { RedisClientType } from 'redis'
 import {
   L2_REPORTER_REQUEST_RESPONSE_REQUEST_QUEUE_NAME,
   L2_REQUEST_RESPONSE_REQUEST_REPORTER_STATE_NAME,
-  L2_REQUEST_RESPONSE_REQUEST_SERVICE_NAME
+  L2_REQUEST_RESPONSE_REQUEST_SERVICE_NAME,
+  NONCE_MANAGER_L2_REQUEST_RESPONSE_REQUEST_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -11,6 +12,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_REQUEST_RESPONSE_REQUEST_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_L2_REQUEST_RESPONSE_REQUEST_QUEUE_NAME,
     service: L2_REQUEST_RESPONSE_REQUEST_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_REQUEST_RESPONSE_REQUEST_QUEUE_NAME,
     concurrency: 1,

--- a/core/src/reporter/request-response.ts
+++ b/core/src/reporter/request-response.ts
@@ -1,6 +1,7 @@
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
+  NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME,
   REPORTER_REQUEST_RESPONSE_QUEUE_NAME,
   REQUEST_RESPONSE_REPORTER_STATE_NAME,
   REQUEST_RESPONSE_SERVICE_NAME
@@ -12,6 +13,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     redisClient,
     stateName: REQUEST_RESPONSE_REPORTER_STATE_NAME,
     service: REQUEST_RESPONSE_SERVICE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME,
     reporterQueueName: REPORTER_REQUEST_RESPONSE_QUEUE_NAME,
     concurrency: 1,
     delegatedFee: false,

--- a/core/src/reporter/state.ts
+++ b/core/src/reporter/state.ts
@@ -1,9 +1,11 @@
+import { Mutex } from 'async-mutex'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import { getReporter, getReporters } from '../api'
 import { OraklError, OraklErrorCode } from '../errors'
 import { IReporterConfig } from '../types'
 import { isAddressValid } from '../utils'
+import { Wallet } from './types'
 import { buildCaverWallet, buildWallet, isPrivateKeyAddressPairValid } from './utils'
 
 const FILE_NAME = import.meta.url
@@ -16,7 +18,9 @@ export class State {
   chain: string
   delegatedFee: boolean
   logger: Logger
-  wallets
+  wallets: Wallet[]
+  nonces: { [key: string]: number }
+  mutex: Mutex
 
   constructor({
     redisClient,
@@ -131,19 +135,28 @@ export class State {
     await this.redisClient.set(this.stateName, JSON.stringify(updatedActiveReporters))
 
     // Update wallets
-    let wallet
+    let wallet: Wallet
+    let nonce: number
     if (this.delegatedFee) {
-      wallet = await buildCaverWallet({
+      wallet = buildCaverWallet({
         privateKey: toAddReporter.privateKey,
         providerUrl: this.providerUrl
       })
+      nonce = Number(await wallet.caver.rpc.klay.getTransactionCount(wallet.address))
     } else {
-      wallet = await buildWallet({
+      wallet = buildWallet({
         privateKey: toAddReporter.privateKey,
         providerUrl: this.providerUrl
       })
+      nonce = await wallet.getTransactionCount()
     }
     this.wallets = { ...this.wallets, [toAddReporter.oracleAddress]: wallet }
+
+    // Update nonce
+    this.nonces = {
+      ...this.nonces,
+      [toAddReporter.oracleAddress]: nonce
+    }
 
     return toAddReporter
   }
@@ -225,27 +238,83 @@ export class State {
       }
     })
 
-    const wallets = reporters.map((R) => {
-      let wallet
+    const wallets: { [key: string]: Wallet }[] = []
+    for (const R of reporters) {
+      let wallet: Wallet
+      let nonce: number
       if (this.delegatedFee) {
         wallet = buildCaverWallet({
           privateKey: R.privateKey,
           providerUrl: this.providerUrl
         })
+        nonce = Number(await wallet.caver.rpc.klay.getTransactionCount(wallet.address))
       } else {
         wallet = buildWallet({
           privateKey: R.privateKey,
           providerUrl: this.providerUrl
         })
+        nonce = await wallet.getTransactionCount()
       }
 
-      return { [R.oracleAddress]: wallet }
-    })
+      wallets.push({ [R.oracleAddress]: wallet })
+
+      // Update nonce
+      this.nonces = {
+        ...this.nonces,
+        [R.oracleAddress]: nonce
+      }
+
+      // Create a mutex object
+      this.mutex = new Mutex()
+    }
 
     // Update
     await this.redisClient.set(this.stateName, JSON.stringify(reporters))
     this.wallets = Object.assign({}, ...wallets)
 
     return reporters
+  }
+
+  /**
+   * Get nonce for oracleAddress. If nonce is not found, raise an error.
+   * This function implements a mutex to ensure it cannot be called concurrently.
+   *
+   * @param {string} oracleAddress
+   * @return {number} nonce
+   * @exception {OraklErrorCode.NonceNotFound} raise when nonce is not found
+   */
+  async getAndIncrementNonce(oracleAddress: string): Promise<number> {
+    return await this.mutex.runExclusive(async () => {
+      const wallet = this.wallets[oracleAddress]
+      if (!wallet) {
+        const msg = `Wallet for oracle ${oracleAddress} is not active`
+        this.logger.error(msg)
+        throw new OraklError(OraklErrorCode.WalletNotActive, msg)
+      }
+
+      let remoteNonce: number
+      if (this.delegatedFee) {
+        remoteNonce = Number(await wallet.caver.rpc.klay.getTransactionCount(wallet.address))
+      } else {
+        remoteNonce = await wallet.getTransactionCount()
+      }
+
+      const localNonce = this.nonces[oracleAddress]
+
+      let nonce: number
+      if (!localNonce || remoteNonce > localNonce) {
+        this.logger.warn(
+          { name: 'getAndIncrementNonce', file: FILE_NAME },
+          `Nonce value discrepancy. Remote: ${remoteNonce}, Local: ${localNonce}. Updating local nonce to remote nonce.`
+        )
+        nonce = remoteNonce
+      } else {
+        nonce = localNonce
+      }
+
+      this.nonces[oracleAddress] = nonce + 1
+
+      return nonce
+    })
   }
 }

--- a/core/src/reporter/types.ts
+++ b/core/src/reporter/types.ts
@@ -1,6 +1,10 @@
+import { NonceManager } from '@ethersproject/experimental'
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
+import { CaverWallet } from './utils'
 
 export interface IReporters {
   [index: string]: (redisClient: RedisClientType, _logger: Logger) => Promise<void>
 }
+
+export type Wallet = CaverWallet | NonceManager

--- a/core/src/reporter/utils.ts
+++ b/core/src/reporter/utils.ts
@@ -65,22 +65,24 @@ export async function sendTransaction({
   payload,
   gasLimit,
   value,
-  logger
+  logger,
+  nonce
 }: {
-  wallet
+  wallet: NonceManager
   to: string
   payload?: string
   gasLimit?: number | string
   value?: number | string | ethers.BigNumber
   logger: Logger
+  nonce: number
 }) {
   const _logger = logger.child({ name: 'sendTransaction', file: FILE_NAME })
 
   if (payload) {
     payload = add0x(payload)
   }
-
   const tx = {
+    nonce,
     from: await wallet.getAddress(),
     to: to,
     data: payload || '0x00',
@@ -134,7 +136,8 @@ export async function sendTransactionDelegatedFee({
   payload,
   gasLimit,
   value,
-  logger
+  logger,
+  nonce
 }: {
   wallet: CaverWallet
   to: string
@@ -142,10 +145,12 @@ export async function sendTransactionDelegatedFee({
   gasLimit?: number | string
   value?: number | string
   logger: Logger
+  nonce: number
 }) {
   const _logger = logger.child({ name: 'sendTransactionDelegatedFee', file: FILE_NAME })
 
   const txParams = {
+    nonce,
     from: wallet.address,
     to,
     input: payload,
@@ -211,7 +216,8 @@ export async function sendTransactionCaver({
   payload,
   gasLimit,
   logger,
-  value
+  value,
+  nonce
 }: {
   wallet: CaverWallet
   to: string
@@ -219,10 +225,12 @@ export async function sendTransactionCaver({
   gasLimit: number | string
   logger: Logger
   value?: number | string
+  nonce: number
 }) {
   const _logger = logger.child({ name: 'sendTransactionCaver', file: FILE_NAME })
 
   const txParams = {
+    nonce,
     from: wallet.address,
     to,
     input: payload,

--- a/core/src/reporter/vrf-L2-fulfill.ts
+++ b/core/src/reporter/vrf-L2-fulfill.ts
@@ -3,7 +3,8 @@ import type { RedisClientType } from 'redis'
 import {
   L2_REPORTER_VRF_FULFILL_QUEUE_NAME,
   L2_VRF_FULFILL_REPORTER_STATE_NAME,
-  L2_VRF_FULFILL_SERVICE_NAME
+  L2_VRF_FULFILL_SERVICE_NAME,
+  NONCE_MANAGER_L2_VRF_FULFILL_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -11,6 +12,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_VRF_FULFILL_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_L2_VRF_FULFILL_QUEUE_NAME,
     service: L2_VRF_FULFILL_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_VRF_FULFILL_QUEUE_NAME,
     concurrency: 1,

--- a/core/src/reporter/vrf-L2-request.ts
+++ b/core/src/reporter/vrf-L2-request.ts
@@ -3,7 +3,8 @@ import type { RedisClientType } from 'redis'
 import {
   L2_REPORTER_VRF_REQUEST_QUEUE_NAME,
   L2_VRF_REQUEST_REPORTER_STATE_NAME,
-  L2_VRF_REQUEST_SERVICE_NAME
+  L2_VRF_REQUEST_SERVICE_NAME,
+  NONCE_MANAGER_L2_VRF_REQUEST_QUEUE_NAME
 } from '../settings'
 import { factory } from './factory'
 
@@ -11,6 +12,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
   await factory({
     redisClient,
     stateName: L2_VRF_REQUEST_REPORTER_STATE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_L2_VRF_REQUEST_QUEUE_NAME,
     service: L2_VRF_REQUEST_SERVICE_NAME,
     reporterQueueName: L2_REPORTER_VRF_REQUEST_QUEUE_NAME,
     concurrency: 1,

--- a/core/src/reporter/vrf.ts
+++ b/core/src/reporter/vrf.ts
@@ -2,6 +2,7 @@ import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
   CONCURRENCY,
+  NONCE_MANAGER_VRF_QUEUE_NAME,
   REPORTER_VRF_QUEUE_NAME,
   VRF_REPORTER_STATE_NAME,
   VRF_SERVICE_NAME
@@ -13,6 +14,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     redisClient,
     stateName: VRF_REPORTER_STATE_NAME,
     service: VRF_SERVICE_NAME,
+    nonceManagerQueueName: NONCE_MANAGER_VRF_QUEUE_NAME,
     reporterQueueName: REPORTER_VRF_QUEUE_NAME,
     concurrency: CONCURRENCY,
     delegatedFee: false,

--- a/core/src/reporter/vrf.ts
+++ b/core/src/reporter/vrf.ts
@@ -1,6 +1,11 @@
 import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
-import { REPORTER_VRF_QUEUE_NAME, VRF_REPORTER_STATE_NAME, VRF_SERVICE_NAME } from '../settings'
+import {
+  CONCURRENCY,
+  REPORTER_VRF_QUEUE_NAME,
+  VRF_REPORTER_STATE_NAME,
+  VRF_SERVICE_NAME
+} from '../settings'
 import { factory } from './factory'
 
 export async function buildReporter(redisClient: RedisClientType, logger: Logger) {
@@ -9,7 +14,7 @@ export async function buildReporter(redisClient: RedisClientType, logger: Logger
     stateName: VRF_REPORTER_STATE_NAME,
     service: VRF_SERVICE_NAME,
     reporterQueueName: REPORTER_VRF_QUEUE_NAME,
-    concurrency: 1,
+    concurrency: CONCURRENCY,
     delegatedFee: false,
     _logger: logger
   })

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -101,8 +101,6 @@ export const L2_WORKER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}
 
 export const NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-queue`
 export const NONCE_MANAGER_VRF_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-vrf-queue`
-export const NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-data-feed-l2-queue`
-export const NONCE_MANAGER_DATA_FEED_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-data-feed-queue`
 export const NONCE_MANAGER_L2_REQUEST_RESPONSE_FUFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-l2-fulfill-queue`
 export const NONCE_MANAGER_L2_REQUEST_RESPONSE_REQUEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-l2-request-queue`
 export const NONCE_MANAGER_L2_VRF_FULFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-vrf-l2-fulfill-queue`

--- a/core/src/settings.ts
+++ b/core/src/settings.ts
@@ -99,6 +99,15 @@ export const L2_WORKER_VRF_FULFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-worker-vrf-f
 export const L2_WORKER_REQUEST_RESPONSE_REQUEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-worker-request-response-request-l2-queue`
 export const L2_WORKER_REQUEST_RESPONSE_FULFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-worker-request-response-fulfill-l2-queue`
 
+export const NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-queue`
+export const NONCE_MANAGER_VRF_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-vrf-queue`
+export const NONCE_MANAGER_L2_DATA_FEED_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-data-feed-l2-queue`
+export const NONCE_MANAGER_DATA_FEED_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-data-feed-queue`
+export const NONCE_MANAGER_L2_REQUEST_RESPONSE_FUFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-l2-fulfill-queue`
+export const NONCE_MANAGER_L2_REQUEST_RESPONSE_REQUEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-request-response-l2-request-queue`
+export const NONCE_MANAGER_L2_VRF_FULFILL_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-vrf-l2-fulfill-queue`
+export const NONCE_MANAGER_L2_VRF_REQUEST_QUEUE_NAME = `${DEPLOYMENT_NAME}-nonce-manager-vrf-l2-request-queue`
+
 export const REPORTER_REQUEST_RESPONSE_QUEUE_NAME = `${DEPLOYMENT_NAME}-reporter-request-response-queue`
 export const REPORTER_VRF_QUEUE_NAME = `${DEPLOYMENT_NAME}-reporter-vrf-queue`
 export const REPORTER_AGGREGATOR_QUEUE_NAME = `${DEPLOYMENT_NAME}-reporter-aggregator-queue`
@@ -218,6 +227,15 @@ export const LISTENER_JOB_SETTINGS = {
 }
 
 export const WORKER_JOB_SETTINGS = {
+  removeOnComplete: REMOVE_ON_COMPLETE,
+  // FIXME Should not be removed until resolved, however, for now in
+  // testnet, we can safely keep this settings.
+  removeOnFail: REMOVE_ON_FAIL,
+  attempts: 10,
+  backoff: 1_000
+}
+
+export const NONCE_MANAGER_JOB_SETTINGS = {
   removeOnComplete: REMOVE_ON_COMPLETE,
   // FIXME Should not be removed until resolved, however, for now in
   // testnet, we can safely keep this settings.

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -391,6 +391,10 @@ export interface ITransactionParameters {
   to: string
 }
 
+export interface ITransactionParametersWithNonce extends ITransactionParameters {
+  nonce: number
+}
+
 export interface IVrfTransactionParameters {
   blockNum: string
   seed: string

--- a/core/src/worker/request-response.ts
+++ b/core/src/worker/request-response.ts
@@ -6,7 +6,7 @@ import { Logger } from 'pino'
 import type { RedisClientType } from 'redis'
 import {
   BULLMQ_CONNECTION,
-  REPORTER_REQUEST_RESPONSE_QUEUE_NAME,
+  NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME,
   REQUEST_RESPONSE_FULFILL_GAS_MINIMUM,
   WORKER_JOB_SETTINGS,
   WORKER_REQUEST_RESPONSE_QUEUE_NAME
@@ -27,7 +27,7 @@ const FILE_NAME = import.meta.url
 
 export async function worker(redisClient: RedisClientType, _logger: Logger) {
   const logger = _logger.child({ name: 'worker', file: FILE_NAME })
-  const queue = new Queue(REPORTER_REQUEST_RESPONSE_QUEUE_NAME, BULLMQ_CONNECTION)
+  const queue = new Queue(NONCE_MANAGER_REQUEST_RESPONSE_QUEUE_NAME, BULLMQ_CONNECTION)
   const worker = new Worker(
     WORKER_REQUEST_RESPONSE_QUEUE_NAME,
     await job(queue, _logger),

--- a/core/test/nonce-manager.test.ts
+++ b/core/test/nonce-manager.test.ts
@@ -1,0 +1,167 @@
+import { NonceManager } from '@ethersproject/experimental'
+import { jest } from '@jest/globals'
+import { Mutex } from 'async-mutex'
+import { createClient, RedisClientType } from 'redis'
+import { OraklError, OraklErrorCode } from '../src/errors'
+import { buildMockLogger } from '../src/logger'
+import { State } from '../src/reporter/state'
+import { CaverWallet } from '../src/reporter/utils'
+
+describe('nonce-manager', () => {
+  const PROVIDER_URL = process.env.GITHUB_ACTIONS
+    ? 'https://public-en-cypress.klaytn.net'
+    : 'https://public-en.kairos.node.kaia.io'
+  const redisClient: RedisClientType = createClient({ url: '' })
+  const ORACLE_ADDRESS = '0x0E4E90de7701B72df6F21343F51C833F7d2d3CFb'
+  const REPORTER = {
+    id: '1',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    oracleAddress: ORACLE_ADDRESS,
+    chain: '',
+    service: ''
+  }
+
+  jest.spyOn(State.prototype, 'all').mockImplementation(async () => [REPORTER])
+  jest.spyOn(redisClient, 'set').mockImplementation(async () => {
+    return null
+  })
+
+  let state: State
+  let delegatedState: State
+
+  beforeEach(() => {
+    state = new State({
+      redisClient,
+      providerUrl: PROVIDER_URL,
+      stateName: '',
+      service: '',
+      chain: '',
+      delegatedFee: false,
+      logger: buildMockLogger()
+    })
+
+    delegatedState = new State({
+      redisClient,
+      providerUrl: PROVIDER_URL,
+      stateName: '',
+      service: '',
+      chain: '',
+      delegatedFee: true,
+      logger: buildMockLogger()
+    })
+  })
+
+  test('wallet not active', async () => {
+    try {
+      state.mutex = new Mutex()
+      state.wallets = {}
+      await state.getAndIncrementNonce(ORACLE_ADDRESS)
+    } catch (error) {
+      expect(error.code).toBe(OraklErrorCode.WalletNotActive)
+    }
+  })
+
+  test('cannot get transaction count', async () => {
+    await state.refresh()
+    const wallet = state.wallets[ORACLE_ADDRESS] as NonceManager
+    jest.spyOn(wallet, 'getTransactionCount').mockImplementation(async () => {
+      throw new OraklError(OraklErrorCode.FailedToGetWalletTransactionCount)
+    })
+    try {
+      await state.getAndIncrementNonce(ORACLE_ADDRESS)
+    } catch (error) {
+      expect(error.code).toBe(OraklErrorCode.FailedToGetWalletTransactionCount)
+    }
+
+    await delegatedState.refresh()
+    const caverWallet = delegatedState.wallets[ORACLE_ADDRESS] as CaverWallet
+    jest.spyOn(caverWallet.caver.rpc.klay, 'getTransactionCount').mockImplementation(async () => {
+      throw new OraklError(OraklErrorCode.FailedToGetWalletTransactionCount)
+    })
+  })
+
+  test('increments nonce after func is called', async () => {
+    for (const currState of [state, delegatedState]) {
+      await currState.refresh()
+      const returnedNonce = await currState.getAndIncrementNonce(ORACLE_ADDRESS)
+      const currNonce = currState.nonces[ORACLE_ADDRESS]
+      expect(currNonce).toBe(returnedNonce + 1)
+    }
+  })
+
+  test('check delegatedFee handling', async () => {
+    await state.refresh()
+    const wallet = state.wallets[ORACLE_ADDRESS] as NonceManager
+    const currNonce = await wallet.getTransactionCount()
+    const returnedNonce = await state.getAndIncrementNonce(ORACLE_ADDRESS)
+    expect(returnedNonce).toBe(currNonce)
+
+    await delegatedState.refresh()
+    const caverWallet = delegatedState.wallets[ORACLE_ADDRESS] as CaverWallet
+    const currCaverNonce = Number(
+      await caverWallet.caver.rpc.klay.getTransactionCount(caverWallet.address)
+    )
+    const returnedCaverNonce = await delegatedState.getAndIncrementNonce(ORACLE_ADDRESS)
+    expect(returnedCaverNonce).toBe(currCaverNonce)
+  })
+
+  test('concurrent nonce calls', async () => {
+    const CONCURRENT_CALLS = 50
+
+    for (const currState of [state, delegatedState]) {
+      await currState.refresh()
+      const noncePromises: Promise<number>[] = []
+      for (let i = 0; i < CONCURRENT_CALLS; i++) {
+        noncePromises.push(state.getAndIncrementNonce(ORACLE_ADDRESS))
+      }
+      const nonces = await Promise.all(noncePromises)
+      expect(new Set(nonces).size).toBe(CONCURRENT_CALLS)
+      expect(Math.max(...nonces) - Math.min(...nonces)).toBe(CONCURRENT_CALLS - 1)
+    }
+  })
+
+  test('localNonce is smaller than walletNonce', async () => {
+    for (const currState of [state, delegatedState]) {
+      await currState.refresh()
+      currState.nonces[ORACLE_ADDRESS] = 0
+      const nonce = await currState.getAndIncrementNonce(ORACLE_ADDRESS)
+
+      if (!currState.delegatedFee) {
+        const wallet = currState.wallets[ORACLE_ADDRESS] as NonceManager
+        const walletNonce = await wallet.getTransactionCount()
+        expect(nonce).toBe(walletNonce)
+      } else {
+        const caverWallet = currState.wallets[ORACLE_ADDRESS] as CaverWallet
+        const walletNonce = Number(
+          await caverWallet.caver.rpc.klay.getTransactionCount(caverWallet.address)
+        )
+        expect(nonce).toBe(walletNonce)
+      }
+    }
+  })
+
+  test('localNonce is greater than walletNonce', async () => {
+    for (const currState of [state, delegatedState]) {
+      await currState.refresh()
+
+      if (!currState.delegatedFee) {
+        const wallet = currState.wallets[ORACLE_ADDRESS] as NonceManager
+        const walletNonce = await wallet.getTransactionCount()
+
+        currState.nonces[ORACLE_ADDRESS] = walletNonce + 1
+        const nonce = await currState.getAndIncrementNonce(ORACLE_ADDRESS)
+        expect(nonce).not.toBe(walletNonce)
+      } else {
+        const caverWallet = currState.wallets[ORACLE_ADDRESS] as CaverWallet
+        const walletNonce = Number(
+          await caverWallet.caver.rpc.klay.getTransactionCount(caverWallet.address)
+        )
+
+        currState.nonces[ORACLE_ADDRESS] = walletNonce + 1
+        const nonce = await currState.getAndIncrementNonce(ORACLE_ADDRESS)
+        expect(nonce).not.toBe(walletNonce)
+      }
+    }
+  })
+})

--- a/core/test/nonce-manager.test.ts
+++ b/core/test/nonce-manager.test.ts
@@ -111,7 +111,7 @@ describe('nonce-manager', () => {
   test('concurrent nonce calls', async () => {
     // send multiple concurrent calls to getAndIncrementNonce()
     // check that all nonces are unique and increment by 1
-    const CONCURRENT_CALLS = 50
+    const CONCURRENT_CALLS = 10
 
     for (const currState of [state, delegatedState]) {
       await currState.refresh()

--- a/core/test/nonce-manager.test.ts
+++ b/core/test/nonce-manager.test.ts
@@ -123,7 +123,7 @@ describe('nonce-manager', () => {
       expect(new Set(nonces).size).toBe(CONCURRENT_CALLS)
       expect(Math.max(...nonces) - Math.min(...nonces)).toBe(CONCURRENT_CALLS - 1)
     }
-  })
+  }, 60_000)
 
   test('localNonce is smaller than walletNonce', async () => {
     // when walletNonce is greater than localNonce,

--- a/core/test/nonce-manager.test.ts
+++ b/core/test/nonce-manager.test.ts
@@ -63,6 +63,7 @@ describe('nonce-manager', () => {
   })
 
   test('cannot get transaction count', async () => {
+    // override state.getTransactionCount() to throw error
     await state.refresh()
     const wallet = state.wallets[ORACLE_ADDRESS] as NonceManager
     jest.spyOn(wallet, 'getTransactionCount').mockImplementation(async () => {
@@ -91,6 +92,7 @@ describe('nonce-manager', () => {
   })
 
   test('check delegatedFee handling', async () => {
+    // check that nonce is updated correctly when delegatedFee is true & false
     await state.refresh()
     const wallet = state.wallets[ORACLE_ADDRESS] as NonceManager
     const currNonce = await wallet.getTransactionCount()
@@ -107,6 +109,8 @@ describe('nonce-manager', () => {
   })
 
   test('concurrent nonce calls', async () => {
+    // send multiple concurrent calls to getAndIncrementNonce()
+    // check that all nonces are unique and increment by 1
     const CONCURRENT_CALLS = 50
 
     for (const currState of [state, delegatedState]) {
@@ -122,6 +126,8 @@ describe('nonce-manager', () => {
   })
 
   test('localNonce is smaller than walletNonce', async () => {
+    // when walletNonce is greater than localNonce,
+    // localNonce should be updated to walletNonce
     for (const currState of [state, delegatedState]) {
       await currState.refresh()
       currState.nonces[ORACLE_ADDRESS] = 0
@@ -142,6 +148,8 @@ describe('nonce-manager', () => {
   })
 
   test('localNonce is greater than walletNonce', async () => {
+    // when localNonce is smaller than walletNonce,
+    // nothing should happen, localNonce should be returned and incremented
     for (const currState of [state, delegatedState]) {
       await currState.refresh()
 

--- a/core/test/reporter.test.ts
+++ b/core/test/reporter.test.ts
@@ -103,11 +103,10 @@ describe('Filter invalid reporters inside of State', function () {
     : 'https://public-en.kairos.node.kaia.io'
   const redisClient: RedisClientType = createClient({ url: '' })
 
-  // Empty wallet on kairos (baobab)
   const VALID_REPORTER = {
     id: '2',
-    address: '0xBa6d8c06b4b086E8D883e025Cc1Cb477241afC8b',
-    privateKey: '0x77487195a50a7ca67d0bb5caebe3672b62aeb956d9ca6316723de1e19de84976',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
     oracleAddress: '0x0E4E90de7701B72df6F21343F51C833F7d2d3CFb',
     chain: '',
     service: ''

--- a/core/test/reporter.test.ts
+++ b/core/test/reporter.test.ts
@@ -36,12 +36,13 @@ describe('Reporter', function () {
           privateKey: PRIVATE_KEY,
           providerUrl: PROVIDER_URL
         })
+        const nonce = await wallet.getTransactionCount()
 
         const to = '0x000000000000000000000000000000000000000' // wrong address
         const payload = '0x'
 
         expect(async () => {
-          await sendTransaction({ wallet, to, payload, logger })
+          await sendTransaction({ wallet, to, payload, logger, nonce })
         }).rejects.toThrow('TxInvalidAddress')
       } catch (e) {
         if (e.code == OraklErrorCode.ProviderNetworkError) {
@@ -80,6 +81,7 @@ describe('Reporter', function () {
       privateKey: '0xaa8707622845b72c76b7b9f329b154140441eda385ca39e3cdc66d2bee5f98e0',
       providerUrl: 'https://public-en.kairos.node.kaia.io'
     })
+    const nonce = Number(await wallet.caver.rpc.klay.getTransactionCount(wallet.address))
 
     const iface = new ethers.utils.Interface(COUNTER.abi)
     const payload = iface.encodeFunctionData('increment')
@@ -89,7 +91,8 @@ describe('Reporter', function () {
       to: COUNTER.address,
       payload,
       logger,
-      gasLimit: 100_000
+      gasLimit: 100_000,
+      nonce
     })
   })
 })
@@ -97,12 +100,14 @@ describe('Reporter', function () {
 describe('Filter invalid reporters inside of State', function () {
   const PROVIDER_URL = process.env.GITHUB_ACTIONS
     ? 'https://public-en-cypress.klaytn.net'
-    : 'http://127.0.0.1:8545'
+    : 'https://public-en.kairos.node.kaia.io'
   const redisClient: RedisClientType = createClient({ url: '' })
+
+  // Empty wallet on kairos (baobab)
   const VALID_REPORTER = {
     id: '2',
-    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    address: '0xBa6d8c06b4b086E8D883e025Cc1Cb477241afC8b',
+    privateKey: '0x77487195a50a7ca67d0bb5caebe3672b62aeb956d9ca6316723de1e19de84976',
     oracleAddress: '0x0E4E90de7701B72df6F21343F51C833F7d2d3CFb',
     chain: '',
     service: ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -3659,6 +3659,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.5.0.tgz#353c69a0b9e75250971a64ac203b0ebfddd75482"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
 async@1.x:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
@@ -12632,6 +12639,11 @@ tslib@^2.0.0, tslib@^2.1.0:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.4.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
 tsort@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
# Description

Related [issue](https://github.com/Bisonai/orakl/issues/1570)

This PR implements:
 - Manual nonce management function in reporter state. The function is mutex, meaning only a single process can execute it at any given time. Other concurrent calls to the function will be on queue until the lock becomes free
 - Nonce manager queue and worker in reporter service. The Worker service's worker submits jobs to `nonceManagerQueue` and `nonceManagerWorker` in Reporter service submits them to `reporterQueue` along with a nonce value

Part 2 of "Revamp reporter" will be handling edge cases such as json rpc unresponsiveness, service restart/crash, and redis flushes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
