### PR TITLE
(DAL) IP based ws limit, CloseHandler, Refactoring

### DIFF
--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -138,7 +138,7 @@ func (c *Controller) startBroadCast() {
 	}
 
 	for symbol := range c.configs {
-		c.broadcastDataForSymbol(symbol)
+		go c.broadcastDataForSymbol(symbol)
 	}
 }
 

--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -55,8 +55,8 @@ func (c *Controller) Start(ctx context.Context) {
 	go c.Collector.Start(ctx)
 	log.Info().Str("Player", "controller").Msg("api collector started")
 	go c.handleConnection(ctx)
-	log.Info().Str("Player", "contrller").Msg("connection handler started")
-	c.startBroadCast()
+	log.Info().Str("Player", "controller").Msg("connection handler started")
+	go c.startBroadCast()
 }
 
 func (c *Controller) handleConnection(ctx context.Context) {

--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -111,16 +111,15 @@ func (c *Controller) configIdToSymbol(id int32) string {
 
 func (c *Controller) broadcastDataForSymbol(symbol string) {
 	for data := range c.broadcast[symbol] {
-		go c.castSubmissionData(&data, &symbol)
+		go c.castSubmissionData(&data, symbol)
 	}
 }
 
-// pass by pointer to reduce memory copy time
-func (c *Controller) castSubmissionData(data *dalcommon.OutgoingSubmissionData, symbol *string) {
+func (c *Controller) castSubmissionData(data *dalcommon.OutgoingSubmissionData, symbol string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for conn := range c.clients {
-		if _, ok := c.clients[conn][*symbol]; ok {
+		if _, ok := c.clients[conn][symbol]; ok {
 			if err := conn.WriteJSON(*data); err != nil {
 				log.Error().Str("Player", "controller").Err(err).Msg("failed to write message")
 				delete(c.clients, conn)

--- a/node/pkg/dal/api/types.go
+++ b/node/pkg/dal/api/types.go
@@ -17,11 +17,12 @@ type Subscription struct {
 type Controller struct {
 	Collector *collector.Collector
 
-	configs    map[string]types.Config
-	clients    map[*websocket.Conn]map[string]bool
-	register   chan *websocket.Conn
-	unregister chan *websocket.Conn
-	broadcast  map[string]chan dalcommon.OutgoingSubmissionData
+	configs         map[string]types.Config
+	clients         map[*websocket.Conn]map[string]bool
+	register        chan *websocket.Conn
+	unregister      chan *websocket.Conn
+	broadcast       map[string]chan dalcommon.OutgoingSubmissionData
+	connectionCount map[string]int
 
 	mu sync.RWMutex
 }

--- a/node/pkg/dal/api/types.go
+++ b/node/pkg/dal/api/types.go
@@ -17,12 +17,11 @@ type Subscription struct {
 type Controller struct {
 	Collector *collector.Collector
 
-	configs         map[string]types.Config
-	clients         map[*websocket.Conn]map[string]bool
-	register        chan *websocket.Conn
-	unregister      chan *websocket.Conn
-	broadcast       map[string]chan dalcommon.OutgoingSubmissionData
-	connectionCount map[string]int
+	configs    map[string]types.Config
+	clients    map[*websocket.Conn]map[string]bool
+	register   chan *websocket.Conn
+	unregister chan *websocket.Conn
+	broadcast  map[string]chan dalcommon.OutgoingSubmissionData
 
 	mu sync.RWMutex
 }

--- a/node/pkg/dal/api/types.go
+++ b/node/pkg/dal/api/types.go
@@ -5,9 +5,12 @@ import (
 
 	"bisonai.com/orakl/node/pkg/common/types"
 	"bisonai.com/orakl/node/pkg/dal/collector"
+
 	dalcommon "bisonai.com/orakl/node/pkg/dal/common"
 	"github.com/gofiber/contrib/websocket"
 )
+
+const DEFAULT_MAX_CONNS = 10
 
 type Subscription struct {
 	Method string   `json:"method"`
@@ -22,8 +25,9 @@ type Controller struct {
 	register   chan *websocket.Conn
 	unregister chan *websocket.Conn
 	broadcast  map[string]chan dalcommon.OutgoingSubmissionData
-
-	mu sync.RWMutex
+	connQueue  map[string][]*websocket.Conn
+	maxConns   int
+	mu         sync.RWMutex
 }
 
 type BulkResponse struct {

--- a/node/pkg/dal/api/websocketcontroller.go
+++ b/node/pkg/dal/api/websocketcontroller.go
@@ -25,7 +25,7 @@ func HandleWebsocket(conn *websocket.Conn) {
 
 	ctxPointer, ok := conn.Locals("context").(*context.Context)
 	if !ok {
-		log.Error().Str("Player", "controller").Msg("ctx not found")
+		log.Error().Str("Player", "controller").Str("RemoteAddr", conn.RemoteAddr().String()).Msg("ctx not found")
 		return
 	}
 
@@ -36,7 +36,7 @@ func HandleWebsocket(conn *websocket.Conn) {
 
 	id, err := stats.InsertWebsocketConnection(ctx, apiKey)
 	if err != nil {
-		log.Error().Str("Player", "controller").Err(err).Msg("failed to insert websocket connection")
+		log.Error().Str("Player", "controller").Str("RemoteAddr", conn.RemoteAddr().String()).Err(err).Msg("failed to insert websocket connection")
 		return
 	}
 	log.Info().Str("Player", "controller").Int32("id", id).Msg("inserted websocket connection")
@@ -45,7 +45,7 @@ func HandleWebsocket(conn *websocket.Conn) {
 		conn.CloseHandler()(websocket.CloseNormalClosure, "normal closure")
 		err = stats.UpdateWebsocketConnection(ctx, id)
 		if err != nil {
-			log.Error().Str("Player", "controller").Err(err).Msg("failed to update websocket connection")
+			log.Error().Str("Player", "controller").Str("RemoteAddr", conn.RemoteAddr().String()).Err(err).Msg("failed to update websocket connection")
 			return
 		}
 		log.Info().Str("Player", "controller").Int32("id", id).Msg("updated websocket connection")
@@ -53,7 +53,7 @@ func HandleWebsocket(conn *websocket.Conn) {
 
 	for {
 		if err := handleMessage(ctx, conn, c, id); err != nil {
-			log.Error().Str("Player", "controller").Err(err).Msg("failed to handle message")
+			log.Error().Str("Player", "controller").Str("RemoteAddr", conn.RemoteAddr().String()).Err(err).Msg("failed to handle message")
 			return
 		}
 	}

--- a/node/pkg/dal/api/websocketcontroller.go
+++ b/node/pkg/dal/api/websocketcontroller.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"bisonai.com/orakl/node/pkg/dal/utils/stats"
+	"github.com/gofiber/contrib/websocket"
+	"github.com/rs/zerolog/log"
+)
+
+func HandleWebsocket(conn *websocket.Conn) {
+	c, ok := conn.Locals("apiController").(*Controller)
+	if !ok {
+		log.Error().Str("Player", "controller").Msg("api controller not found")
+		return
+	}
+
+	closeHandler := conn.CloseHandler()
+	conn.SetCloseHandler(func(code int, text string) error {
+		log.Info().Str("Player", "controller").Int("code", code).Str("text", text).Msg("close handler")
+		c.unregister <- conn
+		return closeHandler(code, text)
+	})
+
+	ctxPointer, ok := conn.Locals("context").(*context.Context)
+	if !ok {
+		log.Error().Str("Player", "controller").Msg("ctx not found")
+		return
+	}
+
+	ctx := *ctxPointer
+	apiKey := conn.Headers("X-Api-Key")
+	c.mu.RLock()
+	if c.connectionCount[apiKey] >= 10 {
+		log.Error().Str("Player", "controller").Msg("too many connections")
+		c.mu.RUnlock()
+		return
+	}
+	c.mu.RUnlock()
+
+	c.register <- conn
+
+	id, err := stats.InsertWebsocketConnection(ctx, apiKey)
+	if err != nil {
+		log.Error().Str("Player", "controller").Err(err).Msg("failed to insert websocket connection")
+		return
+	}
+	log.Info().Str("Player", "controller").Int32("id", id).Msg("inserted websocket connection")
+
+	defer func() {
+		conn.CloseHandler()(websocket.CloseNormalClosure, "normal closure")
+		err = stats.UpdateWebsocketConnection(ctx, id)
+		if err != nil {
+			log.Error().Str("Player", "controller").Err(err).Msg("failed to update websocket connection")
+			return
+		}
+		log.Info().Str("Player", "controller").Int32("id", id).Msg("updated websocket connection")
+	}()
+
+	subscriptionTimer := time.NewTimer(5 * time.Second)
+	defer subscriptionTimer.Stop()
+
+	go func(ctx context.Context, conn *websocket.Conn, subscriptionTimer *time.Timer, c *Controller) {
+		for {
+			select {
+			case <-subscriptionTimer.C:
+				conn.CloseHandler()(websocket.ClosePolicyViolation, "no subscription in 5 seconds")
+				return
+			case <-ctx.Done():
+				conn.CloseHandler()(websocket.CloseNormalClosure, "normal closure")
+				return
+			}
+		}
+	}(ctx, conn, subscriptionTimer, c)
+
+	for {
+		if err := handleMessage(ctx, conn, c, id, subscriptionTimer); err != nil {
+			log.Error().Str("Player", "controller").Err(err).Msg("failed to handle message")
+			return
+		}
+	}
+}
+
+func handleMessage(ctx context.Context, conn *websocket.Conn, c *Controller, id int32, subscriptionTimer *time.Timer) error {
+	var msg Subscription
+	if err := conn.ReadJSON(&msg); err != nil {
+		return err
+	}
+
+	if msg.Method == "SUBSCRIBE" {
+		subscriptionTimer.Stop()
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.clients[conn] == nil {
+			c.clients[conn] = make(map[string]bool)
+		}
+		addedSymbols := make([]string, 0, len(msg.Params))
+		for _, param := range msg.Params {
+			symbol := strings.TrimPrefix(param, "submission@")
+			if _, ok := c.configs[symbol]; !ok {
+				continue
+			}
+
+			if _, ok := c.clients[conn][symbol]; ok {
+				continue
+			}
+
+			c.clients[conn][symbol] = true
+			addedSymbols = append(addedSymbols, symbol)
+		}
+		defer func() {
+			err := stats.InsertWebsocketSubscriptions(ctx, id, addedSymbols)
+			if err != nil {
+				log.Error().Str("Player", "controller").Err(err).Msg("failed to insert websocket subscriptions")
+			}
+		}()
+	}
+
+	return nil
+}

--- a/node/pkg/dal/k6/script.js
+++ b/node/pkg/dal/k6/script.js
@@ -1,0 +1,84 @@
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { check } from "k6";
+
+import ws from "k6/ws";
+const sessionDuration = randomIntBetween(120000, 240000);
+const msg =
+  '{"method":"SUBSCRIBE","params":["submission@ADA-KRW","submission@AKT-KRW","submission@AAVE-KRW","submission@ADA-USDT","submission@ATOM-USDT","submission@APT-KRW","submission@ASTR-KRW","submission@AUCTION-KRW","submission@AVAX-USDT","submission@ARB-KRW","submission@AVAX-KRW","submission@BCH-KRW","submission@BLUR-KRW","submission@AXS-KRW","submission@BLAST-KRW","submission@BNB-USDT","submission@BORA-KRW","submission@BTC-KRW","submission@BTC-USDT","submission@BSV-KRW","submission@CHF-USD","submission@BTG-KRW","submission@BTT-KRW","submission@BONK-KRW","submission@CHZ-KRW","submission@CTC-KRW","submission@DAI-USDT","submission@DOGE-USDT","submission@DOGE-KRW","submission@DOT-KRW","submission@DOT-USDT","submission@ENS-KRW","submission@EOS-KRW","submission@ETH-USDT","submission@ETC-KRW","submission@FET-KRW","submission@FTM-USDT","submission@FLOW-KRW","submission@GAS-KRW","submission@GBP-USD","submission@GLM-KRW","submission@ETH-KRW","submission@GRT-KRW","submission@HPO-KRW","submission@HBAR-KRW","submission@EUR-USD","submission@IQ-KRW","submission@JOY-USDT","submission@IMX-KRW","submission@JPY-USD","submission@KLAY-KRW","submission@KLAY-USDT","submission@KNC-KRW","submission@KRW-USD","submission@LINK-KRW","submission@KSP-KRW","submission@LTC-USDT","submission@MBL-KRW","submission@MATIC-KRW","submission@MBX-KRW","submission@MED-KRW","submission@MATIC-USDT","submission@MLK-KRW","submission@MINA-KRW","submission@MNR-KRW","submission@NEAR-KRW","submission@MTL-KRW","submission@ONDO-KRW","submission@ONG-KRW","submission@PEPE-KRW","submission@SAND-KRW","submission@PYTH-KRW","submission@PAXG-USDT","submission@SEI-KRW","submission@SHIB-KRW","submission@SNT-KRW","submission@PER-KLAY","submission@SHIB-USDT","submission@PEPE-USDT","submission@SOL-USDT","submission@SOL-KRW","submission@STPT-KRW","submission@STG-KRW","submission@STX-KRW","submission@STRK-KRW","submission@TRX-KRW","submission@SUI-KRW","submission@TRX-USDT","submission@USDT-KRW","submission@WEMIX-KRW","submission@USDT-USD","submission@USDC-USDT","submission@WEMIX-USDT","submission@WLD-KRW","submission@WAVES-KRW","submission@XEC-KRW","submission@XLM-KRW","submission@XRP-KRW","submission@XRP-USDT","submission@ZK-KRW","submission@ZETA-KRW","submission@ZRO-KRW","submission@UNI-USDT"]}';
+export const options = {
+  // A number specifying the number of VUs to run concurrently.
+  vus: 120,
+  // A string specifying the total duration of the test run.
+  iterations: 240,
+
+  // The following section contains configuration options for execution of this
+  // test script in Grafana Cloud.
+  //
+  // See https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/
+  // to learn about authoring and running k6 test scripts in Grafana k6 Cloud.
+  //
+  // cloud: {
+  //   // The ID of the project to which the test is assigned in the k6 Cloud UI.
+  //   // By default tests are executed in default project.
+  //   projectID: "",
+  //   // The name of the test in the k6 Cloud UI.
+  //   // Test runs with the same name will be grouped.
+  //   name: "script.js"
+  // },
+
+  // Uncomment this section to enable the use of Browser API in your tests.
+  //
+  // See https://grafana.com/docs/k6/latest/using-k6-browser/running-browser-tests/ to learn more
+  // about using Browser API in your test scripts.
+  //
+  // scenarios: {
+  //   // The scenario name appears in the result summary, tags, and so on.
+  //   // You can give the scenario any name, as long as each name in the script is unique.
+  //   ui: {
+  //     // Executor is a mandatory parameter for browser-based tests.
+  //     // Shared iterations in this case tells k6 to reuse VUs to execute iterations.
+  //     //
+  //     // See https://grafana.com/docs/k6/latest/using-k6/scenarios/executors/ for other executor types.
+  //     executor: 'shared-iterations',
+  //     options: {
+  //       browser: {
+  //         // This is a mandatory parameter that instructs k6 to launch and
+  //         // connect to a chromium-based browser, and use it to run UI-based
+  //         // tests.
+  //         type: 'chromium',
+  //       },
+  //     },
+  //   },
+  // }
+};
+
+// The function that defines VU logic.
+//
+// See https://grafana.com/docs/k6/latest/examples/get-started-with-k6/ to learn more
+// about authoring k6 scripts.
+//
+export default function () {
+  const url = "ws://dal.baobab.orakl.network/ws";
+  const params = { headers: { "X-API-Key": "" } };
+
+  const res = ws.connect(url, params, function (socket) {
+    socket.on("open", function open() {
+      console.log("connected");
+      socket.send(msg);
+    });
+
+    socket.on("ping", function () {
+      console.log("PING!");
+    });
+
+    socket.on("message", (data) => console.log("Message received: ", data));
+    socket.on("close", () => console.log("disconnected"));
+
+    socket.setTimeout(function () {
+      console.log(`Closing the socket forcefully 3s after graceful LEAVE`);
+      socket.close();
+    }, sessionDuration + 15000);
+  });
+
+  check(res, { "status is 101": (r) => r && r.status === 101 });
+}

--- a/node/pkg/dal/tests/api_test.go
+++ b/node/pkg/dal/tests/api_test.go
@@ -163,58 +163,97 @@ func TestApiWebsocket(t *testing.T) {
 
 	go testItems.App.Listen(":8090")
 
-	conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
-	if err != nil {
-		t.Fatalf("error creating websocket helper: %v", err)
-	}
+	t.Run("test subscription", func(t *testing.T) {
+		conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
+		if err != nil {
+			t.Fatalf("error creating websocket helper: %v", err)
+		}
 
-	err = conn.Dial(ctx)
-	if err != nil {
-		t.Fatalf("error dialing websocket: %v", err)
-	}
+		err = conn.Dial(ctx)
+		if err != nil {
+			t.Fatalf("error dialing websocket: %v", err)
+		}
 
-	err = conn.Write(ctx, api.Subscription{
-		Method: "SUBSCRIBE",
-		Params: []string{"submission@test-aggregate"},
+		err = conn.Write(ctx, api.Subscription{
+			Method: "SUBSCRIBE",
+			Params: []string{"submission@test-aggregate"},
+		})
+		if err != nil {
+			t.Fatalf("error subscribing to websocket: %v", err)
+		}
+
+		sampleSubmissionData, err := generateSampleSubmissionData(
+			testItems.TmpConfig.ID,
+			int64(15),
+			time.Now(),
+			1,
+			"test-aggregate",
+		)
+		if err != nil {
+			t.Fatalf("error generating sample submission data: %v", err)
+		}
+
+		err = testPublishData(ctx, *sampleSubmissionData)
+		if err != nil {
+			t.Fatalf("error publishing sample submission data: %v", err)
+		}
+
+		ch := make(chan any)
+		go conn.Read(ctx, ch)
+
+		expected, err := testItems.Controller.Collector.IncomingDataToOutgoingData(ctx, *sampleSubmissionData)
+		if err != nil {
+			t.Fatalf("error converting sample submission data to outgoing data: %v", err)
+		}
+
+		sample := <-ch
+
+		result, err := wsfcommon.MessageToStruct[common.OutgoingSubmissionData](sample.(map[string]any))
+		if err != nil {
+			t.Fatalf("error converting sample to struct: %v", err)
+		}
+		assert.Equal(t, *expected, result)
+		err = conn.Close()
+		if err != nil {
+			t.Fatalf("error closing websocket: %v", err)
+		}
 	})
-	if err != nil {
-		t.Fatalf("error subscribing to websocket: %v", err)
-	}
 
-	sampleSubmissionData, err := generateSampleSubmissionData(
-		testItems.TmpConfig.ID,
-		int64(15),
-		time.Now(),
-		1,
-		"test-aggregate",
-	)
-	if err != nil {
-		t.Fatalf("error generating sample submission data: %v", err)
-	}
+	t.Run("test disconnection on no subscription", func(t *testing.T) {
+		conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
+		if err != nil {
+			t.Fatalf("error creating websocket helper: %v", err)
+		}
 
-	err = testPublishData(ctx, *sampleSubmissionData)
-	if err != nil {
-		t.Fatalf("error publishing sample submission data: %v", err)
-	}
+		err = conn.Dial(ctx)
+		if err != nil {
+			t.Fatalf("error dialing websocket: %v", err)
+		}
 
-	ch := make(chan any)
-	go conn.Read(ctx, ch)
+		time.Sleep(6 * time.Second) // Sleep longer than the subscription timeout period
+		assert.Error(t, conn.IsAlive(ctx), "expected to fail due to no subscription")
 
-	expected, err := testItems.Controller.Collector.IncomingDataToOutgoingData(ctx, *sampleSubmissionData)
-	if err != nil {
-		t.Fatalf("error converting sample submission data to outgoing data: %v", err)
-	}
+		err = conn.Close()
+		if err != nil {
+			t.Fatalf("error closing websocket: %v", err)
+		}
+	})
 
-	sample := <-ch
+	t.Run("test fail for 10+ dial", func(t *testing.T) {
+		conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
+		if err != nil {
+			t.Fatalf("error creating websocket helper: %v", err)
+		}
 
-	result, err := wsfcommon.MessageToStruct[common.OutgoingSubmissionData](sample.(map[string]any))
-	if err != nil {
-		t.Fatalf("error converting sample to struct: %v", err)
-	}
-	assert.Equal(t, *expected, result)
+		for i := 0; i < 10; i++ {
+			err = conn.Dial(ctx)
+			if err != nil {
+				t.Fatalf("error dialing websocket: %v", err)
+			}
+		}
 
-	err = conn.Close()
-	if err != nil {
-		t.Fatalf("error closing websocket: %v", err)
-	}
+		err = conn.Dial(ctx)
+		assert.NoError(t, err)
+		assert.Error(t, conn.IsAlive(ctx), "expected to fail due to no subscription")
+	})
 }

--- a/node/pkg/dal/tests/api_test.go
+++ b/node/pkg/dal/tests/api_test.go
@@ -218,42 +218,4 @@ func TestApiWebsocket(t *testing.T) {
 			t.Fatalf("error closing websocket: %v", err)
 		}
 	})
-
-	t.Run("test disconnection on no subscription", func(t *testing.T) {
-		conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
-		if err != nil {
-			t.Fatalf("error creating websocket helper: %v", err)
-		}
-
-		err = conn.Dial(ctx)
-		if err != nil {
-			t.Fatalf("error dialing websocket: %v", err)
-		}
-
-		time.Sleep(6 * time.Second) // Sleep longer than the subscription timeout period
-		assert.Error(t, conn.IsAlive(ctx), "expected to fail due to no subscription")
-
-		err = conn.Close()
-		if err != nil {
-			t.Fatalf("error closing websocket: %v", err)
-		}
-	})
-
-	t.Run("test fail for 10+ dial", func(t *testing.T) {
-		conn, err := wss.NewWebsocketHelper(ctx, wss.WithEndpoint("ws://localhost:8090/ws"), wss.WithRequestHeaders(headers))
-		if err != nil {
-			t.Fatalf("error creating websocket helper: %v", err)
-		}
-
-		for i := 0; i < 10; i++ {
-			err = conn.Dial(ctx)
-			if err != nil {
-				t.Fatalf("error dialing websocket: %v", err)
-			}
-		}
-
-		err = conn.Dial(ctx)
-		assert.NoError(t, err)
-		assert.Error(t, conn.IsAlive(ctx), "expected to fail due to no subscription")
-	})
 }

--- a/node/pkg/dal/utils/stats/stats.go
+++ b/node/pkg/dal/utils/stats/stats.go
@@ -71,6 +71,14 @@ func InsertWebsocketSubscription(ctx context.Context, connectionId int32, topic 
 	})
 }
 
+func InsertWebsocketSubscriptions(ctx context.Context, connectionId int32, topics []string) error {
+	rows := make([][]any, 0, len(topics))
+	for _, topic := range topics {
+		rows = append(rows, []any{connectionId, topic})
+	}
+	return db.BulkInsert(ctx, "websocket_subscriptions", []string{"connection_id", "topic"}, rows)
+}
+
 func StatsMiddleware(c *fiber.Ctx) error {
 	start := time.Now()
 	if err := c.Next(); err != nil {

--- a/node/pkg/wss/utils.go
+++ b/node/pkg/wss/utils.go
@@ -281,6 +281,20 @@ func (ws *WebsocketHelper) Close() error {
 	return nil
 }
 
+func (ws *WebsocketHelper) IsAlive(ctx context.Context) error {
+	if ws.Conn == nil {
+		return fmt.Errorf("websocket is not running")
+	}
+	ctx = ws.Conn.CloseRead(ctx)
+
+	err := ws.Conn.Ping(ctx)
+	if err != nil {
+		log.Error().Err(err).Str("endpoint", ws.Endpoint).Msg("error pinging websocket")
+		return err
+	}
+	return nil
+}
+
 func defaultReader(ctx context.Context, conn *websocket.Conn) (map[string]interface{}, error) {
 	var data map[string]interface{}
 	err := wsjson.Read(ctx, conn, &data)


### PR DESCRIPTION
# Description



## IP Limit

default limits to 10 websocket connection per ip

## CloseHandler

CloseHandler is called on client side disconnection
```
        closeHandler := conn.CloseHandler()
	conn.SetCloseHandler(func(code int, text string) error {
		log.Info().Str("Player", "controller").Int("code", code).Str("text", text).Msg("close handler")
		c.unregister <- conn
		return closeHandler(code, text)
	})
```

Custom closeHandler which overwrites default closeHandler so that it can automatically signal unregister on disconnection from client side.

## Refactoring

- Separated file `websocketcontroller` from `controller`
- Separated func `handleMessage` from `handleWebsocket` function
- Encapsulated internal logics inside `Controller.Start` method for readability


## Minor update

- `InsertWebsocketSubscriptions` for bulk insertion of subscription stats
- k6 script for stress testing and memory leak reproduction
- websockethelper `isAlive` func to be later used in test codes so that it can check conn live from client side

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
