### PR TITLE
(OraklNode) Fix xt hidden subscription limitation

### DIFF
--- a/node/pkg/websocketfetcher/providers/xt/xt.go
+++ b/node/pkg/websocketfetcher/providers/xt/xt.go
@@ -26,24 +26,25 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 	fetcher.FeedMap = config.FeedMaps.Separated
 	fetcher.FeedDataBuffer = config.FeedDataBuffer
 
-	params := []string{}
+	subscriptions := []any{}
 	for feed := range fetcher.FeedMap {
 		symbol := strings.ReplaceAll(feed, "-", "_")
 		symbol = strings.ToLower(symbol)
-		params = append(params, fmt.Sprintf("ticker@%s", symbol))
-	}
+		params := []string{
+			fmt.Sprintf("ticker@%s", symbol)}
 
-	subscription := Subscription{
-		Method: "subscribe",
-		Params: params,
-		ID:     uuid.New().String(),
+		subscriptions = append(subscriptions, Subscription{
+			Method: "subscribe",
+			Params: params,
+			ID:     uuid.New().String(),
+		})
 	}
 
 	ws, err := wss.NewWebsocketHelper(ctx,
 		wss.WithCustomReadFunc(fetcher.customReadFunc),
 		wss.WithCompressionMode(),
 		wss.WithEndpoint(URL),
-		wss.WithSubscriptions([]any{subscription}),
+		wss.WithSubscriptions(subscriptions),
 		wss.WithProxyUrl(config.Proxy))
 	if err != nil {
 		log.Error().Str("Player", "Xt").Err(err).Msg("error in xt.New")


### PR DESCRIPTION
# Description

Even though official documents says it is possible to subscribe to multiple pairs with single request, there are limitation for this. it should be requesting subscription one by one
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
