### PR TITLE
(OraklNode) xt takes lowercase symbols

### DIFF
--- a/node/pkg/websocketfetcher/providers/xt/xt.go
+++ b/node/pkg/websocketfetcher/providers/xt/xt.go
@@ -29,6 +29,7 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 	params := []string{}
 	for feed := range fetcher.FeedMap {
 		symbol := strings.ReplaceAll(feed, "-", "_")
+		symbol = strings.ToLower(symbol)
 		params = append(params, fmt.Sprintf("ticker@%s", symbol))
 	}
 


### PR DESCRIPTION
# Description

XT takes lowercase symbols for subscription, which wasn't taken cared of from local testing. This PR adds symbol string to lowercase logic into xt.com exchange websocket fetcher

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
