### PR TITLE
(OraklNode) Rollback klayswap back to `slot0` call

### DIFF
--- a/node/pkg/chain/websocketchainreader/type.go
+++ b/node/pkg/chain/websocketchainreader/type.go
@@ -49,7 +49,7 @@ func WithChainType(chainType BlockchainType) SubscribeOption {
 	}
 }
 
-func WithBlockNumber(blockNumber *big.Int) SubscribeOption {
+func WithStartBlockNumber(blockNumber *big.Int) SubscribeOption {
 	return func(c *SubscribeConfig) {
 		c.BlockNumber = blockNumber
 	}

--- a/node/pkg/chain/websocketchainreader/websocketreader.go
+++ b/node/pkg/chain/websocketchainreader/websocketreader.go
@@ -2,6 +2,7 @@ package websocketchainreader
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 

--- a/node/pkg/chain/websocketchainreader/websocketreader.go
+++ b/node/pkg/chain/websocketchainreader/websocketreader.go
@@ -168,6 +168,7 @@ func processLogs(ctx context.Context, sub klaytn.Subscription, logs <-chan types
 		case vLog := <-logs:
 			select {
 			case ch <- vLog:
+				return true
 			case <-ctx.Done():
 				return false
 			}

--- a/node/pkg/chain/websocketchainreader/websocketreader.go
+++ b/node/pkg/chain/websocketchainreader/websocketreader.go
@@ -2,7 +2,6 @@ package websocketchainreader
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"time"
 

--- a/node/pkg/chain/websocketchainreader/websocketreader.go
+++ b/node/pkg/chain/websocketchainreader/websocketreader.go
@@ -168,7 +168,7 @@ func processLogs(ctx context.Context, sub klaytn.Subscription, logs <-chan types
 		case vLog := <-logs:
 			select {
 			case ch <- vLog:
-				return true
+				continue
 			case <-ctx.Done():
 				return false
 			}

--- a/node/pkg/websocketfetcher/providers/uniswap/uniswap.go
+++ b/node/pkg/websocketfetcher/providers/uniswap/uniswap.go
@@ -207,7 +207,11 @@ func (f *UniswapFetcher) wssBase(ctx context.Context, feed common.Feed, definiti
 		return err
 	}
 
-	err = f.WebsocketChainReader.Subscribe(ctx, websocketchainreader.WithAddress(address), websocketchainreader.WithChannel(logChannel), websocketchainreader.WithChainType(chainType), websocketchainreader.WithBlockNumber(big.NewInt(157383590)))
+	err = f.WebsocketChainReader.Subscribe(
+		ctx,
+		websocketchainreader.WithAddress(address),
+		websocketchainreader.WithChannel(logChannel),
+		websocketchainreader.WithChainType(chainType))
 	if err != nil {
 		log.Error().Str("Player", "Uniswap").Err(err).Msg("error in uniswap.subscribeEvent, failed to subscribe")
 		return err
@@ -218,7 +222,6 @@ func (f *UniswapFetcher) wssBase(ctx context.Context, feed common.Feed, definiti
 		if err != nil {
 			continue
 		}
-		log.Debug().Str("Player", "Uniswap").Any("res", res).Msg("unpacking event log")
 		var sqrtPrice interface{}
 
 		if chainType == websocketchainreader.Ethereum {

--- a/node/pkg/websocketfetcher/providers/uniswap/uniswap.go
+++ b/node/pkg/websocketfetcher/providers/uniswap/uniswap.go
@@ -123,7 +123,7 @@ func (f *UniswapFetcher) subscribeEvent(ctx context.Context, feed common.Feed) e
 
 func (f *UniswapFetcher) slotBase(ctx context.Context, feed common.Feed, definition *common.DexFeedDefinition) error {
 	ticker := time.NewTicker(2 * time.Second)
-
+	defer ticker.Stop()
 	for range ticker.C {
 		price, err := f.getPriceThroughSlotCall(ctx, definition)
 		if err != nil {


### PR DESCRIPTION
# Description

wss event subscription fails from klaytn, rollbacks to slot0 call to retrieve price from the pool

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
