### PR TITLE
(OraklNode) partition `raft` test codes, rollback recover

### DIFF
--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -343,6 +343,11 @@ func (r *Raft) becomeLeader(ctx context.Context) {
 
 			case <-r.LeaderJobTicker.C:
 				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Error().Msgf("recovered from panic in LeaderJob: %v", r)
+						}
+					}()
 					err := r.LeaderJob()
 					if err != nil {
 						log.Error().Err(err).Msg("failed to execute leader job")


### PR DESCRIPTION
# Description

- Separate raft test codes into multiple scenarios
- Rollback recover from leaderjob panic

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
