### PR TITLE
(OraklNode) Reduce default 120 sec -> 10 sec for msg ttl

### DIFF
--- a/node/pkg/libp2p/setup/type.go
+++ b/node/pkg/libp2p/setup/type.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	"bisonai.com/orakl/node/pkg/secrets"
 
@@ -102,5 +103,5 @@ func NewHost(ctx context.Context, opts ...HostOption) (host.Host, error) {
 
 func MakePubsub(ctx context.Context, host host.Host) (*pubsub.PubSub, error) {
 	log.Debug().Msg("creating pubsub instance")
-	return pubsub.NewGossipSub(ctx, host)
+	return pubsub.NewGossipSub(ctx, host, pubsub.WithSeenMessagesTTL(10*time.Second))
 }


### PR DESCRIPTION
# Description

Set golibp2p pubsub option for message cache ttl

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
