### PR TITLE
(OraklNode) Add missing ping pong functionality

### DIFF
--- a/node/pkg/websocketfetcher/providers/bitget/bitget.go
+++ b/node/pkg/websocketfetcher/providers/bitget/bitget.go
@@ -81,7 +81,10 @@ func (f *BitgetFetcher) ping(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				log.Debug().Str("Player", "Bitget").Msg("sending ping message to bitget server")
-				f.Ws.RawWrite(ctx, "ping")
+				err := f.Ws.RawWrite(ctx, "ping")
+				if err != nil {
+					log.Error().Str("Player", "Bitget").Err(err).Msg("error in bitget.ping")
+				}
 			case <-ctx.Done():
 				ticker.Stop()
 				return

--- a/node/pkg/websocketfetcher/providers/bitget/bitget.go
+++ b/node/pkg/websocketfetcher/providers/bitget/bitget.go
@@ -2,10 +2,13 @@ package bitget
 
 import (
 	"context"
+	"encoding/json"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
 	"bisonai.com/orakl/node/pkg/wss"
 	"github.com/rs/zerolog/log"
+	"nhooyr.io/websocket"
 )
 
 type BitgetFetcher common.Fetcher
@@ -35,6 +38,7 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 	}
 
 	ws, err := wss.NewWebsocketHelper(ctx,
+		wss.WithCustomReadFunc(fetcher.customReadFunc),
 		wss.WithEndpoint(URL),
 		wss.WithSubscriptions([]any{subscription}),
 		wss.WithProxyUrl(config.Proxy))
@@ -66,5 +70,43 @@ func (f *BitgetFetcher) handleMessage(ctx context.Context, message map[string]an
 }
 
 func (f *BitgetFetcher) Run(ctx context.Context) {
+	f.ping(ctx)
 	f.Ws.Run(ctx, f.handleMessage)
+}
+
+func (f *BitgetFetcher) ping(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				log.Debug().Str("Player", "Bitget").Msg("sending ping message to bitget server")
+				f.Ws.RawWrite(ctx, "ping")
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (f *BitgetFetcher) customReadFunc(ctx context.Context, conn *websocket.Conn) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		log.Error().Str("Player", "Bitget").Err(err).Msg("error in Bitget.customReadFunc, failed to read from websocket")
+		return nil, err
+	}
+	if string(data) == "pong" {
+		log.Debug().Str("Player", "Bitget").Msg("received pong")
+		return nil, nil
+	}
+
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		log.Error().Str("Player", "Bitget").Err(err).Msg("error in Bitget.customReadFunc, failed to unmarshal data")
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/node/pkg/websocketfetcher/providers/bitget/type.go
+++ b/node/pkg/websocketfetcher/providers/bitget/type.go
@@ -1,5 +1,7 @@
 package bitget
 
+// TODO: migrate to v2 (reference: https://www.bitget.com/api-doc/spot/websocket/public/Tickers-Channel)
+// wss://ws.bitget.com/v2/ws/public
 const URL = "wss://ws.bitget.com/mix/v1/stream"
 
 type Arg struct {

--- a/node/pkg/websocketfetcher/providers/bitmart/bitmart.go
+++ b/node/pkg/websocketfetcher/providers/bitmart/bitmart.go
@@ -85,7 +85,10 @@ func (f *BitmartFetcher) ping(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				log.Debug().Str("Player", "Bitmart").Msg("sending ping message to bitmart server")
-				f.Ws.RawWrite(ctx, "ping")
+				err := f.Ws.RawWrite(ctx, "ping")
+				if err != nil {
+					log.Error().Str("Player", "Bitmart").Err(err).Msg("error in bitmart.ping")
+				}
 			case <-ctx.Done():
 				ticker.Stop()
 				return

--- a/node/pkg/websocketfetcher/providers/bitmart/bitmart.go
+++ b/node/pkg/websocketfetcher/providers/bitmart/bitmart.go
@@ -2,12 +2,15 @@ package bitmart
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
 	"bisonai.com/orakl/node/pkg/wss"
 	"github.com/rs/zerolog/log"
+	"nhooyr.io/websocket"
 )
 
 type BitmartFetcher common.Fetcher
@@ -38,6 +41,7 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 	}
 
 	ws, err := wss.NewWebsocketHelper(ctx,
+		wss.WithCustomReadFunc(fetcher.customReadFunc),
 		wss.WithEndpoint(URL),
 		wss.WithSubscriptions(subscriptions),
 		wss.WithProxyUrl(config.Proxy))
