### PR TITLE
(OraklNode) Splitted report

### DIFF
--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -389,10 +389,7 @@ func (r *Reporter) HandleSubmissionMessage(ctx context.Context, msg raft.Message
 
 func (r *Reporter) splitReport(ctx context.Context, feedHashes [][32]byte, values []*big.Int, timestamps []*big.Int, proofs [][]byte) error {
 	for start := 0; start < len(feedHashes); start += MAX_REPORT_BATCH_SIZE {
-		end := start + MAX_REPORT_BATCH_SIZE
-		if end > len(feedHashes) {
-			end = len(feedHashes)
-		}
+		end := min(start+MAX_REPORT_BATCH_SIZE, len(feedHashes))
 
 		batchFeedHashes := feedHashes[start:end]
 		batchValues := values[start:end]
@@ -405,7 +402,6 @@ func (r *Reporter) splitReport(ctx context.Context, feedHashes [][32]byte, value
 			err = r.reportDirect(ctx, SUBMIT_WITH_PROOFS, batchFeedHashes, batchValues, batchTimestamps, batchProofs)
 			if err != nil {
 				log.Error().Str("Player", "Reporter").Err(err).Msg("splitReport")
-				return err
 			}
 		}
 	}

--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -3,6 +3,7 @@ package reporter
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"strconv"
 	"time"
 
@@ -241,12 +242,7 @@ func (r *Reporter) reportWithProofs(ctx context.Context, aggregates []GlobalAggr
 	}
 	log.Debug().Str("Player", "Reporter").Int("proofs", len(proofs)).Msg("contract arguements generated")
 
-	err = r.reportDelegated(ctx, SUBMIT_WITH_PROOFS, feedHashes, values, timestamps, proofs)
-	if err != nil {
-		log.Error().Str("Player", "Reporter").Err(err).Msg("reporting directly")
-		return r.reportDirect(ctx, SUBMIT_WITH_PROOFS, feedHashes, values, timestamps, proofs)
-	}
-	return nil
+	return r.splitReport(ctx, feedHashes, values, timestamps, proofs)
 }
 
 func (r *Reporter) reportDirect(ctx context.Context, functionString string, args ...interface{}) error {
@@ -388,5 +384,30 @@ func (r *Reporter) HandleSubmissionMessage(ctx context.Context, msg raft.Message
 		return err
 	}
 
+	return nil
+}
+
+func (r *Reporter) splitReport(ctx context.Context, feedHashes [][32]byte, values []*big.Int, timestamps []*big.Int, proofs [][]byte) error {
+	for start := 0; start < len(feedHashes); start += MAX_REPORT_BATCH_SIZE {
+		end := start + MAX_REPORT_BATCH_SIZE
+		if end > len(feedHashes) {
+			end = len(feedHashes)
+		}
+
+		batchFeedHashes := feedHashes[start:end]
+		batchValues := values[start:end]
+		batchTimestamps := timestamps[start:end]
+		batchProofs := proofs[start:end]
+
+		err := r.reportDelegated(ctx, SUBMIT_WITH_PROOFS, batchFeedHashes, batchValues, batchTimestamps, batchProofs)
+		if err != nil {
+			log.Error().Str("Player", "Reporter").Err(err).Msg("splitReport")
+			err = r.reportDirect(ctx, SUBMIT_WITH_PROOFS, batchFeedHashes, batchValues, batchTimestamps, batchProofs)
+			if err != nil {
+				log.Error().Str("Player", "Reporter").Err(err).Msg("splitReport")
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -28,6 +28,7 @@ const (
 
 	GET_REPORTER_CONFIGS = `SELECT name, id, submit_interval, aggregate_interval FROM configs;`
 
+	MAX_REPORT_BATCH_SIZE        = 50
 	DEVIATION_INTERVAL           = 2000
 	DEVIATION_THRESHOLD          = 0.05
 	DEVIATION_ABSOLUTE_THRESHOLD = 0.1


### PR DESCRIPTION
# Description

SubmissionProxy contract has max batch size of 50, if single submission entries length exceed 50, it should be splitted.
This PR adds `splitReport` function which splits submission based on max batch size 50 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
