### PR TITLE
sentinel oversubmission in checker

### DIFF
--- a/sentinel/pkg/checker/event/app.go
+++ b/sentinel/pkg/checker/event/app.go
@@ -208,7 +208,7 @@ func countLastMinFeedEvents(ctx context.Context, feed FeedToCheck) (int, error) 
 	type Count struct {
 		Count int `db:"count"`
 	}
-	query := feedLastMinEventQuery(feed.SchemaName)
+	query := feedLastMinEventQuery(feed.SchemaName, feed.ExpectedInterval)
 	count, err := db.QueryRow[Count](ctx, query, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to query last minute event count")
@@ -284,7 +284,7 @@ func handleFeedSubmissionDelay(offset time.Duration, feed *FeedToCheck, msg *str
 }
 
 func handleFeedOverSubmission(count int, feed *FeedToCheck, msg *string) {
-	maxFeedSubmissionCount := int(time.Minute.Milliseconds()/(time.Duration(feed.ExpectedInterval)*time.Millisecond).Milliseconds()) * 2
+	maxFeedSubmissionCount := 2 // 2 times within the specified feed.ExpectedInterval will be considered oversubmission
 	if count >= maxFeedSubmissionCount {
 		log.Warn().Str("feed", feed.FeedName).Msg(fmt.Sprintf("%s submitted %d times in one minute", feed.FeedName, count))
 		feed.OversubmissionCount++

--- a/sentinel/pkg/checker/event/app.go
+++ b/sentinel/pkg/checker/event/app.go
@@ -15,6 +15,7 @@ import (
 
 const AlarmOffset = 3
 const VRF_EVENT = "vrf_random_words_fulfilled"
+const MaxFeedSubmissionCount = 2 // 2 times within the specified feed.ExpectedInterval will be considered oversubmission
 
 var EventCheckInterval time.Duration
 var POR_BUFFER = 60 * time.Second
@@ -284,12 +285,11 @@ func handleFeedSubmissionDelay(offset time.Duration, feed *FeedToCheck, msg *str
 }
 
 func handleFeedOverSubmission(count int, feed *FeedToCheck, msg *string) {
-	maxFeedSubmissionCount := 2 // 2 times within the specified feed.ExpectedInterval will be considered oversubmission
-	if count >= maxFeedSubmissionCount {
+	if count >= MaxFeedSubmissionCount {
 		log.Warn().Str("feed", feed.FeedName).Msg(fmt.Sprintf("%s submitted %d times in one minute", feed.FeedName, count))
 		feed.OversubmissionCount++
 		if feed.OversubmissionCount > AlarmOffset {
-			*msg += fmt.Sprintf("%s made over %d submissions/minute %d times consecutively\n", feed.FeedName, maxFeedSubmissionCount, AlarmOffset+1)
+			*msg += fmt.Sprintf("%s made %dx more submissions, %d times consecutively\n", feed.FeedName, MaxFeedSubmissionCount, AlarmOffset+1)
 			feed.OversubmissionCount = 0
 		}
 	} else {

--- a/sentinel/pkg/checker/event/types.go
+++ b/sentinel/pkg/checker/event/types.go
@@ -46,10 +46,10 @@ type PegPorConfig struct {
 }
 
 type FeedToCheck struct {
-	SchemaName       string
-	FeedName         string
-	ExpectedInterval int
-	LatencyChecked   int
+	SchemaName          string
+	FeedName            string
+	ExpectedInterval    int
+	LatencyChecked      int
 	OversubmissionCount int
 }
 
@@ -69,8 +69,9 @@ func feedEventQuery(schemaName string) string {
 	return fmt.Sprintf(`SELECT time FROM %s.feed_feed_updated ORDER BY time DESC LIMIT 1;`, schemaName)
 }
 
-func feedLastMinEventQuery(schemaName string) string {
-	return fmt.Sprintf(`SELECT COUNT(*) FROM %s.feed_feed_updated WHERE time >= EXTRACT(EPOCH FROM NOW() - INTERVAL '1 minute');`, schemaName)
+func feedLastMinEventQuery(schemaName string, interval int) string {
+	intervalInSeconds := interval / 1000
+	return fmt.Sprintf(`SELECT COUNT(*) FROM %s.feed_feed_updated WHERE time >= NOW() - INTERVAL '%d seconds';`, schemaName, intervalInSeconds)
 }
 
 func aggregatorEventQuery(schemaName string) string {


### PR DESCRIPTION
# Description

Current logic:
 - get submission count from db in the last `1 minute`
 - oversubmission_count = 1 minute / `feed.ExpectedInterval`, which used to be okay when the `ExpectedInterval` is 15 seconds. But this doesn't work when the interval is over 1 minutes

Updated to:
 - get submission count from db in the last `feed.ExpectedInterval seconds`
 - oversubmission_count = 2
 - if submission count >= oversubmission_count send slack message

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
