### PR TITLE
(OraklNode) Websocket feed data buffer preparation for 100+ more price pairs

### DIFF
--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	DefaultStoreInterval = 250 * time.Millisecond
-	DefaultBufferSize    = 500
+	DefaultBufferSize    = 3000
 )
 
 type AppConfig struct {


### PR DESCRIPTION
# Description

Increase websocket feed data buffersize for 300% increased price pairs

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
