### PR TITLE
(OraklNode) Replace redis into in memory data types

### DIFF
--- a/node/pkg/common/keys/keys.go
+++ b/node/pkg/common/keys/keys.go
@@ -4,14 +4,6 @@ import (
 	"strconv"
 )
 
-func LatestFeedDataKey(feedID int32) string {
-	return "latestFeedData:" + strconv.Itoa(int(feedID))
-}
-
 func SubmissionDataStreamKey(configId int32) string {
 	return "submissionDataStream:" + strconv.Itoa(int(configId))
-}
-
-func FeedDataBufferKey() string {
-	return "feedDataBuffer"
 }

--- a/node/pkg/fetcher/app.go
+++ b/node/pkg/fetcher/app.go
@@ -15,9 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const LocalAggregatesChannelSize = 2_000
-const DefaultLocalAggregateInterval = 200 * time.Millisecond
-
 func New(bus *bus.MessageBus) *App {
 	return &App{
 		Fetchers:         make(map[int32]*Fetcher, 0),
@@ -26,7 +23,7 @@ func New(bus *bus.MessageBus) *App {
 			FeedDataMap: make(map[int32]*FeedData),
 			Mu:          sync.RWMutex{},
 		},
-		FeedDataDumpChannel: make(chan *FeedData, 10000),
+		FeedDataDumpChannel: make(chan *FeedData, DefaultFeedDataDumpChannelSize),
 		Bus:                 bus,
 	}
 }

--- a/node/pkg/fetcher/app.go
+++ b/node/pkg/fetcher/app.go
@@ -407,7 +407,7 @@ func (a *App) initialize(ctx context.Context) error {
 		}
 
 		if len(fetcherFeeds) > 0 {
-			a.Fetchers[config.ID] = NewFetcher(config, fetcherFeeds)
+			a.Fetchers[config.ID] = NewFetcher(config, fetcherFeeds, a.LatestFeedDataMap)
 		}
 
 		// for localAggregator it'll get all feeds to be collected
@@ -415,7 +415,7 @@ func (a *App) initialize(ctx context.Context) error {
 		if getFeedsErr != nil {
 			return getFeedsErr
 		}
-		a.LocalAggregators[config.ID] = NewLocalAggregator(config, localAggregatorFeeds, a.LocalAggregateBulkWriter.localAggregatesChannel, a.Bus)
+		a.LocalAggregators[config.ID] = NewLocalAggregator(config, localAggregatorFeeds, a.LocalAggregateBulkWriter.localAggregatesChannel, a.Bus, a.LatestFeedDataMap)
 	}
 	streamIntervalRaw := os.Getenv("FEED_DATA_STREAM_INTERVAL")
 	streamInterval, err := time.ParseDuration(streamIntervalRaw)

--- a/node/pkg/fetcher/app_test.go
+++ b/node/pkg/fetcher/app_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"bisonai.com/orakl/node/pkg/common/keys"
 	"bisonai.com/orakl/node/pkg/db"
 	"github.com/stretchr/testify/assert"
 )
