### PR TITLE
update sentinel signer expiry check

### DIFF
--- a/sentinel/pkg/checker/signer/app.go
+++ b/sentinel/pkg/checker/signer/app.go
@@ -52,7 +52,12 @@ func Start(ctx context.Context) error {
 	log.Info().Msg("Starting signer expiration checker")
 	checkTicker := time.NewTicker(signerCheckInterval)
 	defer checkTicker.Stop()
-	check(ctx)
+
+	err = check(ctx)
+	if err != nil {
+		return err
+	}
+
 	for range checkTicker.C {
 		err = check(ctx)
 		if err != nil {
@@ -85,7 +90,6 @@ func check(ctx context.Context) error {
 	}
 	if alarmMessage != "" {
 		alert.SlackAlert(alarmMessage)
-		alarmMessage = ""
 	}
 
 	return nil

--- a/sentinel/pkg/checker/signer/app.go
+++ b/sentinel/pkg/checker/signer/app.go
@@ -83,7 +83,7 @@ func check(ctx context.Context) error {
 		log.Info().Msgf("Signer: %s, Expiration: %s", signerAddress, (*exp).String())
 		if err != nil || exp == nil {
 			log.Error().Err(err).Msg(fmt.Sprintf("Failed to extract expiration for signer: %s", signerAddress))
-			alarmMessage += fmt.Sprintf("Failed to extract expiration for signer: %s\n", signerAddress)
+			alarmMessage += fmt.Sprintf("Failed to extract expiration for signer %s with following error: %v\n", signerAddress, err)
 			continue
 		}
 		if (*exp).Before(time.Now()) {

--- a/sentinel/pkg/checker/signer/app.go
+++ b/sentinel/pkg/checker/signer/app.go
@@ -21,12 +21,14 @@ var signerCheckInterval time.Duration
 var jsonRpcUrl string
 var submissionProxyContractAddr string
 
+const DEFAULT_SIGNER_CHECK_INTERVAL_HOUR = 24
+
 func setUp(ctx context.Context) error {
 	var err error
 	signerCheckInterval, err = time.ParseDuration(os.Getenv("SIGNER_CHECK_INTERVAL"))
 	if err != nil {
-		signerCheckInterval = 24 * time.Hour
-		log.Error().Err(err).Msg("Using default signer check interval of 6 hours")
+		signerCheckInterval = DEFAULT_SIGNER_CHECK_INTERVAL_HOUR * time.Hour
+		log.Error().Err(err).Msgf("Using default signer check interval of %s hours", DEFAULT_SIGNER_CHECK_INTERVAL_HOUR)
 	}
 
 	jsonRpcUrl = os.Getenv("JSON_RPC_URL")

--- a/sentinel/pkg/checker/signer/app.go
+++ b/sentinel/pkg/checker/signer/app.go
@@ -28,7 +28,7 @@ func setUp(ctx context.Context) error {
 	signerCheckInterval, err = time.ParseDuration(os.Getenv("SIGNER_CHECK_INTERVAL"))
 	if err != nil {
 		signerCheckInterval = DEFAULT_SIGNER_CHECK_INTERVAL_HOUR * time.Hour
-		log.Error().Err(err).Msgf("Using default signer check interval of %s hours", DEFAULT_SIGNER_CHECK_INTERVAL_HOUR)
+		log.Error().Err(err).Msgf("Using default signer check interval of %d hours", DEFAULT_SIGNER_CHECK_INTERVAL_HOUR)
 	}
 
 	jsonRpcUrl = os.Getenv("JSON_RPC_URL")


### PR DESCRIPTION
# Description

Previously:
 - get orakl signer address from node endpoint
 - use hardcoded kf signer address
 - send slack message if it's 5 weeks left until either of the signers expire, every 6 hours

Currently:
 - get orakl and kf signer addresses and expiry dates from SubmissionProxy
 - check if any of the signers have expired every 24 hours and send slack message 

Fixes #1741 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
