### PR TITLE
(BootAPI) Keep boot host alive

### DIFF
--- a/.github/workflows/boot-api.test.yaml
+++ b/.github/workflows/boot-api.test.yaml
@@ -39,22 +39,6 @@ jobs:
           cache-dependency-path: |
             ./node/go.sum
 
-      - name: Run lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.54
-          working-directory: node/pkg/boot
-          skip-pkg-cache: true
-          skip-build-cache: true
-          args: --timeout=10m
-
-      - name: Run Vet
-        run: |
-          cd ./node/pkg/boot
-          go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
-          go vet ./...
-          go vet -vettool=$(which shadow) ./...
-
       - name: Install golang-migrate
         run: |
           curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -14,6 +14,7 @@ import (
 	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
 	"github.com/gofiber/fiber/v2"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
 )
 
@@ -39,12 +40,18 @@ func Run(ctx context.Context) error {
 		port = "8089"
 	}
 
+	h, err := libp2pSetup.NewHost(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to make host")
+		return err
+	}
+
 	refreshTicker := time.NewTicker(REFRESH_INTERVAL)
 	go func() {
 		for {
 			select {
 			case <-refreshTicker.C:
-				err = RefreshJob(ctx)
+				err = RefreshJob(ctx, h)
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to refresh peers")
 				}
@@ -71,7 +78,7 @@ func Run(ctx context.Context) error {
 
 }
 
-func RefreshJob(ctx context.Context) error {
+func RefreshJob(ctx context.Context, h host.Host) error {
 	log.Info().Msg("Refreshing peers")
 	peers, err := db.QueryRows[peer.PeerModel](ctx, peer.GetPeer, nil)
 	if err != nil {
@@ -83,14 +90,7 @@ func RefreshJob(ctx context.Context) error {
 		return nil
 	}
 
-	h, err := libp2pSetup.NewHost(ctx, libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(0))
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to make host")
-		return err
-	}
-
 	for _, p := range peers {
-
 		isAlive, liveCheckErr := libp2pUtils.IsHostAlive(ctx, h, p.Url)
 		if liveCheckErr != nil {
 			log.Error().Err(liveCheckErr).Msg("Failed to check peer")
@@ -107,12 +107,6 @@ func RefreshJob(ctx context.Context) error {
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to delete peer")
 		}
-	}
-
-	err = h.Close()
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to close host")
-		return err
 	}
 
 	return nil

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context) error {
 	}
 
 	app.Use(func(c *fiber.Ctx) error {
-		c.Locals("host", &h)
+		c.Locals("host", h)
 		return c.Next()
 	})
 

--- a/node/pkg/boot/boot.go
+++ b/node/pkg/boot/boot.go
@@ -29,22 +29,16 @@ func Run(ctx context.Context) error {
 		return err
 	}
 
-	app, err := utils.Setup(ctx)
+	app, err := utils.Setup(ctx, &h)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to setup boot server")
 		return err
 	}
 
-	app.Use(func(c *fiber.Ctx) error {
-		c.Locals("host", h)
-		return c.Next()
-	})
-
 	v1 := app.Group("/api/v1")
 	v1.Get("/", func(c *fiber.Ctx) error {
 		return c.SendString("Orakl Node Boot API")
 	})
-
 	peer.Routes(v1)
 
 	port := os.Getenv("BOOT_API_PORT")

--- a/node/pkg/boot/peer/controller.go
+++ b/node/pkg/boot/peer/controller.go
@@ -31,12 +31,11 @@ func sync(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString("Failed to validate request")
 	}
 
-	rawHost, ok := c.Locals("host").(*host.Host)
+	h, ok := c.Locals("host").(host.Host)
 	if !ok {
 		log.Error().Msg("Failed to get host")
 		return c.Status(fiber.StatusInternalServerError).SendString("Failed to get host")
 	}
-	h := *rawHost
 
 	defer func() {
 		closeErr := h.Close()

--- a/node/pkg/boot/peer/controller.go
+++ b/node/pkg/boot/peer/controller.go
@@ -31,20 +31,13 @@ func sync(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString("Failed to validate request")
 	}
 
-	h, ok := c.Locals("host").(host.Host)
+	h, ok := c.Locals("host").(*host.Host)
 	if !ok {
 		log.Error().Msg("Failed to get host")
 		return c.Status(fiber.StatusInternalServerError).SendString("Failed to get host")
 	}
 
-	defer func() {
-		closeErr := h.Close()
-		if closeErr != nil {
-			log.Error().Err(closeErr).Msg("Failed to close host")
-		}
-	}()
-
-	isAlive, err := libp2pUtils.IsHostAlive(c.Context(), h, payload.Url)
+	isAlive, err := libp2pUtils.IsHostAlive(c.Context(), *h, payload.Url)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to check peer")
 		return c.Status(fiber.StatusInternalServerError).SendString("Failed to check peer")

--- a/node/pkg/boot/peer/controller.go
+++ b/node/pkg/boot/peer/controller.go
@@ -2,10 +2,10 @@ package peer
 
 import (
 	"bisonai.com/orakl/node/pkg/db"
-	libp2pSetup "bisonai.com/orakl/node/pkg/libp2p/setup"
 	libp2pUtils "bisonai.com/orakl/node/pkg/libp2p/utils"
 	"github.com/go-playground/validator"
 	"github.com/gofiber/fiber/v2"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
 )
 
@@ -31,11 +31,13 @@ func sync(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString("Failed to validate request")
 	}
 
-	h, err := libp2pSetup.NewHost(c.Context(), libp2pSetup.WithHolePunch(), libp2pSetup.WithPort(0))
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to make host")
-		return c.Status(fiber.StatusInternalServerError).SendString("Failed to make host")
+	rawHost, ok := c.Locals("host").(*host.Host)
+	if !ok {
+		log.Error().Msg("Failed to get host")
+		return c.Status(fiber.StatusInternalServerError).SendString("Failed to get host")
 	}
+	h := *rawHost
+
 	defer func() {
 		closeErr := h.Close()
 		if closeErr != nil {

--- a/node/pkg/boot/tests/peer_test.go
+++ b/node/pkg/boot/tests/peer_test.go
@@ -103,7 +103,13 @@ func TestRefresh(t *testing.T) {
 
 	assert.Equal(t, res.Url, url, "expected to have the same url")
 
-	err = boot.RefreshJob(ctx)
+	bootHost, err := libp2pSetup.NewHost(ctx)
+	if err != nil {
+		t.Fatalf("error making host: %v", err)
+	}
+	defer bootHost.Close()
+
+	err = boot.RefreshJob(ctx, bootHost)
 	if err != nil {
 		t.Fatalf("error refreshing peers: %v", err)
 	}
@@ -117,7 +123,7 @@ func TestRefresh(t *testing.T) {
 
 	h.Close()
 
-	err = boot.RefreshJob(ctx)
+	err = boot.RefreshJob(ctx, bootHost)
 	if err != nil {
 		t.Fatalf("error refreshing peers: %v", err)
 	}

--- a/node/pkg/boot/utils/utils.go
+++ b/node/pkg/boot/utils/utils.go
@@ -13,10 +13,11 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
 )
 
-func Setup(ctx context.Context) (*fiber.App, error) {
+func Setup(ctx context.Context, h *host.Host) (*fiber.App, error) {
 	_, err := db.GetPool(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("error getting db pool")
@@ -37,6 +38,11 @@ func Setup(ctx context.Context) (*fiber.App, error) {
 	))
 
 	app.Use(cors.New())
+	app.Use(func(c *fiber.Ctx) error {
+
+		c.Locals("host", h)
+		return c.Next()
+	})
 	return app, nil
 
 }


### PR DESCRIPTION
# Description

Instead of generating new libp2p host every time the check happens, use single host for repeated checks

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
