### PR TITLE
optimize fetcher accumulator cpu usage

### DIFF
--- a/.github/workflows/node.test.yaml
+++ b/.github/workflows/node.test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     services:
       postgres:

--- a/node/pkg/fetcher/accumulator.go
+++ b/node/pkg/fetcher/accumulator.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const ACCUMULATOR_WORKER_COUNT = 3
+
 func NewAccumulator(interval time.Duration) *Accumulator {
 	return &Accumulator{
 		Interval: interval,
@@ -21,16 +23,33 @@ func (a *Accumulator) Run(ctx context.Context) {
 	a.cancel = cancel
 	a.isRunning = true
 
+	// dummy channel to signal accumulator workers to batch insert data to db
+	jobChannel := make(chan struct{}, 100)
+	for i := 0; i < ACCUMULATOR_WORKER_COUNT; i++ {
+		go a.accumulatorWorker(accumulatorCtx, jobChannel)
+	}
+
 	ticker := time.NewTicker(DefaultLocalAggregateInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
+		case <-ticker.C:
+			jobChannel <- struct{}{}
 		case <-ctx.Done():
 			log.Debug().Str("Player", "Fetcher").Msg("fetcher local aggregates channel goroutine stopped")
 			return
-		case <-ticker.C:
-			go a.accumulatorJob(ctx)
+		}
+	}
+}
+
+func (a *Accumulator) accumulatorWorker(ctx context.Context, jobChannel <-chan struct{}) {
+	for {
+		select {
+		case <-jobChannel:
+			a.accumulatorJob(ctx)
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/node/pkg/fetcher/accumulator.go
+++ b/node/pkg/fetcher/accumulator.go
@@ -24,7 +24,7 @@ func (a *Accumulator) Run(ctx context.Context) {
 	a.isRunning = true
 
 	// dummy channel to signal accumulator workers to batch insert data to db
-	jobChannel := make(chan struct{}, ACCUMULATOR_WORKER_COUNT*2)
+	jobChannel := make(chan struct{})
 	for i := 0; i < ACCUMULATOR_WORKER_COUNT; i++ {
 		go a.accumulatorWorker(accumulatorCtx, jobChannel)
 	}

--- a/node/pkg/fetcher/accumulator.go
+++ b/node/pkg/fetcher/accumulator.go
@@ -24,7 +24,7 @@ func (a *Accumulator) Run(ctx context.Context) {
 	a.isRunning = true
 
 	// dummy channel to signal accumulator workers to batch insert data to db
-	jobChannel := make(chan struct{}, 100)
+	jobChannel := make(chan struct{}, ACCUMULATOR_WORKER_COUNT*2)
 	for i := 0; i < ACCUMULATOR_WORKER_COUNT; i++ {
 		go a.accumulatorWorker(accumulatorCtx, jobChannel)
 	}

--- a/node/pkg/fetcher/accumulator_test.go
+++ b/node/pkg/fetcher/accumulator_test.go
@@ -60,7 +60,7 @@ func TestAccumulator(t *testing.T) {
 
 	go app.Accumulator.Run(ctx)
 
-	time.Sleep(DefaultLocalAggregateInterval * 2)
+	time.Sleep(DefaultLocalAggregateInterval * 4)
 
 	redisData, redisErr := db.GetObject[LocalAggregate](ctx, keys.LocalAggregateKey(data.ConfigID))
 	if redisErr != nil {


### PR DESCRIPTION
# Description

Current:
 - create and destroy a goroutine every 250ms, which might be a cpu intensive process (goroutines are lightweight but the overhead of creating and destroying might still add up)

Updated:
 - create a certain number (now 3) of goroutines, called `accumulatorWorker`, that are always active. 
 - trigger an available worker through a dummy channel

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
