### PR TITLE
(OraklNode) aggregator roundID mutex & start round id update

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -51,7 +51,7 @@ func (n *Aggregator) Run(ctx context.Context) {
 	if err != nil {
 		log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to get latest round id, setting roundId to 1")
 	} else if latestRoundId > 0 {
-		n.RoundID = latestRoundId
+		n.RoundID = latestRoundId + 1
 	}
 
 	n.Raft.Run(ctx)

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -58,6 +58,8 @@ func (n *Aggregator) Run(ctx context.Context) {
 }
 
 func (n *Aggregator) LeaderJob(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	n.RoundID++
 	n.Raft.IncreaseTerm()
 	return n.PublishTriggerMessage(ctx, n.RoundID, time.Now())

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -76,6 +76,8 @@ type Aggregator struct {
 	nodeCtx    context.Context
 	nodeCancel context.CancelFunc
 	isRunning  bool
+
+	mu sync.Mutex
 }
 
 type PriceDataMessage struct {


### PR DESCRIPTION
# Description

## RoundID mutex lock

RoundID is accessed through go thread which makes it thread unsafe
This PR tries to prevent unexpected outcome due to concurrent access to roundID (but not likely to happen 🥹)

## Start RoundID update

Previous start roundID was set as latest round from db.
it should be latest round id + 1 to prevent duplicate roundID

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
