### PR TITLE
(OraklNode) Set fixed deviation reporter job interval

### DIFF
--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -88,24 +88,20 @@ func (a *App) setReporters(ctx context.Context, h host.Host, ps *pubsub.PubSub) 
 		return errorSentinel.ErrReporterNotFound
 	}
 
-	groupedDeviationConfigs := groupConfigsByAggregateIntervals(configs)
-	for groupInterval, configs := range groupedDeviationConfigs {
-		deviationReporter, errNewDeviationReporter := NewReporter(
-			ctx,
-			WithHost(h),
-			WithPubsub(ps),
-			WithConfigs(configs),
-			WithInterval(groupInterval),
-			WithContractAddress(contractAddress),
-			WithCachedWhitelist(cachedWhitelist),
-			WithJobType(DeviationJob),
-		)
-		if errNewDeviationReporter != nil {
-			log.Error().Str("Player", "Reporter").Err(errNewDeviationReporter).Msg("failed to set deviation reporter")
-			continue
-		}
-		a.Reporters = append(a.Reporters, deviationReporter)
+	deviationReporter, errNewDeviationReporter := NewReporter(
+		ctx,
+		WithHost(h),
+		WithPubsub(ps),
+		WithConfigs(configs),
+		WithInterval(DEVIATION_INTERVAL),
+		WithContractAddress(contractAddress),
+		WithCachedWhitelist(cachedWhitelist),
+		WithJobType(DeviationJob),
+	)
+	if errNewDeviationReporter != nil {
+		log.Error().Str("Player", "Reporter").Err(errNewDeviationReporter).Msg("failed to set deviation reporter")
 	}
+	a.Reporters = append(a.Reporters, deviationReporter)
 
 	log.Info().Str("Player", "Reporter").Msgf("%d reporters set", len(a.Reporters))
 	return nil
@@ -307,18 +303,6 @@ func groupConfigsBySubmitIntervals(reporterConfigs []Config) map[int][]Config {
 		var interval = 5000
 		if sa.SubmitInterval != nil && *sa.SubmitInterval > 0 {
 			interval = *sa.SubmitInterval
-		}
-		grouped[interval] = append(grouped[interval], sa)
-	}
-	return grouped
-}
-
-func groupConfigsByAggregateIntervals(reporterConfigs []Config) map[int][]Config {
-	grouped := make(map[int][]Config)
-	for _, sa := range reporterConfigs {
-		var interval = 5000
-		if sa.AggregateInterval != nil && *sa.AggregateInterval > 0 {
-			interval = *sa.AggregateInterval
 		}
 		grouped[interval] = append(grouped[interval], sa)
 	}

--- a/node/pkg/reporter/app.go
+++ b/node/pkg/reporter/app.go
@@ -79,7 +79,7 @@ func (a *App) setReporters(ctx context.Context, h host.Host, ps *pubsub.PubSub) 
 		)
 		if errNewReporter != nil {
 			log.Error().Str("Player", "Reporter").Err(errNewReporter).Msg("failed to set reporter")
-			continue
+			return errNewReporter
 		}
 		a.Reporters = append(a.Reporters, reporter)
 	}
@@ -100,6 +100,7 @@ func (a *App) setReporters(ctx context.Context, h host.Host, ps *pubsub.PubSub) 
 	)
 	if errNewDeviationReporter != nil {
 		log.Error().Str("Player", "Reporter").Err(errNewDeviationReporter).Msg("failed to set deviation reporter")
+		return errNewDeviationReporter
 	}
 	a.Reporters = append(a.Reporters, deviationReporter)
 

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -32,7 +32,7 @@ func NewReporter(ctx context.Context, opts ...ReporterOption) (*Reporter, error)
 
 	topicString := TOPIC_STRING + "-"
 	if config.JobType == DeviationJob {
-		topicString += "deviation-" + strconv.Itoa(config.Interval)
+		topicString += "deviation"
 	} else {
 		topicString += strconv.Itoa(config.Interval)
 	}

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -28,6 +28,7 @@ const (
 
 	GET_REPORTER_CONFIGS = `SELECT name, id, submit_interval, aggregate_interval FROM configs;`
 
+	DEVIATION_INTERVAL           = 2000
 	DEVIATION_THRESHOLD          = 0.05
 	DEVIATION_ABSOLUTE_THRESHOLD = 0.1
 	DECIMALS                     = 8


### PR DESCRIPTION
# Description

Deviation job used to follow the interval of global aggregate interval, which is now 400ms. It is unnecessarily short since block generation is theoretically done every second from Kaia chain.

This update fixes deviation job interval into 2 seconds

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
