### PR TITLE
(DAL) Add endpoint which returns in different format

### DIFF
--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -233,7 +233,7 @@ func getLatestFeeds(c *fiber.Ctx) error {
 	return c.JSON(results)
 }
 
-func getLatestFeedsBulk(c *fiber.Ctx) error {
+func getLatestFeedsTransposed(c *fiber.Ctx) error {
 	controller, ok := c.Locals("apiController").(*Controller)
 	if !ok {
 		return errors.New("api controller not found")
@@ -275,7 +275,7 @@ func getLatestFeedsBulk(c *fiber.Ctx) error {
 	return c.JSON(bulk)
 }
 
-func getAllLatestFeedsBulk(c *fiber.Ctx) error {
+func getAllLatestFeedsTransposed(c *fiber.Ctx) error {
 	controller, ok := c.Locals("apiController").(*Controller)
 	if !ok {
 		return errors.New("api controller not found")

--- a/node/pkg/dal/api/route.go
+++ b/node/pkg/dal/api/route.go
@@ -10,8 +10,8 @@ func Routes(router fiber.Router) {
 
 	api.Get("/symbols", getSymbols)
 	api.Get("/latest-data-feeds/all", getAllLatestFeeds)
-	api.Get("/latest-data-feeds/bulk/all", getAllLatestFeedsBulk)
-	api.Get("/latest-data-feeds/bulk/:symbols", getLatestFeedsBulk)
+	api.Get("/latest-data-feeds/transpose/all", getAllLatestFeedsTransposed)
+	api.Get("/latest-data-feeds/transpose/:symbols", getLatestFeedsTransposed)
 	api.Get("/latest-data-feeds/:symbols", getLatestFeeds)
 	api.Get("/ws", websocket.New(HandleWebsocket))
 }

--- a/node/pkg/dal/api/route.go
+++ b/node/pkg/dal/api/route.go
@@ -10,6 +10,8 @@ func Routes(router fiber.Router) {
 
 	api.Get("/symbols", getSymbols)
 	api.Get("/latest-data-feeds/all", getAllLatestFeeds)
-	api.Get("/latest-data-feeds/:symbols", getLatestFeeds)
+	api.Get("/latest-data-feeds/bulk/all", getAllLatestFeedsBulk)
+	api.Get("/latest-data-feeds/bulk/:symbols", getLatestFeedsBulk)
+	api.Get("/latest-data-feeds/:symbols", getLatestFeedsBulk)
 	api.Get("/ws", websocket.New(HandleWebsocket))
 }

--- a/node/pkg/dal/api/route.go
+++ b/node/pkg/dal/api/route.go
@@ -12,6 +12,6 @@ func Routes(router fiber.Router) {
 	api.Get("/latest-data-feeds/all", getAllLatestFeeds)
 	api.Get("/latest-data-feeds/bulk/all", getAllLatestFeedsBulk)
 	api.Get("/latest-data-feeds/bulk/:symbols", getLatestFeedsBulk)
-	api.Get("/latest-data-feeds/:symbols", getLatestFeedsBulk)
+	api.Get("/latest-data-feeds/:symbols", getLatestFeeds)
 	api.Get("/ws", websocket.New(HandleWebsocket))
 }

--- a/node/pkg/dal/api/types.go
+++ b/node/pkg/dal/api/types.go
@@ -25,3 +25,12 @@ type Controller struct {
 
 	mu sync.RWMutex
 }
+
+type BulkResponse struct {
+	Symbols        []string   `json:"symbols"`
+	Values         []string   `json:"values"`
+	AggregateTimes []string   `json:"aggregateTimes"`
+	Proofs         [][]byte   `json:"proofs"`
+	FeedHashes     [][32]byte `json:"feedHashes"`
+	Decimals       []string   `json:"decimals"`
+}


### PR DESCRIPTION
# Description

Adds two endpoints

```
api.Get("/latest-data-feeds/bulk/all", getAllLatestFeedsBulk)
api.Get("/latest-data-feeds/bulk/:symbols", getLatestFeedsBulk)
```

it'll return data in following format
```
{
    "symbols": [
...
    ],
    "values": [
...
    ],
    "aggregateTimes": [
...
    ],
    "proofs": [
....
    ],
    "feedHashes": [
  ...
    ],
    "decimals": [
...
    ]
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
