### PR TITLE
fix oversubmission query timestamp issue

### DIFF
--- a/sentinel/pkg/checker/event/types.go
+++ b/sentinel/pkg/checker/event/types.go
@@ -69,9 +69,9 @@ func feedEventQuery(schemaName string) string {
 	return fmt.Sprintf(`SELECT time FROM %s.feed_feed_updated ORDER BY time DESC LIMIT 1;`, schemaName)
 }
 
-func feedLastMinEventQuery(schemaName string, interval int) string {
+func feedLastIntervalEventQuery(schemaName string, interval int) string {
 	intervalInSeconds := interval / 1000
-	return fmt.Sprintf(`SELECT COUNT(*) FROM %s.feed_feed_updated WHERE time >= NOW() - INTERVAL '%d seconds';`, schemaName, intervalInSeconds)
+	return fmt.Sprintf(`SELECT COUNT(*) FROM %s.feed_feed_updated WHERE time >= EXTRACT(EPOCH FROM NOW()) - %d;`, schemaName, intervalInSeconds)
 }
 
 func aggregatorEventQuery(schemaName string) string {


### PR DESCRIPTION
# Description

Issue: `time` column has been treated as timestamp but turned out it's data type is numeric
Solution: convert `now()` into a numeric value (unit is seconds) as well and subtract the interval (unit is seconds)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
