### PR TITLE
get multiple data feed by symbols

### DIFF
--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -177,7 +177,7 @@ func getSymbols(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
-func getLatestFeeds(c *fiber.Ctx) error {
+func getAllLatestFeeds(c *fiber.Ctx) error {
 	controller, ok := c.Locals("apiController").(*Controller)
 	if !ok {
 		return errors.New("api controller not found")
@@ -187,7 +187,7 @@ func getLatestFeeds(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
-func getLatestMultipleFeeds(c *fiber.Ctx) error {
+func getLatestFeeds(c *fiber.Ctx) error {
 	controller, ok := c.Locals("apiController").(*Controller)
 	if !ok {
 		return errors.New("api controller not found")
@@ -204,6 +204,10 @@ func getLatestMultipleFeeds(c *fiber.Ctx) error {
 	for i, symbol := range symbols {
 		if !strings.Contains(symbol, "-") {
 			return fmt.Errorf("wrong symbol format: %s, symbol should be in {BASE}-{QUOTE} format", symbol)
+		}
+
+		if symbol == "" {
+			continue
 		}
 
 		if !strings.Contains(symbol, "test") {

--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"bisonai.com/orakl/node/pkg/common/types"
@@ -186,29 +187,36 @@ func getLatestFeeds(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
-func getLatestFeed(c *fiber.Ctx) error {
+func getLatestMultipleFeeds(c *fiber.Ctx) error {
 	controller, ok := c.Locals("apiController").(*Controller)
 	if !ok {
 		return errors.New("api controller not found")
 	}
 
-	symbol := c.Params("symbol")
+	symbolsStr := c.Params("symbols")
 
-	if symbol == "" {
+	if symbolsStr == "" {
 		return errors.New("invalid symbol: empty symbol")
 	}
-	if !strings.Contains(symbol, "-") {
-		return errors.New("symbol should be in {BASE}-{QUOTE} format")
+
+	symbols := strings.Split(symbolsStr, ",")
+	results := make([]*dalcommon.OutgoingSubmissionData, len(symbols))
+	for i, symbol := range symbols {
+		if !strings.Contains(symbol, "-") {
+			return fmt.Errorf("wrong symbol format: %s, symbol should be in {BASE}-{QUOTE} format", symbol)
+		}
+
+		if !strings.Contains(symbol, "test") {
+			symbol = strings.ToUpper(symbol)
+		}
+
+		result, err := controller.Collector.GetLatestData(symbol)
+		if err != nil {
+			return err
+		}
+
+		results[i] = result
 	}
 
-	if !strings.Contains(symbol, "test") {
-		symbol = strings.ToUpper(symbol)
-	}
-
-	result, err := controller.Collector.GetLatestData(symbol)
-	if err != nil {
-		return err
-	}
-
-	return c.JSON(*result)
+	return c.JSON(results)
 }

--- a/node/pkg/dal/api/route.go
+++ b/node/pkg/dal/api/route.go
@@ -9,7 +9,7 @@ func Routes(router fiber.Router) {
 	api := router.Group("/dal")
 
 	api.Get("/symbols", getSymbols)
-	api.Get("/latest-data-feeds/all", getLatestFeeds)
-	api.Get("/latest-data-feeds/:symbols", getLatestMultipleFeeds)
+	api.Get("/latest-data-feeds/all", getAllLatestFeeds)
+	api.Get("/latest-data-feeds/:symbols", getLatestFeeds)
 	api.Get("/ws", websocket.New(HandleWebsocket))
 }

--- a/node/pkg/dal/api/route.go
+++ b/node/pkg/dal/api/route.go
@@ -10,6 +10,6 @@ func Routes(router fiber.Router) {
 
 	api.Get("/symbols", getSymbols)
 	api.Get("/latest-data-feeds/all", getLatestFeeds)
-	api.Get("/latest-data-feeds/:symbol", getLatestFeed)
+	api.Get("/latest-data-feeds/:symbols", getLatestMultipleFeeds)
 	api.Get("/ws", websocket.New(HandleWebsocket))
 }

--- a/node/pkg/dal/tests/api_test.go
+++ b/node/pkg/dal/tests/api_test.go
@@ -136,7 +136,7 @@ func TestApiGetLatest(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	result, err := request.Request[common.OutgoingSubmissionData](request.WithEndpoint("http://localhost:8090/api/v1/dal/latest-data-feeds/test-aggregate"), request.WithHeaders(map[string]string{"X-API-Key": testItems.ApiKey}))
+	result, err := request.Request[[]common.OutgoingSubmissionData](request.WithEndpoint("http://localhost:8090/api/v1/dal/latest-data-feeds/test-aggregate"), request.WithHeaders(map[string]string{"X-API-Key": testItems.ApiKey}))
 	if err != nil {
 		t.Fatalf("error getting latest data: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestApiGetLatest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error converting sample submission data to outgoing data: %v", err)
 	}
-	assert.Equal(t, *expected, result)
+	assert.Equal(t, *expected, result[0])
 }
 
 func TestApiWebsocket(t *testing.T) {

--- a/node/pkg/dal/utils/initializer/initializer.go
+++ b/node/pkg/dal/utils/initializer/initializer.go
@@ -46,7 +46,7 @@ func Setup(ctx context.Context, apiController *api.Controller, keyCache *keycach
 
 	app := fiber.New(fiber.Config{
 		AppName:           "Data Availability Layer API 0.1.0",
-		EnablePrintRoutes: false,
+		EnablePrintRoutes: true,
 		ErrorHandler:      CustomErrorHandler,
 	})
 


### PR DESCRIPTION
# Description

Related issue: https://github.com/Bisonai/orakl/issues/1777

 - update `getLatestFeed` api to `getLatestMutlipleFeeds`
 - takes a list of symbols as a param separated by comma
 - returns an array of requested data

[Updated docs](https://www.notion.so/bisonai/DAL-API-Beta-4685cad8dad741b39b68942dea10928d?pvs=4)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
