### PR TITLE
(OraklNode) Deviation Threshold based on submission interval

### DIFF
--- a/node/pkg/reporter/reporter.go
+++ b/node/pkg/reporter/reporter.go
@@ -47,11 +47,13 @@ func NewReporter(ctx context.Context, opts ...ReporterOption) (*Reporter, error)
 	}
 
 	raft := raft.NewRaftNode(config.Host, config.Ps, topic, MESSAGE_BUFFER, groupInterval)
+	deviationThreshold := GetDeviationThreshold(groupInterval)
 	reporter := &Reporter{
 		Raft:               raft,
 		contractAddress:    config.ContractAddress,
 		SubmissionInterval: groupInterval,
 		CachedWhitelist:    config.CachedWhitelist,
+		deviationThreshold: deviationThreshold,
 	}
 	reporter.SubmissionPairs = make(map[int32]SubmissionPair)
 	for _, sa := range config.Configs {
@@ -313,7 +315,7 @@ func (r *Reporter) deviationJob() error {
 		return nil
 	}
 
-	deviatingAggregates := GetDeviatingAggregates(lastSubmissions, lastAggregates)
+	deviatingAggregates := GetDeviatingAggregates(lastSubmissions, lastAggregates, r.deviationThreshold)
 	if len(deviatingAggregates) == 0 {
 		return nil
 	}

--- a/node/pkg/reporter/types.go
+++ b/node/pkg/reporter/types.go
@@ -28,11 +28,16 @@ const (
 
 	GET_REPORTER_CONFIGS = `SELECT name, id, submit_interval, aggregate_interval FROM configs;`
 
-	MAX_REPORT_BATCH_SIZE        = 50
-	DEVIATION_INTERVAL           = 2000
-	DEVIATION_THRESHOLD          = 0.05
+	MAX_REPORT_BATCH_SIZE = 50
+	DEVIATION_INTERVAL    = 2000
+
 	DEVIATION_ABSOLUTE_THRESHOLD = 0.1
 	DECIMALS                     = 8
+
+	MAX_DEVIATION_THRESHOLD = 0.01
+	MIN_DEVIATION_THRESHOLD = 0.05
+	MIN_INTERVAL            = 15
+	MAX_INTERVAL            = 3600
 )
 
 type Config struct {
@@ -122,7 +127,8 @@ type Reporter struct {
 	SubmissionInterval time.Duration
 	CachedWhitelist    []common.Address
 
-	contractAddress string
+	contractAddress    string
+	deviationThreshold float64
 
 	nodeCtx    context.Context
 	nodeCancel context.CancelFunc


### PR DESCRIPTION
# Description

set deviation threshold based on submission interval 

https://go.dev/play/p/0NuWyupgKRf

```golang
func main() {
	// Example usage
	fmt.Println(getDeviationThreshold(15 * time.Second)) // 15 seconds
	fmt.Println(getDeviationThreshold(1 * time.Hour))    // 1 hour
	fmt.Println(getDeviationThreshold(30 * time.Minute)) // 30 minutes
	fmt.Println(getDeviationThreshold(1 * time.Second))  // 1 second (extrapolation)
	fmt.Println(getDeviationThreshold(2 * time.Hour))    // 2 hours (extrapolation)
}

/*
0.05
0.01
0.030083682008368202
0.05
0.01
*/
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
