### PR TITLE
(Sentinel) Higher Delegator balance alarm threshold for mainnet

### DIFF
--- a/sentinel/pkg/checker/balance/app.go
+++ b/sentinel/pkg/checker/balance/app.go
@@ -113,6 +113,9 @@ func Start(ctx context.Context) error {
 func loadEnvs() {
 	SubmitterAlarmAmount = 25
 	DelegatorAlarmAmount = 10000
+	if os.Getenv("CHAIN") == "cypress" {
+		DelegatorAlarmAmount = 50000
+	}
 	BalanceCheckInterval = 60 * time.Second
 	BalanceAlarmInterval = 30 * time.Minute
 

--- a/sentinel/pkg/checker/balance/app_test.go
+++ b/sentinel/pkg/checker/balance/app_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/klaytn/klaytn/common"
@@ -84,7 +85,7 @@ func TestLoadWalletFromDelegator(t *testing.T) {
 
 func TestGetBalance(t *testing.T) {
 	ctx := context.Background()
-	err := setClient("https://klaytn-baobab.g.allthatnode.com/full/evm")
+	err := setClient(os.Getenv("JSON_RPC_URL"))
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}


### PR DESCRIPTION
# Description

increase delegator alarm amount to 50000

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
