### PR TITLE
(OraklNode) Include websocket endpoint into error log

### DIFF
--- a/node/pkg/wss/utils.go
+++ b/node/pkg/wss/utils.go
@@ -127,7 +127,7 @@ func (ws *WebsocketHelper) Dial(ctx context.Context) error {
 	}
 	conn, _, err := dialFunc(ctx, ws.Endpoint, dialOption)
 	if err != nil {
-		log.Error().Err(err).Msg("error opening websocket connection")
+		log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error opening websocket connection")
 		return err
 	}
 	ws.Conn = conn
@@ -157,7 +157,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 		for _, subscription := range ws.Subscriptions {
 			err := ws.Write(ctx, subscription)
 			if err != nil {
-				log.Error().Err(err).Msg("error writing subscription to websocket")
+				log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error writing subscription to websocket")
 				return err
 			}
 		}
@@ -172,7 +172,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 		default:
 			err := retrier.Retry(dialJob, 3, 1, 10)
 			if err != nil {
-				log.Error().Err(err).Msg("error dialing websocket")
+				log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error dialing websocket")
 				break
 			}
 
@@ -181,7 +181,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 
 			err = retrier.Retry(subscribeJob, 3, 1, 10)
 			if err != nil {
-				log.Error().Err(err).Msg("error subscribing to websocket")
+				log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error subscribing to websocket")
 				break
 			}
 
@@ -190,13 +190,13 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 				data, err := readFunc(ctx, ws.Conn)
 				ws.mu.Unlock()
 				if err != nil {
-					log.Error().Err(err).Msg("error reading from websocket")
+					log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error reading from websocket")
 					break
 				}
 				go func() {
 					routerErr := router(ctx, data)
 					if routerErr != nil {
-						log.Warn().Err(routerErr).Msg("error processing websocket message")
+						log.Warn().Err(routerErr).Str("endpoint", ws.Endpoint).Msg("error processing websocket message")
 					}
 				}()
 			}
@@ -210,7 +210,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 func (ws *WebsocketHelper) Write(ctx context.Context, message interface{}) error {
 	err := wsjson.Write(ctx, ws.Conn, message)
 	if err != nil {
-		log.Error().Err(err).Msg("error writing to websocket")
+		log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error writing to websocket")
 		return err
 	}
 	return nil
@@ -221,7 +221,7 @@ func (ws *WebsocketHelper) Read(ctx context.Context, ch chan any) error {
 		var t any
 		err := wsjson.Read(ctx, ws.Conn, &t)
 		if err != nil {
-			log.Error().Err(err).Msg("error reading from websocket")
+			log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error reading from websocket")
 			return err
 		}
 		ch <- t
@@ -234,7 +234,7 @@ func (ws *WebsocketHelper) Close() error {
 	}
 	err := ws.Conn.Close(websocket.StatusNormalClosure, "")
 	if err != nil {
-		log.Error().Err(err).Msg("error closing websocket")
+		log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error closing websocket")
 		return err
 	}
 	return nil


### PR DESCRIPTION
# Description

some errors are hard to find the source, try to add details from websocket helper package
```
{"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:07:25Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:07:35Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:07:35Z","message":"error readin
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:07:35Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:07:35Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:07:35Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:07:54Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:07:54Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:07:54Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:07:55Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:07:55Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:07:55Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:05Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:05Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:05Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:08:11Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:08:11Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:08:11Z","message":"error closing websocket"}
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:15Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:15Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:15Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:08:29Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:08:29Z","message":"error readin
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:35Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:35Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:08:35Z"
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:08:45Z","message":"Error marshalling object"}
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:08:45Z","message":"error in storing feed data"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:08:55Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:08:55Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:08:55Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:09:05Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:09:05Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:09:05Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:09:05Z","message":"Error marshalling object"}
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:09:05Z","message":"error in storing feed data"}
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:09:17Z","message":"Error marshalling object"}
│ {"level":"error","error":"json: error calling MarshalJSON for type *time.Time: Time.MarshalJSON: year outside of range [0,9999]","time":"2024-06-20T05:09:17Z","message":"error in storing feed data"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:09:39Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:09:39Z","message":"error readin
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:09:55Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:09:55Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:09:55Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:09:56Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:09:56Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:09:56Z","message":"error closing websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:09:59Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:09:59Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:09:59Z","message":"error closing websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:10:17Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:10:17Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:10:29Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:10:29Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:10:29Z","message":"error closing websocket"}
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:10:55Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:10:55Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:10:55Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:10:58Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:10:58Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:10:58Z","message":"error closing websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:10:59Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:10:59Z","message":"error readin
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:11:35Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:11:35Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:11:35Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:11:59Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:11:59Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:11:59Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:15Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:15Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:15Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:12:17Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:12:17Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:12:29Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:12:29Z","message":"error readin
│ {"level":"error","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:12:45Z","message":"failed t
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:12:45Z"
│ {"level":"error","Player":"Bitstamp","error":"Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","time":"2024-06-20T05:12:45Z"
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:12:46Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:12:46Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:12:46Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:55Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:55Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:12:55Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:13:01Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:13:01Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:13:01Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:13:15Z","message":"failed to read response body"}
│ {"level":"error","Player":"btse","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:13:15Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Btse","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:13:15Z","message":"error in fetchVolumes"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:13:30Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:13:30Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:13:56Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: received close frame: status = StatusNormalClosure and reason = \"\"","time":"2024-06-20T05:13:56Z","message":"error readin
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:14:02Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to read JSON message: failed to get reader: failed to read frame header: EOF","time":"2024-06-20T05:14:02Z","message":"error reading from websocket"}
│ {"level":"error","error":"failed to close WebSocket: failed to read frame header: EOF","time":"2024-06-20T05:14:02Z","message":"error closing websocket"}
│ {"level":"error","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:14:45Z","message":"failed to read response body"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:14:45Z","message":"error in FetchVolumes"}
│ {"level":"error","Player":"Bitstamp","error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)","time":"2024-06-20T05:14:45Z","message":"error in fetchVolumes"}
│
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