@@ -70,5 +74,43 @@ func (f *BitmartFetcher) handleMessage(ctx context.Context, message map[string]a
 }
 
 func (f *BitmartFetcher) Run(ctx context.Context) {
+	f.ping(ctx)
 	f.Ws.Run(ctx, f.handleMessage)
+}
+
+func (f *BitmartFetcher) ping(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				log.Debug().Str("Player", "Bitmart").Msg("sending ping message to bitmart server")
+				f.Ws.RawWrite(ctx, "ping")
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (f *BitmartFetcher) customReadFunc(ctx context.Context, conn *websocket.Conn) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		log.Error().Str("Player", "Bitmart").Err(err).Msg("error in Bitmart.customReadFunc, failed to read from websocket")
+		return nil, err
+	}
+	if string(data) == "pong" {
+		log.Debug().Str("Player", "Bitmart").Msg("received pong")
+		return nil, nil
+	}
+
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		log.Error().Str("Player", "Bitmart").Err(err).Msg("error in Bitmart.customReadFunc, failed to unmarshal data")
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/node/pkg/websocketfetcher/providers/crypto/crypto.go
+++ b/node/pkg/websocketfetcher/providers/crypto/crypto.go
@@ -59,10 +59,10 @@ func (f *CryptoDotComFetcher) handleMessage(ctx context.Context, message map[str
 	}
 
 	if response.Method == "public/heartbeat" {
-		heartbeat, err := common.MessageToStruct[Heartbeat](message)
-		if err != nil {
-			log.Error().Str("Player", "CryptoDotCom").Err(err).Msg("error in cryptodotcom.handleMessage")
-			return err
+		heartbeat, heartbeatConvertErr := common.MessageToStruct[Heartbeat](message)
+		if heartbeatConvertErr != nil {
+			log.Error().Str("Player", "CryptoDotCom").Err(heartbeatConvertErr).Msg("error in cryptodotcom.handleMessage")
+			return heartbeatConvertErr
 		}
 		return f.Ws.Write(ctx, Heartbeat{
 			ID:     heartbeat.ID,

--- a/node/pkg/websocketfetcher/providers/crypto/crypto.go
+++ b/node/pkg/websocketfetcher/providers/crypto/crypto.go
@@ -58,6 +58,18 @@ func (f *CryptoDotComFetcher) handleMessage(ctx context.Context, message map[str
 		return err
 	}
 
+	if response.Method == "public/heartbeat" {
+		heartbeat, err := common.MessageToStruct[Heartbeat](message)
+		if err != nil {
+			log.Error().Str("Player", "CryptoDotCom").Err(err).Msg("error in cryptodotcom.handleMessage")
+			return err
+		}
+		return f.Ws.Write(ctx, Heartbeat{
+			ID:     heartbeat.ID,
+			Method: "public/respond-heartbeat",
+		})
+	}
+
 	if response.Result.Channel != "ticker" {
 		return nil
 	}

--- a/node/pkg/websocketfetcher/providers/crypto/types.go
+++ b/node/pkg/websocketfetcher/providers/crypto/types.go
@@ -31,3 +31,8 @@ type Response struct {
 		} `json:"data"`
 	} `json:"result"`
 }
+
+type Heartbeat struct {
+	ID     int    `json:"id"`
+	Method string `json:"method"`
+}

--- a/node/pkg/websocketfetcher/providers/lbank/lbank.go
+++ b/node/pkg/websocketfetcher/providers/lbank/lbank.go
@@ -46,6 +46,17 @@ func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInter
 }
 
 func (f *LbankFetcher) handleMessage(ctx context.Context, message map[string]any) error {
+	if _, exists := message["ping"]; exists {
+		ping, err := common.MessageToStruct[Ping](message)
+		if err != nil {
+			log.Error().Str("Player", "Lbank").Err(err).Msg("error in MessageToPing")
+			return err
+		}
+		return f.Ws.Write(ctx, Pong{
+			Action: "pong",
+			Pong:   ping.Ping,
+		})
+	}
 	response, err := common.MessageToStruct[Response](message)
 	if err != nil {
 		log.Error().Str("Player", "Lbank").Err(err).Msg("error in MessageToResponse")

--- a/node/pkg/websocketfetcher/providers/lbank/type.go
+++ b/node/pkg/websocketfetcher/providers/lbank/type.go
@@ -27,3 +27,13 @@ type Response struct {
 	Server string `json:"SERVER"`
 	TS     string `json:"TS"`
 }
+
+type Ping struct {
+	Action string `json:"action"`
+	Ping   string `json:"ping"`
+}
+
+type Pong struct {
+	Action string `json:"action"`
+	Pong   string `json:"pong"`
+}


### PR DESCRIPTION
# Description

Some websocket api requires manual ping pong from application level to keep connected. this adds related code updates for following exchanges

- lbank
- crypto.com
- bitget
- bitmart

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
