### PR TITLE
(OraklNode) Prevent duplicate raft message from aggregator

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -33,8 +33,16 @@ func NewAggregator(h host.Host, ps *pubsub.PubSub, topicString string, config Co
 		Config: config,
 		Raft:   raft.NewRaftNode(h, ps, topic, 1000, aggregateInterval),
 
-		roundPrices: &RoundPrices{prices: map[int32][]int64{}},
-		roundProofs: &RoundProofs{proofs: map[int32][][]byte{}},
+		roundPrices: &RoundPrices{
+			prices:  map[int32][]int64{},
+			senders: map[int32][]string{},
+			locked:  map[int32]bool{},
+		},
+		roundProofs: &RoundProofs{
+			proofs:  map[int32][][]byte{},
+			senders: map[int32][]string{},
+			locked:  map[int32]bool{},
+		},
 
 		RoundID:               1,
 		Signer:                signHelper,

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -52,6 +52,17 @@ type Config struct {
 	AggregateInterval int32  `db:"aggregate_interval"`
 }
 
+type RoundTriggers struct {
+	locked map[int32]bool
+	mu     sync.Mutex
+}
+
+func (r *RoundTriggers) cleanup(roundID int32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.locked, roundID)
+}
+
 type RoundPrices struct {
 	senders map[int32][]string
 	prices  map[int32][]int64
@@ -105,6 +116,7 @@ type Aggregator struct {
 	Raft *raft.Raft
 
 	LatestLocalAggregates *LatestLocalAggregates
+	RoundTriggers         *RoundTriggers
 	roundPrices           *RoundPrices
 	roundProofs           *RoundProofs
 

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -53,13 +53,51 @@ type Config struct {
 }
 
 type RoundPrices struct {
-	prices map[int32][]int64
-	mu     sync.Mutex
+	senders map[int32][]string
+	prices  map[int32][]int64
+	locked  map[int32]bool
+	mu      sync.Mutex
+}
+
+func (r *RoundPrices) isReplay(roundID int32, sender string) bool {
+	for _, s := range r.senders[roundID] {
+		if s == sender {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *RoundPrices) cleanup(roundID int32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.senders, roundID)
+	delete(r.prices, roundID)
+	delete(r.locked, roundID)
 }
 
 type RoundProofs struct {
-	proofs map[int32][][]byte
-	mu     sync.Mutex
+	senders map[int32][]string
+	proofs  map[int32][][]byte
+	locked  map[int32]bool
+	mu      sync.Mutex
+}
+
+func (r *RoundProofs) isReplay(roundID int32, sender string) bool {
+	for _, s := range r.senders[roundID] {
+		if s == sender {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *RoundProofs) cleanup(roundID int32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.senders, roundID)
+	delete(r.proofs, roundID)
+	delete(r.locked, roundID)
 }
 
 type Aggregator struct {

--- a/node/pkg/utils/calculator/calculator.go
+++ b/node/pkg/utils/calculator/calculator.go
@@ -51,6 +51,15 @@ func GetInt64Med(nums []int64) (int64, error) {
 	if len(nums) == 0 {
 		return 0, errorSentinel.ErrCalculatorEmptyArr
 	}
+
+	if len(nums) == 1 {
+		return nums[0], nil
+	}
+
+	if len(nums) == 2 {
+		return (nums[0] + nums[1]) / 2, nil
+	}
+
 	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
 	n := len(nums)
 	if n%2 == 0 {


### PR DESCRIPTION
# Description

- store senders per round for price & proof, validate if it has been already sent
- lock round price aggregation or proof generation once it has been executed
- trigger round logic only when prices or proofs equals length of cluster nodes. (previously it was equal or greater than)
- rollback cleanup logic to remove data 20 rounds ago on new round start (approximately 8 secs ago)
- add 'if' statements to bypass sorting from median calculation if length of parameter is lower than 2

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
