### PR TITLE
(OraklNode) Increase volume fetch interval for certain ws

### DIFF
--- a/node/pkg/websocketfetcher/common/type.go
+++ b/node/pkg/websocketfetcher/common/type.go
@@ -20,6 +20,7 @@ const (
 	GetAllProxiesQuery  = `SELECT * FROM proxies`
 	VolumeCacheLifespan = 10 * time.Minute
 	VolumeFetchInterval = 10000
+	VolumeFetchTimeout  = 6 * time.Second
 )
 
 type Proxy = types.Proxy

--- a/node/pkg/websocketfetcher/providers/bitstamp/utils.go
+++ b/node/pkg/websocketfetcher/providers/bitstamp/utils.go
@@ -44,7 +44,7 @@ func TradeEventToFeedData(data TradeEvent, feedMap map[string]int32, volumeCache
 }
 
 func FetchVolumes(feedMap map[string]int32, volumeCacheMap *common.VolumeCacheMap) error {
-	result, err := request.Request[[]VolumeEntry](request.WithEndpoint(ALL_CURRENCY_PAIR_TICKER_ENDPOINT), request.WithTimeout(3*time.Second))
+	result, err := request.Request[[]VolumeEntry](request.WithEndpoint(ALL_CURRENCY_PAIR_TICKER_ENDPOINT), request.WithTimeout(common.VolumeFetchTimeout))
 	if err != nil {
 		log.Error().Str("Player", "Bitstamp").Err(err).Msg("error in FetchVolumes")
 		return err

--- a/node/pkg/websocketfetcher/providers/btse/utils.go
+++ b/node/pkg/websocketfetcher/providers/btse/utils.go
@@ -42,7 +42,7 @@ func ResponseToFeedDataList(data Response, feedMap map[string]int32, volumeCache
 }
 
 func FetchVolumes(feedMap map[string]int32, volumeCacheMap *common.VolumeCacheMap) error {
-	result, err := request.Request[[]MarketSummary](request.WithEndpoint(MARKET_SUMMARY_ENDPOINT), request.WithTimeout(3*time.Second))
+	result, err := request.Request[[]MarketSummary](request.WithEndpoint(MARKET_SUMMARY_ENDPOINT), request.WithTimeout(common.VolumeFetchTimeout))
 	if err != nil {
 		log.Error().Str("Player", "btse").Err(err).Msg("error in FetchVolumes")
 		return err

--- a/node/pkg/websocketfetcher/providers/gemini/utils.go
+++ b/node/pkg/websocketfetcher/providers/gemini/utils.go
@@ -45,7 +45,7 @@ func TradeResponseToFeedDataList(data Response, feedMap map[string]int32, volume
 func FetchVolumes(feedMap map[string]int32, volumeCacheMap *common.VolumeCacheMap) {
 	for symbol, id := range feedMap {
 		endpoint := TICKER_ENDPOINT + strings.ToLower(symbol)
-		result, err := request.Request[HttpTickerResponse](request.WithEndpoint(endpoint))
+		result, err := request.Request[HttpTickerResponse](request.WithEndpoint(endpoint), request.WithTimeout(common.VolumeFetchTimeout))
 		if err != nil {
 			log.Error().Str("Player", "Gemini").Err(err).Msg("fetch volumes, http request failed")
 			continue


### PR DESCRIPTION
# Description

prevent context deadline exceeded error on caching trading volume
```bash
│ 5:10AM ERR error in FetchVolumes error="Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)" Player=Bitstamp
│ 5:10AM ERR error in fetchVolumes error="Get \"https://www.bitstamp.net/api/v2/ticker/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)" Player=Bitstamp
```
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
