### PR TITLE
(OraklNode) Add condition to increase nonce

### DIFF
--- a/node/pkg/chain/helper/helper.go
+++ b/node/pkg/chain/helper/helper.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"math/big"
 	"os"
 	"strings"
@@ -262,7 +263,7 @@ func (t *ChainHelper) SubmitDelegatedFallbackDirect(ctx context.Context, contrac
 			if err != nil {
 				if utils.ShouldRetryWithSwitchedJsonRPC(err) {
 					clientIndex = (clientIndex + 1) % len(t.clients)
-				} else {
+				} else if errors.Is(err, errorSentinel.ErrChainTransactionFail) {
 					nonce, err = noncemanager.GetAndIncrementNonce(t.wallet)
 					if err != nil {
 						return err
@@ -287,7 +288,7 @@ func (t *ChainHelper) SubmitDelegatedFallbackDirect(ctx context.Context, contrac
 		if err != nil {
 			if utils.ShouldRetryWithSwitchedJsonRPC(err) {
 				clientIndex = (clientIndex + 1) % len(t.clients)
-			} else {
+			} else if errors.Is(err, errorSentinel.ErrChainTransactionFail) {
 				nonce, err = noncemanager.GetAndIncrementNonce(t.wallet)
 				if err != nil {
 					return err


### PR DESCRIPTION
# Description

The nonce is incremented only when the transaction is picked up by a miner, included in a block, and the block is successfully added to the blockchain. if the function fails before tx being mined, the nonce shouldn't be increased

This pr update nonce increase condition accordingly

please refer to following code for error `errorSentinel.ErrChainTransactionFail` 
https://github.com/Bisonai/orakl/blob/85b145c908e355a337d66c0f1e2a1e95e99dc9b2/node/pkg/chain/utils/utils.go#L348-L375

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
