### PR TITLE
(Sentinel) Group feed checks by its submission interval

### DIFF
--- a/sentinel/pkg/checker/event/app.go
+++ b/sentinel/pkg/checker/event/app.go
@@ -146,7 +146,7 @@ func checkGroupedFeeds(ctx context.Context, feedsByInterval map[int][]FeedToChec
 func checkFeeds(ctx context.Context, feedsToCheck []FeedToCheck) {
 	msg := ""
 	for i := range feedsToCheck {
-		msg = checkEachFeed(ctx, &feedsToCheck[i])
+		msg += checkEachFeed(ctx, &feedsToCheck[i])
 	}
 	if msg != "" {
 		alert.SlackAlert(msg)

--- a/sentinel/pkg/checker/event/app.go
+++ b/sentinel/pkg/checker/event/app.go
@@ -117,11 +117,11 @@ func Start(ctx context.Context) error {
 
 func groupFeedsByInterval(FeedsToCheck []FeedToCheck) map[int][]FeedToCheck {
 	result := make(map[int][]FeedToCheck)
-	for i, feed := range FeedsToCheck {
+	for _, feed := range FeedsToCheck {
 		if result[feed.ExpectedInterval] == nil {
 			result[feed.ExpectedInterval] = make([]FeedToCheck, 0)
 		}
-		result[feed.ExpectedInterval] = append(result[feed.ExpectedInterval], FeedsToCheck[i])
+		result[feed.ExpectedInterval] = append(result[feed.ExpectedInterval], feed)
 	}
 	return result
 }


### PR DESCRIPTION
# Description

Group feeds to check by its submission interval (ex, 15 sec, 1hr)

make submission event checks based on submission interval
if submission interval is 15sec -> check every 15sec

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
