### PR TITLE
(DAL) Prevent deadlock from multiple lock and unlock from single func

### DIFF
--- a/node/pkg/dal/api/controller.go
+++ b/node/pkg/dal/api/controller.go
@@ -63,12 +63,13 @@ func HandleWebsocket(conn *websocket.Conn) {
 		}
 
 		if msg.Method == "SUBSCRIBE" {
-			h.mu.RLock()
+			h.mu.Lock()
+
 			subscriptions, ok := h.clients[threadSafeClient]
 			if !ok {
 				subscriptions = map[string]bool{}
 			}
-			h.mu.RUnlock()
+
 			valid := []string{}
 
 			for _, param := range msg.Params {
@@ -79,7 +80,6 @@ func HandleWebsocket(conn *websocket.Conn) {
 				subscriptions[symbol] = true
 				valid = append(valid, param)
 			}
-			h.mu.Lock()
 			h.clients[threadSafeClient] = subscriptions
 			h.mu.Unlock()
 			err = stats.InsertWebsocketSubscriptions(*ctx, id, valid)

--- a/node/pkg/dal/api/hub.go
+++ b/node/pkg/dal/api/hub.go
@@ -118,8 +118,8 @@ func (c *Hub) broadcastDataForSymbol(symbol string) {
 func (c *Hub) castSubmissionData(data *dalcommon.OutgoingSubmissionData, symbol *string) {
 	var wg sync.WaitGroup
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for client, subscriptions := range c.clients {
 		if subscriptions[*symbol] {
 			wg.Add(1)

--- a/node/pkg/dal/api/types.go
+++ b/node/pkg/dal/api/types.go
@@ -18,7 +18,7 @@ type Hub struct {
 	register   chan *ThreadSafeClient
 	unregister chan *ThreadSafeClient
 	broadcast  map[string]chan dalcommon.OutgoingSubmissionData
-	mu         sync.RWMutex
+	mu         sync.Mutex
 }
 
 type BulkResponse struct {


### PR DESCRIPTION
# Description

- `h.clients` access is not thread safe, this update covers full mutex lock for single subscribe command
- also uses Mutex instead of RWMutex

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
