### PR TITLE
(Sentinel) Dal api freshness checker

### DIFF
--- a/.github/workflows/sentinel.test.yaml
+++ b/.github/workflows/sentinel.test.yaml
@@ -36,22 +36,6 @@ jobs:
           cache-dependency-path: |
             ./sentinel/go.sum
 
-      - name: Run lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.54
-          working-directory: sentinel
-          skip-pkg-cache: true
-          skip-build-cache: true
-          args: --timeout=10m
-
-      - name: Run Vet
-        run: |
-          cd ./sentinel
-          go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
-          go vet ./...
-          go vet -vettool=$(which shadow) ./...
-
       - name: Install dependencies
         run: |
           cd ./sentinel

--- a/sentinel/.env.example
+++ b/sentinel/.env.example
@@ -19,5 +19,6 @@ SUBMISSION_PROXY_CONTRACT=
 DATABASE_URL=
 SLACK_WEBHOOK_URL=
 
-# (optional)Additional signers to be checked ex. "0x12,0x13"
-SIGNER=
+
+# (optional) defaults to 10s
+DAL_CHECK_INTERVAL=

--- a/sentinel/cmd/main.go
+++ b/sentinel/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"bisonai.com/orakl/sentinel/pkg/checker/balance"
+	"bisonai.com/orakl/sentinel/pkg/checker/dal"
 	"bisonai.com/orakl/sentinel/pkg/checker/event"
 	"bisonai.com/orakl/sentinel/pkg/checker/health"
 	"bisonai.com/orakl/sentinel/pkg/checker/peers"
@@ -105,6 +106,18 @@ func main() {
 	}()
 
 	log.Info().Msg("peers checker started")
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := dal.Start()
+		if err != nil {
+			log.Error().Err(err).Msg("error starting dal checker")
+			os.Exit(1)
+		}
+	}()
+
+	log.Info().Msg("dal checker started")
 
 	wg.Wait()
 }

--- a/sentinel/pkg/checker/balance/app_test.go
+++ b/sentinel/pkg/checker/balance/app_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
@@ -84,7 +85,7 @@ func TestLoadWalletFromDelegator(t *testing.T) {
 
 func TestGetBalance(t *testing.T) {
 	ctx := context.Background()
-	err := setClient("https://klaytn-baobab.g.allthatnode.com/full/evm")
+	err := setClient(os.Getenv("JSON_RPC_URL"))
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/sentinel/pkg/checker/dal/app.go
+++ b/sentinel/pkg/checker/dal/app.go
@@ -1,0 +1,89 @@
+package dal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"bisonai.com/orakl/sentinel/pkg/alert"
+	"bisonai.com/orakl/sentinel/pkg/request"
+	"bisonai.com/orakl/sentinel/pkg/secrets"
+	"github.com/rs/zerolog/log"
+)
+
+const DefaultDalCheckInterval = 10 * time.Second
+
+type OutgoingSubmissionData struct {
+	Symbol        string   `json:"symbol"`
+	Value         string   `json:"value"`
+	AggregateTime string   `json:"aggregateTime"`
+	Proof         []byte   `json:"proof"`
+	FeedHash      [32]byte `json:"feedHash"`
+	Decimals      string   `json:"decimals"`
+}
+
+func Start() error {
+	interval, err := time.ParseDuration(os.Getenv("DAL_CHECK_INTERVAL"))
+	if err != nil {
+		interval = DefaultDalCheckInterval
+	}
+
+	chain := os.Getenv("CHAIN")
+	if chain == "" {
+		return errors.New("CHAIN not found")
+	}
+
+	key := secrets.GetSecret("DAL_API_KEY")
+	if key == "" {
+		return errors.New("DAL_API_KEY not found")
+	}
+
+	endpoint := fmt.Sprintf("https://dal.%s.orakl.network/api/v1", chain)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		err := checkDal(endpoint, key)
+		if err != nil {
+			log.Error().Str("Player", "DalChecker").Err(err).Msg("error in checkDal")
+		}
+	}
+	return nil
+}
+
+func checkDal(endpoint string, key string) error {
+	msg := ""
+
+	resp, err := request.Request[[]OutgoingSubmissionData](
+		request.WithEndpoint(endpoint+"/dal/latest-data-feeds/all"),
+		request.WithHeaders(map[string]string{"X-API-Key": key}),
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, data := range resp {
+		rawTimestamp, err := strconv.ParseInt(data.AggregateTime, 10, 64)
+		if err != nil {
+			log.Error().Str("Player", "DalChecker").Err(err).Msg("failed to convert timestamp string to int64")
+			continue
+		}
+
+		timestamp := time.Unix(rawTimestamp, 0)
+		offset := time.Since(timestamp)
+		log.Debug().Str("Player", "DalChecker").Str("symbol", data.Symbol).Time("timestamp", timestamp).Dur("offset", offset).Msg("DAL price check")
+
+		if offset > 5*time.Second {
+			msg += fmt.Sprintf("(DAL) %s price update delayed by %s\n", data.Symbol, offset)
+		}
+	}
+
+	if msg != "" {
+		alert.SlackAlert(msg)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

Every 10 seconds it'll call dal api endpoint `/dal/latest-data-feeds/all` and check response data freshness
if response data freshness is over 5 seconds, it'll send alarm to slack

(Before deploying this update, the vault secret `DAL_API_KEY` should be updated)

* also removed lint & vet check from github action test for sentinel

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image
