### PR TITLE
(OraklNode) Updates for subsec requirements

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -110,7 +110,8 @@ func (n *Aggregator) HandleRoundSyncMessage(ctx context.Context, msg raft.Messag
 		n.RoundID = roundSyncMessage.RoundID
 	}
 
-	n.cleanUpRoundData(roundSyncMessage.RoundID - 1)
+	// removes old round data (2 rounds ago)
+	n.cleanUpRoundData(roundSyncMessage.RoundID - 2)
 
 	n.AggregatorMutex.Lock()
 	defer n.AggregatorMutex.Unlock()

--- a/node/pkg/fetcher/collector.go
+++ b/node/pkg/fetcher/collector.go
@@ -3,10 +3,13 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/rs/zerolog/log"
 )
+
+const DefaultLocalAggregateInterval = 500
 
 func NewCollector(config Config, feeds []Feed) *Collector {
 	return &Collector{
@@ -23,7 +26,12 @@ func (c *Collector) Run(ctx context.Context) {
 	c.cancel = cancel
 	c.isRunning = true
 
-	collectorFrequency := time.Duration(c.FetchInterval) * time.Millisecond
+	localAggregateIntervalRaw := os.Getenv("LOCAL_AGGREGATE_INTERVAL")
+	localAggregateInterval, err := time.ParseDuration(localAggregateIntervalRaw)
+	if err != nil {
+		localAggregateInterval = DefaultLocalAggregateInterval * time.Millisecond
+	}
+	collectorFrequency := localAggregateInterval
 	ticker := time.NewTicker(collectorFrequency)
 	go func() {
 		for {

--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -38,7 +38,7 @@ import (
 
 // TODO: utilize unused providers: bitstamp, gemini, lbank, bitget (should be included in orakl config)
 const (
-	DefaultStoreInterval = 1000 * time.Millisecond
+	DefaultStoreInterval = 500 * time.Millisecond
 	DefaultBufferSize    = 500
 )
 


### PR DESCRIPTION
# Description

## ENV update

### AS-IS 

Local aggregate interval was depending on fetcher frequency of each configuration.  

### TO-BE

sets local aggregate interval through `LOCAL_AGGREGATE_INTERVAL`, and defaults to 500ms (0.5sec)

## Websocket Data store interval update

1 sec -> 0.5 sec

## Removes potential global aggregate data which is 2 rounds before

1 round -> 2 round : due to short global aggregate interval, 1 round might lead to deletion of on going aggregation

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
