### PR TITLE
(OraklNode) Reduce default latest data update interval

### DIFF
--- a/node/pkg/aggregator/streamer.go
+++ b/node/pkg/aggregator/streamer.go
@@ -69,7 +69,7 @@ type Streamer struct {
 	cancelFunc context.CancelFunc
 }
 
-const DefaultLatestDataUpdateInterval = 5 * time.Second
+const DefaultLatestDataUpdateInterval = 3 * time.Second
 const DefaultPgsqlBulkInsertInterval = 1 * time.Second
 const DefaultBufferSize = 1000
 


### PR DESCRIPTION
# Description

5 -> 3 seconds default interval to store latest data if the value has not changed

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