@@ -87,7 +86,7 @@ func TestAppRun(t *testing.T) {
 	for _, fetcher := range app.Fetchers {
 		for _, feed := range fetcher.Feeds {
 
-			result, letestFeedDataErr := db.GetObject[*FeedData](ctx, keys.LatestFeedDataKey(feed.ID))
+			result, letestFeedDataErr := app.LatestFeedDataMap.GetLatestFeedData([]int32{feed.ID})
 			if letestFeedDataErr != nil {
 				t.Fatalf("error getting latest feed data: %v", letestFeedDataErr)
 			}

--- a/node/pkg/fetcher/feeddatabulkwriter.go
+++ b/node/pkg/fetcher/feeddatabulkwriter.go
@@ -44,16 +44,9 @@ func (s *FeedDataBulkWriter) Job(ctx context.Context) error {
 		return nil
 	case entry := <-s.FeedDataDumpChannel:
 		result := []*FeedData{entry}
-	loop:
-		for {
-			select {
-			case entry := <-s.FeedDataDumpChannel:
-				result = append(result, entry)
-			default:
-				break loop
-			}
+		for entry := range s.FeedDataDumpChannel {
+			result = append(result, entry)
 		}
-
 		return copyFeedData(ctx, result)
 	default:
 		return nil

--- a/node/pkg/fetcher/feeddatabulkwriter.go
+++ b/node/pkg/fetcher/feeddatabulkwriter.go
@@ -44,9 +44,16 @@ func (s *FeedDataBulkWriter) Job(ctx context.Context) error {
 		return nil
 	case entry := <-s.FeedDataDumpChannel:
 		result := []*FeedData{entry}
-		for entry := range s.FeedDataDumpChannel {
-			result = append(result, entry)
+	loop:
+		for {
+			select {
+			case entry := <-s.FeedDataDumpChannel:
+				result = append(result, entry)
+			default:
+				break loop
+			}
 		}
+
 		return copyFeedData(ctx, result)
 	default:
 		return nil

--- a/node/pkg/fetcher/fetcher.go
+++ b/node/pkg/fetcher/fetcher.go
@@ -14,12 +14,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewFetcher(config Config, feeds []Feed) *Fetcher {
+func NewFetcher(config Config, feeds []Feed, latestFeedDataMap *LatestFeedDataMap) *Fetcher {
 	return &Fetcher{
-		Config:     config,
-		Feeds:      feeds,
-		fetcherCtx: nil,
-		cancel:     nil,
+		Config:            config,
+		Feeds:             feeds,
+		fetcherCtx:        nil,
+		cancel:            nil,
+		latestFeedDataMap: latestFeedDataMap,
 	}
 }
 
@@ -59,12 +60,11 @@ func (f *Fetcher) fetcherJob(ctx context.Context, proxies []Proxy) error {
 		return errorSentinel.ErrFetcherNoDataFetched
 	}
 
-	err = setLatestFeedData(ctx, result, time.Duration(f.FetchInterval)*time.Millisecond)
+	err = f.latestFeedDataMap.SetLatestFeedData(result)
 	if err != nil {
-		log.Error().Str("Player", "Fetcher").Err(err).Msg("error in setLatestFeedData")
+		log.Error().Str("Player", "Fetcher").Err(err).Msg("error in SetLatestFeedData")
 		return err
 	}
-
 	return setFeedDataBuffer(ctx, result)
 }
 

--- a/node/pkg/fetcher/fetcher_test.go
+++ b/node/pkg/fetcher/fetcher_test.go
@@ -50,11 +50,6 @@ func TestFetcherRun(t *testing.T) {
 
 	defer func() {
 		db.Del(ctx, keys.FeedDataBufferKey())
-		for _, fetcher := range app.Fetchers {
-			for _, feed := range fetcher.Feeds {
-				db.Del(ctx, keys.LatestFeedDataKey(feed.ID))
-			}
-		}
 	}()
 }
 
@@ -87,7 +82,7 @@ func TestFetcherFetcherJob(t *testing.T) {
 
 	for _, fetcher := range app.Fetchers {
 		for _, feed := range fetcher.Feeds {
-			res, latestFeedDataErr := db.GetObject[*FeedData](ctx, keys.LatestFeedDataKey(feed.ID))
+			res, latestFeedDataErr := app.LatestFeedDataMap.GetLatestFeedData([]int32{feed.ID})
 			if latestFeedDataErr != nil {
 				t.Fatalf("error fetching feed data: %v", latestFeedDataErr)
 			}

--- a/node/pkg/fetcher/fetcher_test.go
+++ b/node/pkg/fetcher/fetcher_test.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 
 	"bisonai.com/orakl/node/pkg/admin/tests"
-	"bisonai.com/orakl/node/pkg/common/keys"
-	"bisonai.com/orakl/node/pkg/db"
 	"github.com/elazarl/goproxy"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -47,10 +45,6 @@ func TestFetcherRun(t *testing.T) {
 	for _, fetcher := range app.Fetchers {
 		fetcher.cancel()
 	}
-
-	defer func() {
-		db.Del(ctx, keys.FeedDataBufferKey())
-	}()
 }
 
 func TestFetcherFetcherJob(t *testing.T) {

--- a/node/pkg/fetcher/fetcher_test.go
+++ b/node/pkg/fetcher/fetcher_test.go
@@ -285,7 +285,11 @@ func TestFetcherFilterProxyByLocation(t *testing.T) {
 		{ID: 3, Protocol: "http", Host: "localhost", Port: 8082, Location: &kr},
 	}
 
-	fetcher := NewFetcher(Config{}, []Feed{})
+	testMap := &LatestFeedDataMap{
+		FeedDataMap: make(map[int32]*FeedData),
+	}
+
+	fetcher := NewFetcher(Config{}, []Feed{}, testMap)
 
 	res := fetcher.filterProxyByLocation(proxies, uk)
 	assert.Greater(t, len(res), 0)

--- a/node/pkg/fetcher/localaggregatebulkwriter_test.go
+++ b/node/pkg/fetcher/localaggregatebulkwriter_test.go
@@ -40,7 +40,7 @@ func TestLocalAggregateBulkWriter(t *testing.T) {
 		if getFeedsErr != nil {
 			t.Fatalf("error getting configs: %v", getFeedsErr)
 		}
-		app.LocalAggregators[config.ID] = NewLocalAggregator(config, localAggregatorFeeds, localAggregatesChannel, testItems.messageBus)
+		app.LocalAggregators[config.ID] = NewLocalAggregator(config, localAggregatorFeeds, localAggregatesChannel, testItems.messageBus, app.LatestFeedDataMap)
 		for _, feed := range localAggregatorFeeds {
 			feedData[keys.LatestFeedDataKey(feed.ID)] = &FeedData{FeedID: feed.ID, Value: DUMMY_FEED_VALUE, Timestamp: nil, Volume: DUMMY_FEED_VALUE}
 		}

--- a/node/pkg/fetcher/localaggregator.go
+++ b/node/pkg/fetcher/localaggregator.go
@@ -10,7 +10,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewLocalAggregator(config Config, feeds []Feed, localAggregatesChannel chan *LocalAggregate, bus *bus.MessageBus) *LocalAggregator {
+func NewLocalAggregator(
+	config Config,
+	feeds []Feed,
+	localAggregatesChannel chan *LocalAggregate,
+	bus *bus.MessageBus,
+	latestFeedDataMap *LatestFeedDataMap) *LocalAggregator {
 	return &LocalAggregator{
 		Config:                 config,
 		Feeds:                  feeds,
@@ -18,6 +23,7 @@ func NewLocalAggregator(config Config, feeds []Feed, localAggregatesChannel chan
 		cancel:                 nil,
 		bus:                    bus,
 		localAggregatesChannel: localAggregatesChannel,
+		latestFeedDataMap:      latestFeedDataMap,
 	}
 }
 
@@ -152,5 +158,5 @@ func (c *LocalAggregator) collect(ctx context.Context) ([]*FeedData, error) {
 	for i, feed := range c.Feeds {
 		feedIds[i] = feed.ID
 	}
-	return getLatestFeedData(ctx, feedIds)
+	return c.latestFeedDataMap.GetLatestFeedData(feedIds)
 }

--- a/node/pkg/fetcher/main_test.go
+++ b/node/pkg/fetcher/main_test.go
@@ -16,7 +16,6 @@ import (
 	"bisonai.com/orakl/node/pkg/admin/tests"
 	"bisonai.com/orakl/node/pkg/admin/utils"
 	"bisonai.com/orakl/node/pkg/bus"
-	"bisonai.com/orakl/node/pkg/common/keys"
 	"bisonai.com/orakl/node/pkg/db"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
@@ -261,13 +260,6 @@ func cleanup(ctx context.Context, testItems *TestItems) func() error {
 		err = db.QueryWithoutResult(ctx, "DELETE FROM feed_data", nil)
 		if err != nil {
 			return err
-		}
-
-		for _, eachFeed := range testItems.insertedFeeds {
-			err = db.Del(ctx, keys.LatestFeedDataKey(*eachFeed.ID))
-			if err != nil {
-				return err
-			}
 		}
 
 		err = testItems.app.stopAllFetchers(ctx)

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -21,6 +21,9 @@ const (
 	DefaultFeedDataDumpInterval           = time.Second * 10
 	ForeignExchangePricePairs             = "GBP-USD,EUR-USD,KRW-USD,JPY-USD,CHF-USD"
 	DefaultMedianRatio                    = 0.05
+	LocalAggregatesChannelSize            = 2_000
+	DefaultLocalAggregateInterval         = 200 * time.Millisecond
+	DefaultFeedDataDumpChannelSize        = 20000
 )
 
 type Feed = types.Feed

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -18,7 +18,7 @@ const (
 	SelectFeedsByConfigIdQuery            = `SELECT * FROM feeds WHERE config_id = @config_id`
 	InsertLocalAggregateQuery             = `INSERT INTO local_aggregates (config_id, value) VALUES (@config_id, @value)`
 	DECIMALS                              = 8
-	DefaultStreamInterval                 = time.Second * 5
+	DefaultFeedDataDumpInterval           = time.Second * 10
 	ForeignExchangePricePairs             = "GBP-USD,EUR-USD,KRW-USD,JPY-USD,CHF-USD"
 	DefaultMedianRatio                    = 0.05
 )
@@ -39,10 +39,11 @@ type Fetcher struct {
 	Config
 	Feeds []Feed
 
-	fetcherCtx        context.Context
-	cancel            context.CancelFunc
-	isRunning         bool
-	latestFeedDataMap *LatestFeedDataMap
+	fetcherCtx          context.Context
+	cancel              context.CancelFunc
+	isRunning           bool
+	latestFeedDataMap   *LatestFeedDataMap
+	FeedDataDumpChannel chan *FeedData
 }
 
 type LocalAggregator struct {
@@ -61,9 +62,10 @@ type LocalAggregator struct {
 type FeedDataBulkWriter struct {
 	Interval time.Duration
 
-	writerCtx context.Context
-	cancel    context.CancelFunc
-	isRunning bool
+	FeedDataDumpChannel chan *FeedData
+	writerCtx           context.Context
+	cancel              context.CancelFunc
+	isRunning           bool
 }
 
 type LocalAggregateBulkWriter struct {
@@ -84,6 +86,7 @@ type App struct {
 	WebsocketFetcher         *websocketfetcher.App
 	LatestFeedDataMap        *LatestFeedDataMap
 	Proxies                  []Proxy
+	FeedDataDumpChannel      chan *FeedData
 }
 
 type Definition struct {

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -27,6 +27,7 @@ type Feed = types.Feed
 type FeedData = types.FeedData
 type LocalAggregate = types.LocalAggregate
 type Proxy = types.Proxy
+type LatestFeedDataMap = types.LatestFeedDataMap
 
 type Config struct {
 	ID            int32  `db:"id"`
@@ -38,9 +39,10 @@ type Fetcher struct {
 	Config
 	Feeds []Feed
 
-	fetcherCtx context.Context
-	cancel     context.CancelFunc
-	isRunning  bool
+	fetcherCtx        context.Context
+	cancel            context.CancelFunc
+	isRunning         bool
+	latestFeedDataMap *LatestFeedDataMap
 }
 
 type LocalAggregator struct {
@@ -53,6 +55,7 @@ type LocalAggregator struct {
 	bus           *bus.MessageBus
 
 	localAggregatesChannel chan *LocalAggregate
+	latestFeedDataMap      *LatestFeedDataMap
 }
 
 type FeedDataBulkWriter struct {
@@ -77,9 +80,10 @@ type App struct {
 	Fetchers                 map[int32]*Fetcher
 	LocalAggregators         map[int32]*LocalAggregator
 	FeedDataBulkWriter       *FeedDataBulkWriter
-	WebsocketFetcher         *websocketfetcher.App
-	Proxies                  []Proxy
 	LocalAggregateBulkWriter *LocalAggregateBulkWriter
+	WebsocketFetcher         *websocketfetcher.App
+	LatestFeedDataMap        *LatestFeedDataMap
+	Proxies                  []Proxy
 }
 
 type Definition struct {

--- a/node/pkg/fetcher/utils.go
+++ b/node/pkg/fetcher/utils.go
@@ -3,7 +3,6 @@ package fetcher
 import (
 	"context"
 	"strings"
-	"time"
 
 	"bisonai.com/orakl/node/pkg/common/keys"
 	"bisonai.com/orakl/node/pkg/db"
@@ -22,15 +21,7 @@ func FetchSingle(ctx context.Context, definition *Definition) (float64, error) {
 	return reducer.Reduce(rawResult, definition.Reducers)
 }
 
-func setLatestFeedData(ctx context.Context, feedData []*FeedData, expiration time.Duration) error {
-	latestData := make(map[string]any)
-	for _, data := range feedData {
-		latestData[keys.LatestFeedDataKey(data.FeedID)] = data
-	}
-	return db.MSetObjectWithExp(ctx, latestData, expiration)
-}
-
-func getLatestFeedData(ctx context.Context, feedIds []int32) ([]*FeedData, error) {
+func getLatestFeedData(ctx context.Context, feedIds []int32) ([]FeedData, error) {
 	if len(feedIds) == 0 {
 		return []*FeedData{}, nil
 	}

--- a/node/pkg/fetcher/utils.go
+++ b/node/pkg/fetcher/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"bisonai.com/orakl/node/pkg/common/keys"
 	"bisonai.com/orakl/node/pkg/db"
 	errorSentinel "bisonai.com/orakl/node/pkg/error"
 	"bisonai.com/orakl/node/pkg/utils/calculator"
@@ -19,15 +18,6 @@ func FetchSingle(ctx context.Context, definition *Definition) (float64, error) {
 		return 0, err
 	}
 	return reducer.Reduce(rawResult, definition.Reducers)
-}
-
-func setFeedDataBuffer(ctx context.Context, feedData []*FeedData) error {
-	return db.LPushObject(ctx, keys.FeedDataBufferKey(), feedData)
-}
-
-func getFeedDataBuffer(ctx context.Context) ([]*FeedData, error) {
-	// buffer flushed on pop all
-	return db.PopAllObject[*FeedData](ctx, keys.FeedDataBufferKey())
 }
 
 func copyFeedData(ctx context.Context, feedData []*FeedData) error {

--- a/node/pkg/fetcher/utils.go
+++ b/node/pkg/fetcher/utils.go
@@ -21,22 +21,6 @@ func FetchSingle(ctx context.Context, definition *Definition) (float64, error) {
 	return reducer.Reduce(rawResult, definition.Reducers)
 }
 
-func getLatestFeedData(ctx context.Context, feedIds []int32) ([]FeedData, error) {
-	if len(feedIds) == 0 {
-		return []*FeedData{}, nil
-	}
-	keyList := make([]string, len(feedIds))
-	for i, feedId := range feedIds {
-		keyList[i] = keys.LatestFeedDataKey(feedId)
-	}
-	feedData, err := db.MGetObject[*FeedData](ctx, keyList)
-	if err != nil {
-		return nil, err
-	}
-
-	return feedData, nil
-}
-
 func setFeedDataBuffer(ctx context.Context, feedData []*FeedData) error {
 	return db.LPushObject(ctx, keys.FeedDataBufferKey(), feedData)
 }

--- a/node/pkg/fetcher/utils_test.go
+++ b/node/pkg/fetcher/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"bisonai.com/orakl/node/pkg/common/keys"
 	"bisonai.com/orakl/node/pkg/db"
 	"github.com/stretchr/testify/assert"
 )
@@ -106,66 +105,6 @@ func TestFetchSingle(t *testing.T) {
 	assert.Greater(t, result, float64(0))
 }
 
-func TestSetFeedDataBuffer(t *testing.T) {
-	ctx := context.Background()
-	feedData := []*FeedData{
-		{
-			FeedID: 1,
-			Value:  0.1,
-		},
-		{
-			FeedID: 2,
-			Value:  0.2,
-		},
-	}
-
-	err := setFeedDataBuffer(ctx, feedData)
-	if err != nil {
-		t.Fatalf("error setting feed data buffer: %v", err)
-	}
-
-	defer db.Del(ctx, keys.FeedDataBufferKey())
-
-	result, err := db.LRangeObject[*FeedData](ctx, keys.FeedDataBufferKey(), 0, -1)
-	if err != nil {
-		t.Fatalf("error getting feed data buffer: %v", err)
-	}
-
-	assert.Equal(t, 2, len(result))
-	assert.Contains(t, result, feedData[0])
-	assert.Contains(t, result, feedData[1])
-}
-
-func TestGetFeedDataBuffer(t *testing.T) {
-	ctx := context.Background()
-	feedData := []*FeedData{
-		{
-			FeedID: 1,
-			Value:  0.1,
-		},
-		{
-			FeedID: 2,
-			Value:  0.2,
-		},
-	}
-
-	err := setFeedDataBuffer(ctx, feedData)
-	if err != nil {
-		t.Fatalf("error setting feed data buffer: %v", err)
-	}
-
-	defer db.Del(ctx, keys.FeedDataBufferKey())
-
-	result, err := getFeedDataBuffer(ctx)
-	if err != nil {
-		t.Fatalf("error getting feed data buffer: %v", err)
-	}
-
-	assert.Equal(t, 2, len(result))
-	assert.Contains(t, result, feedData[0])
-	assert.Contains(t, result, feedData[1])
-}
-
 func TestCopyFeedData(t *testing.T) {
 	ctx := context.Background()
 	clean, testItems, err := setup(ctx)
@@ -189,13 +128,6 @@ func TestCopyFeedData(t *testing.T) {
 			Timestamp: &now,
 		})
 	}
-
-	err = setFeedDataBuffer(ctx, feedData)
-	if err != nil {
-		t.Fatalf("error setting feed data buffer: %v", err)
-	}
-
-	defer db.Del(ctx, keys.FeedDataBufferKey())
 
 	err = copyFeedData(ctx, feedData)
 	if err != nil {

--- a/node/pkg/fetcher/utils_test.go
+++ b/node/pkg/fetcher/utils_test.go
@@ -106,69 +106,6 @@ func TestFetchSingle(t *testing.T) {
 	assert.Greater(t, result, float64(0))
 }
 
-func TestSetLatestFeedData(t *testing.T) {
-	ctx := context.Background()
-	feedData := []*FeedData{
-		{
-			FeedID: 1,
-			Value:  0.1,
-		},
-		{
-			FeedID: 2,
-			Value:  0.2,
-		},
-	}
-
-	err := setLatestFeedData(ctx, feedData, 1*time.Second)
-	if err != nil {
-		t.Fatalf("error setting latest feed data: %v", err)
-	}
-	keys := []string{keys.LatestFeedDataKey(1), keys.LatestFeedDataKey(2)}
-
-	defer db.Del(ctx, keys[0])
-	defer db.Del(ctx, keys[1])
-
-	result, err := db.MGetObject[*FeedData](ctx, keys)
-	if err != nil {
-		t.Fatalf("error getting latest feed data: %v", err)
-	}
-
-	assert.Equal(t, 2, len(result))
-	assert.Contains(t, result, feedData[0])
-	assert.Contains(t, result, feedData[1])
-}
-
-func TestGetLatestFeedData(t *testing.T) {
-	ctx := context.Background()
-	feedData := []*FeedData{
-		{
-			FeedID: 1,
-			Value:  0.1,
-		},
-		{
-			FeedID: 2,
-			Value:  0.2,
-		},
-	}
-
-	keys := []string{keys.LatestFeedDataKey(1), keys.LatestFeedDataKey(2)}
-	err := setLatestFeedData(ctx, feedData, 1*time.Second)
-	if err != nil {
-		t.Fatalf("error setting latest feed data: %v", err)
-	}
-	defer db.Del(ctx, keys[0])
-	defer db.Del(ctx, keys[1])
-
-	result, err := getLatestFeedData(ctx, []int32{1, 2})
-	if err != nil {
-		t.Fatalf("error getting latest feed data: %v", err)
-	}
-
-	assert.Equal(t, 2, len(result))
-	assert.Contains(t, result, feedData[0])
-	assert.Contains(t, result, feedData[1])
-}
-
 func TestSetFeedDataBuffer(t *testing.T) {
 	ctx := context.Background()
 	feedData := []*FeedData{

--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -93,7 +93,7 @@ func WithLatestFeedDataMap(latestFeedDataMap *types.LatestFeedDataMap) AppOption
 
 type App struct {
 	fetchers          []common.FetcherInterface
-	buffer            chan common.FeedData
+	buffer            chan *common.FeedData
 	storeInterval     time.Duration
 	chainReader       *websocketchainreader.ChainReader
 	latestFeedDataMap *types.LatestFeedDataMap

--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sync"
 	"time"
 
 	"bisonai.com/orakl/node/pkg/chain/websocketchainreader"
@@ -144,12 +145,15 @@ func (a *App) Init(ctx context.Context, opts ...AppOption) error {
 		StoreInterval: DefaultStoreInterval,
 		LatestFeedDataMap: &types.LatestFeedDataMap{
 			FeedDataMap: make(map[int32]*types.FeedData),
+			Mu:          sync.RWMutex{},
 		},
 	}
 
 	for _, opt := range opts {
 		opt(appConfig)
 	}
+
+	a.latestFeedDataMap = appConfig.LatestFeedDataMap
 
 	if err := a.initializeCex(ctx, *appConfig); err != nil {
 		return err

--- a/node/pkg/websocketfetcher/common/utils.go
+++ b/node/pkg/websocketfetcher/common/utils.go
@@ -53,18 +53,6 @@ func StoreFeeds(ctx context.Context, feedData []*FeedData) error {
 	if len(feedData) == 0 {
 		return nil
 	}
-	latestData := make(map[string]any)
-	for _, data := range feedData {
-		key := keys.LatestFeedDataKey(data.FeedID)
-		if latestData[key] != nil && latestData[key].(*FeedData).Timestamp.After(*data.Timestamp) {
-			continue
-		}
-		latestData[key] = data
-	}
-	err := db.MSetObject(ctx, latestData)
-	if err != nil {
-		return err
-	}
 	return db.LPushObject(ctx, keys.FeedDataBufferKey(), feedData)
 }
 

--- a/node/pkg/websocketfetcher/common/utils.go
+++ b/node/pkg/websocketfetcher/common/utils.go
@@ -3,15 +3,12 @@ package common
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"io"
 	"math"
 	"strconv"
 	"strings"
 
-	"bisonai.com/orakl/node/pkg/common/keys"
-	"bisonai.com/orakl/node/pkg/db"
 	"github.com/rs/zerolog/log"
 )
 
@@ -47,13 +44,6 @@ func GetWssFeedMap(feeds []Feed) map[string]FeedMaps {
 		feedMaps[provider].Separated[separatedName] = feed.ID
 	}
 	return feedMaps
-}
-
-func StoreFeeds(ctx context.Context, feedData []*FeedData) error {
-	if len(feedData) == 0 {
-		return nil
-	}
-	return db.LPushObject(ctx, keys.FeedDataBufferKey(), feedData)
 }
 
 func PriceStringToFloat64(price string) (float64, error) {

--- a/node/pkg/websocketfetcher/tests/utils_test.go
+++ b/node/pkg/websocketfetcher/tests/utils_test.go
@@ -1,14 +1,10 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
-	"bisonai.com/orakl/node/pkg/common/keys"
-	"bisonai.com/orakl/node/pkg/db"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/common"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/binance"
 	"bisonai.com/orakl/node/pkg/websocketfetcher/providers/bitget"
@@ -81,52 +77,6 @@ func TestGetWssFeedMap(t *testing.T) {
 		if _, exists := feedMaps[provider].Separated[separatedName]; !exists {
 			t.Errorf("separated feed %s not found", separatedName)
 		}
-	}
-}
-
-func TestStoreFeeds(t *testing.T) {
-	ctx := context.Background()
-	testTimestamps := []time.Time{
-		time.Now(),
-		time.Now().Add(time.Second),
-		time.Now().Add(time.Second * 2),
-		time.Now().Add(time.Second * 3),
-	}
-
-	feedData := []*common.FeedData{
-		{
-			FeedID:    1,
-			Value:     10000,
-			Timestamp: &testTimestamps[0],
-		},
-		{
-			FeedID:    1,
-			Value:     10001,
-			Timestamp: &testTimestamps[1],
-		},
-		{
-			FeedID:    2,
-			Value:     20000,
-			Timestamp: &testTimestamps[2],
-		},
-		{
-			FeedID:    2,
-			Value:     20001,
-			Timestamp: &testTimestamps[3],
-		},
-	}
-
-	err := common.StoreFeeds(ctx, feedData)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	buffer, err := db.PopAllObject[*common.FeedData](ctx, keys.FeedDataBufferKey())
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(buffer) != 4 {
-		t.Errorf("expected 4 buffer data, got %d", len(buffer))
 	}
 }
 

--- a/node/pkg/websocketfetcher/tests/utils_test.go
+++ b/node/pkg/websocketfetcher/tests/utils_test.go
@@ -121,22 +121,6 @@ func TestStoreFeeds(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	latestFeed1, err := db.GetObject[*common.FeedData](ctx, keys.LatestFeedDataKey(1))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if latestFeed1.Value != 10001 {
-		t.Errorf("expected value 10001, got %f", latestFeed1.Value)
-	}
-
-	latestFeed2, err := db.GetObject[*common.FeedData](ctx, keys.LatestFeedDataKey(2))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if latestFeed2.Value != 20001 {
-		t.Errorf("expected value 20001, got %f", latestFeed2.Value)
-	}
-
 	buffer, err := db.PopAllObject[*common.FeedData](ctx, keys.FeedDataBufferKey())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
# Description

- Use in memory RWMap to store and load latest feed data instead of redis
- Use in memory channel to store pgsql dump feed data instead of redis

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
