### PR TITLE
(OraklNode) Raft updates

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -72,8 +72,6 @@ func (n *Aggregator) Run(ctx context.Context) {
 }
 
 func (n *Aggregator) LeaderJob(ctx context.Context) error {
-	n.Raft.IncreaseTerm()
-
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.RoundID += 1

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -365,7 +365,7 @@ func (r *Raft) becomeLeader(ctx context.Context) {
 }
 
 func (r *Raft) getRandomElectionTimeout() time.Duration {
-	baseTimeout := r.HeartbeatTimeout * 10
+	baseTimeout := r.HeartbeatTimeout * 9
 	jitter := time.Duration(rand.Int63n(int64(r.HeartbeatTimeout * 3)))
 	return baseTimeout + jitter
 }

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -365,8 +365,8 @@ func (r *Raft) becomeLeader(ctx context.Context) {
 }
 
 func (r *Raft) getRandomElectionTimeout() time.Duration {
-	baseTimeout := r.HeartbeatTimeout * 9
-	jitter := time.Duration(rand.Int63n(int64(r.HeartbeatTimeout * 3)))
+	baseTimeout := r.HeartbeatTimeout * 8
+	jitter := time.Duration(rand.Int63n(int64(r.HeartbeatTimeout * 4)))
 	return baseTimeout + jitter
 }
 

--- a/node/pkg/raft/raft.go
+++ b/node/pkg/raft/raft.go
@@ -132,15 +132,18 @@ func (r *Raft) handleHeartbeat(msg Message) error {
 	currentRole := r.Role
 	currentTerm := r.Term
 
-	if heartbeatMessage.Term >= currentTerm {
+	if r.Role == Follower {
+		r.startElectionTimer()
+	}
+
+	if heartbeatMessage.Term > currentTerm {
 		if currentRole == Leader {
 			r.ResignLeader()
 		}
-
-		r.Term = max(heartbeatMessage.Term, currentTerm)
+		r.Term = heartbeatMessage.Term
 		r.Role = Follower
 		r.LeaderID = heartbeatMessage.LeaderID
-		r.startElectionTimer()
+
 		return nil
 	}
 
@@ -362,8 +365,8 @@ func (r *Raft) becomeLeader(ctx context.Context) {
 }
 
 func (r *Raft) getRandomElectionTimeout() time.Duration {
-	baseTimeout := r.HeartbeatTimeout * 9
-	jitter := time.Duration(rand.Int63n(int64(baseTimeout / 10))) // 10% jitter
+	baseTimeout := r.HeartbeatTimeout * 10
+	jitter := time.Duration(rand.Int63n(int64(r.HeartbeatTimeout * 3)))
 	return baseTimeout + jitter
 }
 

--- a/node/pkg/raft/raft_test.go
+++ b/node/pkg/raft/raft_test.go
@@ -121,7 +121,7 @@ func TestRaft_LeaderElection(t *testing.T) {
 		go raftNode.Run(ctx)
 	}
 
-	time.Sleep(2100 * time.Millisecond)
+	time.Sleep(2200 * time.Millisecond)
 
 	t.Run("Verify single leader across nodes", func(t *testing.T) {
 		leaderIds := make(map[string]struct{})

--- a/node/script/test_dal_consumer_ws/main.go
+++ b/node/script/test_dal_consumer_ws/main.go
@@ -23,8 +23,8 @@ type Subscription struct {
 
 func main() {
 	ctx := context.Background()
-	chain := "baobab"
-	key := ""
+	// chain := "baobab"
+	key := "testApiKey"
 	configs, err := fetchConfigs()
 	if err != nil {
 		panic(err)
@@ -38,7 +38,8 @@ func main() {
 		subscription.Params = append(subscription.Params, "submission@"+configs.Name)
 	}
 
-	wsEndpoint := fmt.Sprintf("ws://dal.%s.orakl.network/ws", chain)
+	// wsEndpoint := fmt.Sprintf("ws://dal.%s.orakl.network/ws", chain)
+	wsEndpoint := "ws://localhost:8090/ws"
 
 	wsHelper, err := wss.NewWebsocketHelper(
 		ctx,
@@ -90,11 +91,12 @@ func handleWsMessage(ctx context.Context, data map[string]interface{}) error {
 	}
 
 	t := time.UnixMilli(timestamp)
-
 	diff := time.Since(t)
-	if diff > time.Second {
-		log.Info().Str("Player", "Reporter").Str("Symbol", wsData.Symbol).Str("delay", fmt.Sprintf("%f", diff.Seconds())).Msg("ws message")
-	}
+	log.Info().Str("Player", "Reporter").Str("Symbol", wsData.Symbol).Str("delay", fmt.Sprintf("%f", diff.Seconds())).Msg("ws message")
+
+	// if diff > time.Second {
+	// 	log.Info().Str("Player", "Reporter").Str("Symbol", wsData.Symbol).Str("delay", fmt.Sprintf("%f", diff.Seconds())).Msg("ws message")
+	// }
 
 	return nil
 }


### PR DESCRIPTION
# Description

This PR aims to fix possible unsync scenarios
- both nodes might handle each other's heartbeat messages and then step down as followers at the same time, and then restart election timers and go through same process again, without either one becoming a stable leader
- two nodes receive each other's votes and become candidates at the same time. each node grant vote to each other but neither will have enough votes to become a leader

To prevent this scenario this PR updates followings

- Modify the handleHeartbeat function to only step down if the received heartbeat’s term is strictly greater than the current term (i.e., > instead of >=). This will prevent nodes from stepping down when they receive a heartbeat with the same term, which should help avoid a "tie" scenario where both nodes become candidates and step down constantly.
- Increase election timeout jitter. Increase the election timeout to ensure that both nodes do not constantly start elections at the same time.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
