### PR TITLE
(OraklNode) Libp2p reconnect attempt after disconnection

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -11,6 +11,7 @@ import (
 	"bisonai.com/orakl/node/pkg/aggregator"
 	"bisonai.com/orakl/node/pkg/bus"
 	"bisonai.com/orakl/node/pkg/fetcher"
+	"bisonai.com/orakl/node/pkg/libp2p/helper"
 	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	"bisonai.com/orakl/node/pkg/reporter"
 	"bisonai.com/orakl/node/pkg/utils/retrier"
@@ -80,7 +81,6 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-
 		a := aggregator.New(mb, host, ps)
 		aggregatorErr := a.Run(ctx)
 		if aggregatorErr != nil {
@@ -93,7 +93,6 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-
 		r := reporter.New(mb, host, ps)
 		reporterErr := r.Run(ctx)
 		if reporterErr != nil {
@@ -102,6 +101,18 @@ func main() {
 		}
 	}()
 	log.Info().Msg("Reporter started")
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		helperApp := helper.New(mb, host)
+		libp2pHelperErr := helperApp.Run(ctx)
+		if libp2pHelperErr != nil {
+			log.Error().Err(libp2pHelperErr).Msg("Failed to start libp2p helper")
+			os.Exit(1)
+		}
+	}()
+	log.Info().Msg("libp2p helper started")
 
 	wg.Wait()
 }

--- a/node/migrations/boot/000003_add_url_constraints.down.sql
+++ b/node/migrations/boot/000003_add_url_constraints.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE peers DROP CONSTRAINT IF EXISTS unique_url;

--- a/node/migrations/boot/000003_add_url_constraints.up.sql
+++ b/node/migrations/boot/000003_add_url_constraints.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE peers DROP CONSTRAINT IF EXISTS unique_url;
+ALTER TABLE peers ADD CONSTRAINT unique_url UNIQUE (url);

--- a/node/pkg/admin/admin.go
+++ b/node/pkg/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"bisonai.com/orakl/node/pkg/admin/config"
 	"bisonai.com/orakl/node/pkg/admin/feed"
 	"bisonai.com/orakl/node/pkg/admin/fetcher"
+	"bisonai.com/orakl/node/pkg/admin/host"
 	"bisonai.com/orakl/node/pkg/admin/providerUrl"
 	"bisonai.com/orakl/node/pkg/admin/proxy"
 	"bisonai.com/orakl/node/pkg/admin/reporter"
