### PR TITLE
(BootAPI) Remove unnecessary disconnection

### DIFF
--- a/node/pkg/libp2p/utils/utils.go
+++ b/node/pkg/libp2p/utils/utils.go
@@ -61,11 +61,6 @@ func IsHostAlive(ctx context.Context, h host.Host, addr string) (bool, error) {
 		return false, errorSentinel.ErrLibP2pFailToConnectPeer
 	}
 
-	err = h.Network().ClosePeer(info.ID)
-	if err != nil {
-		return false, err
-	}
-
 	return true, nil
 }
 


### PR DESCRIPTION
# Description

Refresh job is run every 10 seconds, checking if hosts in db is alive or not. previously it was kept disconnecting at the end of `IsHostAlive` call. however, it has been revealed that this is not reflected to peer count from opponent host immediately. 

Rather just keeping it connected seems to reduce unexpected updates of peer count, making number of peers easier to be tracked later through sentinel.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
