### PR TITLE
(DAL) writeControl

### DIFF
--- a/node/pkg/dal/api/hub.go
+++ b/node/pkg/dal/api/hub.go
@@ -49,11 +49,13 @@ func (c *Hub) Start(ctx context.Context, collector *collector.Collector) {
 					delete(c.clients, conn)
 				}
 				c.mu.Unlock()
-				conn.WriteControl(
+				if err := conn.WriteControl(
 					websocket.CloseMessage,
 					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 					time.Now().Add(time.Second),
-				)
+				); err != nil {
+					log.Error().Err(err).Msg("failed to send close message")
+				}
 				conn.Close()
 			}
 		}

--- a/node/pkg/dal/api/hub.go
+++ b/node/pkg/dal/api/hub.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/common/types"
 	"bisonai.com/orakl/node/pkg/dal/collector"
@@ -48,6 +49,11 @@ func (c *Hub) Start(ctx context.Context, collector *collector.Collector) {
 					delete(c.clients, conn)
 				}
 				c.mu.Unlock()
+				conn.WriteControl(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+					time.Now().Add(time.Second),
+				)
 				conn.Close()
 			}
 		}


### PR DESCRIPTION
# Description

Send disconnection message to the client through writeControl

[reference](https://medium.com/@blackhorseya/properly-closing-websocket-connections-in-golang-a902f97716c1)

```
In the WebSocket protocol, a close message is a special control message used to indicate that the endpoint wishes to close the connection. It is an orderly and graceful shutdown process, allowing the peer to send a corresponding close message in response.

After sending a close message, the application typically continues to receive data until it receives a close message from the peer. This ensures that both sides have the opportunity to complete any pending data exchange, adhering to the normal termination process of WebSockets.
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