@@ -44,6 +45,7 @@ func Run(bus *bus.MessageBus) error {
 	wallet.Routes(v1)
 	providerUrl.Routes(v1)
 	config.Routes(v1)
+	host.Routes(v1)
 
 	port := os.Getenv("APP_PORT")
 	if port == "" {

--- a/node/pkg/admin/host/controller.go
+++ b/node/pkg/admin/host/controller.go
@@ -1,0 +1,38 @@
+package host
+
+import (
+	"bisonai.com/orakl/node/pkg/admin/utils"
+	"bisonai.com/orakl/node/pkg/bus"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog/log"
+)
+
+func getPeerCount(c *fiber.Ctx) error {
+	msg, err := utils.SendMessage(c, bus.LIBP2P, bus.GET_PEER_COUNT, nil)
+	if err != nil {
+		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to libp2p helper")
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to get peer count: " + err.Error())
+	}
+	resp := <-msg.Response
+	if !resp.Success {
+		log.Error().Str("Player", "Admin").Msg("failed to get peer count: " + resp.Args["error"].(string))
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to get peer count: " + resp.Args["error"].(string))
+	}
+
+	return c.JSON(resp.Args)
+}
+
+func sync(c *fiber.Ctx) error {
+	msg, err := utils.SendMessage(c, bus.LIBP2P, bus.SYNC, nil)
+	if err != nil {
+		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to libp2p helper")
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to sync libp2p host: " + err.Error())
+	}
+	resp := <-msg.Response
+	if !resp.Success {
+		log.Error().Str("Player", "Admin").Msg("failed to sync libp2p host")
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to sync libp2p host: " + resp.Args["error"].(string))
+	}
+
+	return c.SendString("libp2p synced")
+}

--- a/node/pkg/admin/host/controller.go
+++ b/node/pkg/admin/host/controller.go
@@ -23,7 +23,7 @@ func getPeerCount(c *fiber.Ctx) error {
 }
 
 func sync(c *fiber.Ctx) error {
-	msg, err := utils.SendMessage(c, bus.LIBP2P, bus.SYNC, nil)
+	msg, err := utils.SendMessage(c, bus.LIBP2P, bus.LIBP2P_SYNC, nil)
 	if err != nil {
 		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to libp2p helper")
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to sync libp2p host: " + err.Error())

--- a/node/pkg/admin/host/route.go
+++ b/node/pkg/admin/host/route.go
@@ -1,0 +1,12 @@
+package host
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func Routes(router fiber.Router) {
+	host := router.Group("/host")
+
+	host.Get("/peercount", getPeerCount)
+	host.Post("/sync", sync)
+}

--- a/node/pkg/admin/tests/host_test.go
+++ b/node/pkg/admin/tests/host_test.go
@@ -38,7 +38,7 @@ func TestSync(t *testing.T) {
 	defer cleanup()
 
 	channel := testItems.mb.Subscribe(bus.LIBP2P)
-	waitForMessage(t, channel, bus.ADMIN, bus.LIBP2P, bus.SYNC)
+	waitForMessage(t, channel, bus.ADMIN, bus.LIBP2P, bus.LIBP2P_SYNC)
 
 	result, err := RawPostRequest(testItems.app, "/api/v1/host/sync", nil)
 	if err != nil {

--- a/node/pkg/admin/tests/host_test.go
+++ b/node/pkg/admin/tests/host_test.go
@@ -1,0 +1,49 @@
+//nolint:all
+package tests
+
+import (
+	"context"
+
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/bus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPeerCount(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	channel := testItems.mb.Subscribe(bus.LIBP2P)
+	waitForMessageWithResponse(t, channel, bus.ADMIN, bus.LIBP2P, bus.GET_PEER_COUNT, map[string]any{"Count": 1})
+
+	result, err := GetRequest[struct{ Count int }](testItems.app, "/api/v1/host/peercount", nil)
+	if err != nil {
+		t.Fatalf("error getting peercount: %v", err)
+	}
+
+	assert.Equal(t, 1, result.Count)
+}
+
+func TestSync(t *testing.T) {
+	ctx := context.Background()
+	cleanup, testItems, err := setup(ctx)
+	if err != nil {
+		t.Fatalf("error setting up test: %v", err)
+	}
+	defer cleanup()
+
+	channel := testItems.mb.Subscribe(bus.LIBP2P)
+	waitForMessage(t, channel, bus.ADMIN, bus.LIBP2P, bus.SYNC)
+
+	result, err := RawPostRequest(testItems.app, "/api/v1/host/sync", nil)
+	if err != nil {
+		t.Fatalf("error sync libp2p host: %v", err)
+	}
+
+	assert.Equal(t, string(result), "libp2p synced")
+}

--- a/node/pkg/admin/tests/main_test.go
+++ b/node/pkg/admin/tests/main_test.go
@@ -9,6 +9,7 @@ import (
 	"bisonai.com/orakl/node/pkg/admin/config"
 	"bisonai.com/orakl/node/pkg/admin/feed"
 	"bisonai.com/orakl/node/pkg/admin/fetcher"
+	"bisonai.com/orakl/node/pkg/admin/host"
 	"bisonai.com/orakl/node/pkg/admin/providerUrl"
 	"bisonai.com/orakl/node/pkg/admin/proxy"
 	"bisonai.com/orakl/node/pkg/admin/reporter"
@@ -67,6 +68,7 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	reporter.Routes(v1)
 	providerUrl.Routes(v1)
 	config.Routes(v1)
+	host.Routes(v1)
 	return adminCleanup(testItems), testItems, nil
 }
 

--- a/node/pkg/admin/tests/test_helper.go
+++ b/node/pkg/admin/tests/test_helper.go
@@ -158,3 +158,18 @@ func waitForMessage(t *testing.T, channel <-chan bus.Message, from, to, command 
 		}
 	}()
 }
+
+func waitForMessageWithResponse(t *testing.T, channel <-chan bus.Message, from, to, command string, resp map[string]any) {
+	go func() {
+		select {
+		case msg := <-channel:
+			if msg.From != from || msg.To != to || msg.Content.Command != command {
+				t.Errorf("unexpected message: %v", msg)
+			}
+			msg.Response <- bus.MessageResponse{Success: true, Args: resp}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no message received on channel")
+		}
+	}()
+
+}

--- a/node/pkg/boot/peer/queries.go
+++ b/node/pkg/boot/peer/queries.go
@@ -1,7 +1,7 @@
 package peer
 
 const (
-	InsertPeer = `INSERT INTO peers (url) VALUES (@url) RETURNING *;`
+	InsertPeer = `INSERT INTO peers (url) VALUES (@url) ON CONFLICT (url) DO NOTHING RETURNING *;`
 
 	GetPeer = `SELECT * FROM peers;`
 

--- a/node/pkg/bus/types.go
+++ b/node/pkg/bus/types.go
@@ -34,5 +34,5 @@ const (
 	REFRESH_REPORTER    = "refresh_reporter"
 
 	GET_PEER_COUNT = "get_peer_count"
-	SYNC           = "sync"
+	LIBP2P_SYNC    = "libp2p_sync"
 )

--- a/node/pkg/bus/types.go
+++ b/node/pkg/bus/types.go
@@ -10,6 +10,7 @@ const (
 	FETCHER    = "fetcher"
 	AGGREGATOR = "aggregator"
 	REPORTER   = "reporter"
+	LIBP2P     = "libp2p"
 
 	// Modular Monolith pkg commands, please follow {verb}_{noun} pattern for both variable name and value
 	START_FETCHER_APP   = "start_fetcher_app"
@@ -31,4 +32,7 @@ const (
 	ACTIVATE_REPORTER   = "activate_reporter"
 	DEACTIVATE_REPORTER = "deactivate_reporter"
 	REFRESH_REPORTER    = "refresh_reporter"
+
+	GET_PEER_COUNT = "get_peer_count"
+	SYNC           = "sync"
 )

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -101,6 +101,7 @@ func (a *App) subscribeLibp2pEvent(ctx context.Context, sub event.Subscription) 
 }
 
 func (a *App) handleEvent(ctx context.Context, e interface{}) {
+	log.Info().Str("Player", "Libp2pHelper").Msg("Disconnect event catched, triggering resync")
 	evt := e.(event.EvtPeerConnectednessChanged)
 	if evt.Connectedness == network.NotConnected {
 		for i := 1; i < 4; i++ {

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -94,13 +94,13 @@ func (a *App) subscribeLibp2pEvent(ctx context.Context, sub event.Subscription) 
 				sub.Close()
 				return
 			case e := <-sub.Out():
-				a.handleEvent(ctx, e)
+				a.handleDisconnectEvent(ctx, e)
 			}
 		}
 	}()
 }
 
-func (a *App) handleEvent(ctx context.Context, e interface{}) {
+func (a *App) handleDisconnectEvent(ctx context.Context, e interface{}) {
 	log.Info().Str("Player", "Libp2pHelper").Msg("Disconnect event catched, triggering resync")
 	evt := e.(event.EvtPeerConnectednessChanged)
 	if evt.Connectedness == network.NotConnected {

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -83,6 +83,9 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 			return
 		}
 		msg.Response <- bus.MessageResponse{Success: true}
+	default:
+		bus.HandleMessageError(errorSentinel.ErrBusUnknownCommand, msg, "libp2p helper received unknown command")
+		return
 	}
 }
 

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -1,0 +1,135 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/bus"
+	errorSentinel "bisonai.com/orakl/node/pkg/error"
+	"bisonai.com/orakl/node/pkg/libp2p/setup"
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/rs/zerolog/log"
+)
+
+type App struct {
+	Host host.Host
+	Bus  *bus.MessageBus
+
+	IsRunning bool
+	cancel    context.CancelFunc
+}
+
+func New(bus *bus.MessageBus, h host.Host) *App {
+	return &App{
+		Bus:  bus,
+		Host: h,
+	}
+}
+
+func (a *App) Run(ctx context.Context) error {
+	if a.IsRunning {
+		return nil
+	}
+
+	a.IsRunning = true
+	ctx, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
+
+	defer a.subscribe(ctx)
+
+	sub, err := a.Host.EventBus().Subscribe([]interface{}{
+		new(event.EvtPeerConnectednessChanged),
+	})
+	if err != nil {
+		return fmt.Errorf("event subscription failed: %w", err)
+	}
+
+	a.subscribeLibp2pEvent(ctx, sub)
+	return nil
+}
+
+func (a *App) Stop() {
+	if !a.IsRunning {
+		return
+	}
+	a.IsRunning = false
+	a.cancel()
+}
+
+func (a *App) subscribe(ctx context.Context) {
+	log.Debug().Str("Player", "Libp2pHelper").Msg("subscribing to libp2pHelper topics")
+	channel := a.Bus.Subscribe(bus.LIBP2P)
+	go func() {
+		log.Debug().Str("Player", "Libp2pHelper").Msg("starting libp2p subscription goroutine")
+		for {
+			select {
+			case msg := <-channel:
+				log.Debug().
+					Str("Player", "Libp2pHelper").
+					Str("from", msg.From).
+					Str("to", msg.To).
+					Str("command", msg.Content.Command).
+					Msg("libp2p received bus message")
+				go a.handleMessage(ctx, msg)
+			case <-ctx.Done():
+				log.Debug().Str("Player", "Libp2pHelper").Msg("stopping libp2pHelper subscription goroutine")
+				return
+			}
+		}
+	}()
+}
+
+func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
+	if msg.To != bus.LIBP2P {
+		log.Debug().Str("Player", "Libp2pHelper").Msg("message not for libp2pHelper")
+		return
+	}
+	if msg.From != bus.ADMIN {
+		bus.HandleMessageError(errorSentinel.ErrBusNonAdmin, msg, "libp2pHelper received message from non-admin")
+	}
+
+	switch msg.Content.Command {
+	case bus.GET_PEER_COUNT:
+		log.Debug().Str("Player", "Libp2pHelper").Msg("get peer count msg received")
+		peerCount := len(a.Host.Network().Peers())
+		msg.Response <- bus.MessageResponse{Success: true, Args: map[string]any{"Count": peerCount}}
+	case bus.SYNC:
+		log.Debug().Str("Player", "Libp2pHelper").Msg("libp2p sync msg received")
+		err := setup.ConnectThroughBootApi(ctx, a.Host)
+		if err != nil {
+			bus.HandleMessageError(err, msg, "failed to sync through boot api")
+			return
+		}
+		msg.Response <- bus.MessageResponse{Success: true}
+	}
+}
+
+func (a *App) subscribeLibp2pEvent(ctx context.Context, sub event.Subscription) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				sub.Close()
+				return
+			case e := <-sub.Out():
+				a.handleEvent(ctx, e)
+			}
+		}
+	}()
+}
+
+func (a *App) handleEvent(ctx context.Context, e interface{}) {
+	if evt, ok := e.(event.EvtPeerConnectednessChanged); ok && evt.Connectedness == network.NotConnected {
+		for i := 1; i < 4; i++ {
+			// do not attempt immediate resync, but give some time
+			time.Sleep(time.Duration(i) * time.Minute)
+			err := setup.ConnectThroughBootApi(ctx, a.Host)
+			if err != nil {
+				log.Error().Err(err).Str("Player", "Libp2pHelper").Msg("Error occurred on boot API sync")
+			}
+		}
+	}
+}

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -17,9 +17,6 @@ import (
 type App struct {
 	Host host.Host
 	Bus  *bus.MessageBus
-
-	IsRunning bool
-	cancel    context.CancelFunc
 }
 
 func New(bus *bus.MessageBus, h host.Host) *App {
@@ -30,14 +27,6 @@ func New(bus *bus.MessageBus, h host.Host) *App {
 }
 
 func (a *App) Run(ctx context.Context) error {
-	if a.IsRunning {
-		return nil
-	}
-
-	a.IsRunning = true
-	ctx, cancel := context.WithCancel(ctx)
-	a.cancel = cancel
-
 	defer a.subscribe(ctx)
 
 	sub, err := a.Host.EventBus().Subscribe([]interface{}{
@@ -49,14 +38,6 @@ func (a *App) Run(ctx context.Context) error {
 
 	a.subscribeLibp2pEvent(ctx, sub)
 	return nil
-}
-
-func (a *App) Stop() {
-	if !a.IsRunning {
-		return
-	}
-	a.IsRunning = false
-	a.cancel()
 }
 
 func (a *App) subscribe(ctx context.Context) {

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -75,7 +75,7 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		log.Debug().Str("Player", "Libp2pHelper").Msg("get peer count msg received")
 		peerCount := len(a.Host.Network().Peers())
 		msg.Response <- bus.MessageResponse{Success: true, Args: map[string]any{"Count": peerCount}}
-	case bus.SYNC:
+	case bus.LIBP2P_SYNC:
 		log.Debug().Str("Player", "Libp2pHelper").Msg("libp2p sync msg received")
 		err := setup.ConnectThroughBootApi(ctx, a.Host)
 		if err != nil {

--- a/node/pkg/libp2p/helper/app.go
+++ b/node/pkg/libp2p/helper/app.go
@@ -29,9 +29,7 @@ func New(bus *bus.MessageBus, h host.Host) *App {
 func (a *App) Run(ctx context.Context) error {
 	defer a.subscribe(ctx)
 
-	sub, err := a.Host.EventBus().Subscribe([]interface{}{
-		new(event.EvtPeerConnectednessChanged),
-	})
+	sub, err := a.Host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
 	if err != nil {
 		return fmt.Errorf("event subscription failed: %w", err)
 	}
@@ -103,7 +101,8 @@ func (a *App) subscribeLibp2pEvent(ctx context.Context, sub event.Subscription) 
 }
 
 func (a *App) handleEvent(ctx context.Context, e interface{}) {
-	if evt, ok := e.(event.EvtPeerConnectednessChanged); ok && evt.Connectedness == network.NotConnected {
+	evt := e.(event.EvtPeerConnectednessChanged)
+	if evt.Connectedness == network.NotConnected {
 		for i := 1; i < 4; i++ {
 			// do not attempt immediate resync, but give some time
 			time.Sleep(time.Duration(i) * time.Minute)

--- a/node/pkg/libp2p/setup/setup.go
+++ b/node/pkg/libp2p/setup/setup.go
@@ -56,6 +56,17 @@ func ConnectThroughBootApi(ctx context.Context, h host.Host) error {
 			continue
 		}
 
+		alreadyConnected := false
+		for _, p := range h.Network().Peers() {
+			if info.ID == p {
+				alreadyConnected = true
+				break
+			}
+		}
+		if alreadyConnected {
+			continue
+		}
+
 		err = retrier.Retry(func() error {
 			return h.Connect(ctx, *info)
 		}, 5, 1*time.Second, 5*time.Second)

--- a/node/pkg/libp2p/tests/helper_test.go
+++ b/node/pkg/libp2p/tests/helper_test.go
@@ -21,7 +21,10 @@ func TestNewApp(t *testing.T) {
 
 	mb := bus.New(10)
 
-	_ = helper.New(mb, h)
+	app := helper.New(mb, h)
+	assert.NotNil(t, app)
+	assert.Equal(t, mb, app.Bus)
+	assert.Equal(t, h, app.Host)
 }
 
 func TestAppRunAndStop(t *testing.T) {
@@ -34,6 +37,7 @@ func TestAppRunAndStop(t *testing.T) {
 	mb := bus.New(10)
 
 	libp2pHelper := helper.New(mb, h)
+	assert.NotNil(t, libp2pHelper)
 	err = libp2pHelper.Run(ctx)
 	if err != nil {
 		t.Errorf("Failed to run: %v", err)
@@ -54,6 +58,7 @@ func TestAppGetPeerCount(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to run: %v", err)
 	}
+	assert.NotNil(t, libp2pHelper)
 
 	msg := bus.Message{
 		From: bus.ADMIN,

--- a/node/pkg/libp2p/tests/helper_test.go
+++ b/node/pkg/libp2p/tests/helper_test.go
@@ -37,10 +37,6 @@ func TestAppRunAndStop(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to run: %v", err)
 	}
-	assert.True(t, libp2pHelper.IsRunning)
-
-	libp2pHelper.Stop()
-	assert.False(t, libp2pHelper.IsRunning)
 }
 
 func TestAppGetPeerCount(t *testing.T) {

--- a/node/pkg/libp2p/tests/helper_test.go
+++ b/node/pkg/libp2p/tests/helper_test.go
@@ -1,0 +1,78 @@
+//nolint:all
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"bisonai.com/orakl/node/pkg/bus"
+	"bisonai.com/orakl/node/pkg/libp2p/helper"
+	"bisonai.com/orakl/node/pkg/libp2p/setup"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewApp(t *testing.T) {
+	h, err := setup.NewHost(context.Background())
+	if err != nil {
+		t.Errorf("Failed to make host: %v", err)
+	}
+	defer h.Close()
+
+	mb := bus.New(10)
+
+	_ = helper.New(mb, h)
+}
+
+func TestAppRunAndStop(t *testing.T) {
+	ctx := context.Background()
+	h, err := setup.NewHost(context.Background())
+	if err != nil {
+		t.Errorf("Failed to make host: %v", err)
+	}
+	defer h.Close()
+	mb := bus.New(10)
+
+	libp2pHelper := helper.New(mb, h)
+	err = libp2pHelper.Run(ctx)
+	if err != nil {
+		t.Errorf("Failed to run: %v", err)
+	}
+	assert.True(t, libp2pHelper.IsRunning)
+
+	libp2pHelper.Stop()
+	assert.False(t, libp2pHelper.IsRunning)
+}
+
+func TestAppGetPeerCount(t *testing.T) {
+	ctx := context.Background()
+	h, err := setup.NewHost(context.Background())
+	if err != nil {
+		t.Errorf("Failed to make host: %v", err)
+	}
+	defer h.Close()
+	mb := bus.New(10)
+
+	libp2pHelper := helper.New(mb, h)
+	err = libp2pHelper.Run(ctx)
+	if err != nil {
+		t.Errorf("Failed to run: %v", err)
+	}
+
+	msg := bus.Message{
+		From: bus.ADMIN,
+		To:   bus.LIBP2P,
+		Content: bus.MessageContent{
+			Command: bus.GET_PEER_COUNT,
+			Args:    nil,
+		},
+		Response: make(chan bus.MessageResponse),
+	}
+	err = mb.Publish(msg)
+	if err != nil {
+		t.Errorf("Failed to publish msg: %v", err)
+	}
+
+	res := <-msg.Response
+	assert.True(t, res.Success)
+	assert.Equal(t, 0, res.Args["Count"].(int))
+}

--- a/node/pkg/libp2p/tests/libp2p_test.go
+++ b/node/pkg/libp2p/tests/libp2p_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMakeHost(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
+	h, err := setup.NewHost(context.Background())
 	if err != nil {
 		t.Errorf("Failed to make host: %v", err)
 	}
@@ -18,7 +18,7 @@ func TestMakeHost(t *testing.T) {
 }
 
 func TestMakePubsub(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
+	h, err := setup.NewHost(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to make host: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestMakePubsub(t *testing.T) {
 }
 
 func TestGetHostAddress(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
+	h, err := setup.NewHost(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to make host: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestGetHostAddress(t *testing.T) {
 }
 
 func TestReplaceIp(t *testing.T) {
-	h, err := setup.NewHost(context.Background(), setup.WithHolePunch())
+	h, err := setup.NewHost(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to make host: %v", err)
 	}

--- a/node/taskfiles/taskfile.local.yml
+++ b/node/taskfiles/taskfile.local.yml
@@ -183,7 +183,7 @@ tasks:
   renew-signer:
     dotenv: [".env"]
     cmds:
-      - curl -X POST "http://localhost:$APP_PORT/api/v1/aggregator/renew-signer" | jq
+      - curl -X POST "http://localhost:$APP_PORT/api/v1/aggregator/renew-signer"
   add-json-rpc:
     dotenv: [".env"]
     cmds:
@@ -201,6 +201,14 @@ tasks:
     dotenv: [".env"]
     cmds:
       - curl -X GET "http://localhost:$APP_PORT/api/v1/provider-url" | jq
+  get-peer-count:
+    dotenv: [".env"]
+    cmds:
+      - curl -X GET "http://localhost:$APP_PORT/api/v1/host/peercount" | jq
+  sync-libp2p:
+    dotenv: [".env"]
+    cmds:
+      - curl -X POST "http://localhost:$APP_PORT/api/v1/host/sync"
   test:
     cmds:
       - task: test-db


### PR DESCRIPTION
# Description

## Libp2p Helper (`./pkg/libp2p/helper.app.go`)

This will run alongside with other application on node start

1. Receives command through message bus with following commands

> - `GET_PEER_COUNT` : returns peer count inside orakl cluster
> - `LIBP2P_SYNC` : execute sync, reconnect to existing peers in the cluster

2. Listens to libp2p event, attempt synchronization on peer disconnect event

## New Admin Route (`./pkg/admin/host`)

Sentinel will use the endpoint to track number of peers 
- `/peercount`: returns number of peers inside cluster
- `/sync`: execute sync, reconnect to existing peers in the cluster

## New cli command

- `get-peer-count`, `sync-libp2p`

## Minor Updates

1. Add unique constraint into peers table, preventing duplicate peer entry
2. Update peer insert query to insert only if there's no duplicate entry
3. Update `ConnectThroughBootApi` function to skip peer connection attempt if already connected
4. Test codes included


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
