### PR TITLE
(DAL) Bulk insert user stats

### DIFF
--- a/node/pkg/dal/apiv2/controller.go
+++ b/node/pkg/dal/apiv2/controller.go
@@ -70,16 +70,22 @@ func NewServer(collector *collector.Collector, keyCache *keycache.KeyCache, hub 
 		collector: collector,
 		keyCache:  keyCache,
 		hub:       hub,
-		serveMux:  http.NewServeMux(),
 	}
-	s.serveMux.HandleFunc("/", s.HealthCheckHandler)
-	s.serveMux.HandleFunc("/ws", s.WSHandler)
+	serveMux := http.NewServeMux()
 
-	s.serveMux.HandleFunc("GET /symbols", s.SymbolsHandler)
-	s.serveMux.HandleFunc("GET /latest-data-feeds/all", s.AllLatestFeedsHandler)
-	s.serveMux.HandleFunc("GET /latest-data-feeds/transpose/all", s.AllLatestFeedsTransposedHandler)
-	s.serveMux.HandleFunc("GET /latest-data-feeds/transpose/{symbols}", s.TransposedLatestFeedsHandler)
-	s.serveMux.HandleFunc("GET /latest-data-feeds/{symbols}", s.LatestFeedsHandler)
+	serveMux.HandleFunc("/", s.HealthCheckHandler)
+	serveMux.HandleFunc("/ws", s.WSHandler)
+
+	serveMux.HandleFunc("GET /symbols", s.SymbolsHandler)
+	serveMux.HandleFunc("GET /latest-data-feeds/all", s.AllLatestFeedsHandler)
+	serveMux.HandleFunc("GET /latest-data-feeds/transpose/all", s.AllLatestFeedsTransposedHandler)
+	serveMux.HandleFunc("GET /latest-data-feeds/transpose/{symbols}", s.TransposedLatestFeedsHandler)
+	serveMux.HandleFunc("GET /latest-data-feeds/{symbols}", s.LatestFeedsHandler)
+
+	// Apply the RequestLoggerMiddleware to the ServeMux
+	loggedMux := stats.RequestLoggerMiddleware(serveMux)
+
+	s.handler = loggedMux
 
 	return s
 }
@@ -96,7 +102,7 @@ func (s *ServerV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.serveMux.ServeHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }
 
 func (s *ServerV2) checkAPIKey(ctx context.Context, key string) bool {

--- a/node/pkg/dal/apiv2/controller.go
+++ b/node/pkg/dal/apiv2/controller.go
@@ -49,7 +49,7 @@ func Start(ctx context.Context, opts ...ServerV2Option) error {
 		return err
 	}
 
-	wsServer := NewServer(config.Collector, config.KeyCache, config.Hub)
+	wsServer := NewServer(config.Collector, config.KeyCache, config.Hub, config.StatsApp)
 	httpServer := &http.Server{
 		Handler: wsServer,
 		BaseContext: func(_ net.Listener) context.Context {
@@ -65,7 +65,7 @@ func Start(ctx context.Context, opts ...ServerV2Option) error {
 	return nil
 }
 
-func NewServer(collector *collector.Collector, keyCache *keycache.KeyCache, hub *hub.Hub) *ServerV2 {
+func NewServer(collector *collector.Collector, keyCache *keycache.KeyCache, hub *hub.Hub, statsApp *stats.StatsApp) *ServerV2 {
 	s := &ServerV2{
 		collector: collector,
 		keyCache:  keyCache,
@@ -83,7 +83,7 @@ func NewServer(collector *collector.Collector, keyCache *keycache.KeyCache, hub 
 	serveMux.HandleFunc("GET /latest-data-feeds/{symbols}", s.LatestFeedsHandler)
 
 	// Apply the RequestLoggerMiddleware to the ServeMux
-	loggedMux := stats.RequestLoggerMiddleware(serveMux)
+	loggedMux := statsApp.RequestLoggerMiddleware(serveMux)
 
 	s.handler = loggedMux
 

--- a/node/pkg/dal/apiv2/types.go
+++ b/node/pkg/dal/apiv2/types.go
@@ -21,7 +21,7 @@ type ServerV2 struct {
 	collector *collector.Collector
 	hub       *hub.Hub
 	keyCache  *keycache.KeyCache
-	serveMux  *http.ServeMux
+	handler   http.Handler
 }
 
 type ServerV2Config struct {

--- a/node/pkg/dal/apiv2/types.go
+++ b/node/pkg/dal/apiv2/types.go
@@ -6,6 +6,7 @@ import (
 	"bisonai.com/orakl/node/pkg/dal/collector"
 	"bisonai.com/orakl/node/pkg/dal/hub"
 	"bisonai.com/orakl/node/pkg/dal/utils/keycache"
+	"bisonai.com/orakl/node/pkg/dal/utils/stats"
 )
 
 type BulkResponse struct {
@@ -29,6 +30,7 @@ type ServerV2Config struct {
 	Collector *collector.Collector
 	Hub       *hub.Hub
 	KeyCache  *keycache.KeyCache
+	StatsApp  *stats.StatsApp
 }
 
 type ServerV2Option func(*ServerV2Config)
@@ -48,6 +50,12 @@ func WithCollector(c *collector.Collector) ServerV2Option {
 func WithHub(h *hub.Hub) ServerV2Option {
 	return func(config *ServerV2Config) {
 		config.Hub = h
+	}
+}
+
+func WithStatsApp(s *stats.StatsApp) ServerV2Option {
+	return func(config *ServerV2Config) {
+		config.StatsApp = s
 	}
 }
 

--- a/node/pkg/dal/app.go
+++ b/node/pkg/dal/app.go
@@ -11,6 +11,7 @@ import (
 	"bisonai.com/orakl/node/pkg/dal/collector"
 	"bisonai.com/orakl/node/pkg/dal/hub"
 	"bisonai.com/orakl/node/pkg/dal/utils/keycache"
+	"bisonai.com/orakl/node/pkg/dal/utils/stats"
 	"bisonai.com/orakl/node/pkg/utils/request"
 
 	"github.com/rs/zerolog/log"
@@ -20,6 +21,8 @@ type Config = types.Config
 
 func Run(ctx context.Context) error {
 	log.Debug().Msg("Starting DAL API server")
+
+	stats.Start(ctx)
 
 	keyCache := keycache.NewAPIKeyCache(1 * time.Hour)
 	keyCache.CleanupLoop(10 * time.Minute)

--- a/node/pkg/dal/app.go
+++ b/node/pkg/dal/app.go
@@ -22,7 +22,8 @@ type Config = types.Config
 func Run(ctx context.Context) error {
 	log.Debug().Msg("Starting DAL API server")
 
-	go stats.Start(ctx)
+	statsApp := stats.Start(ctx)
+	defer statsApp.Stop()
 
 	keyCache := keycache.NewAPIKeyCache(1 * time.Hour)
 	keyCache.CleanupLoop(10 * time.Minute)
@@ -48,7 +49,7 @@ func Run(ctx context.Context) error {
 	hub := hub.HubSetup(ctx, configs)
 	go hub.Start(ctx, collector)
 
-	err = apiv2.Start(ctx, apiv2.WithCollector(collector), apiv2.WithHub(hub), apiv2.WithKeyCache(keyCache))
+	err = apiv2.Start(ctx, apiv2.WithCollector(collector), apiv2.WithHub(hub), apiv2.WithKeyCache(keyCache), apiv2.WithStatsApp(statsApp))
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to start DAL WS server")
 		return err

--- a/node/pkg/dal/app.go
+++ b/node/pkg/dal/app.go
@@ -22,7 +22,7 @@ type Config = types.Config
 func Run(ctx context.Context) error {
 	log.Debug().Msg("Starting DAL API server")
 
-	stats.Start(ctx)
+	go stats.Start(ctx)
 
 	keyCache := keycache.NewAPIKeyCache(1 * time.Hour)
 	keyCache.CleanupLoop(10 * time.Minute)


### PR DESCRIPTION
# Description

User statistics for rest calls weren't being collected after migration of framework from fiber to go/http

This adds functionality to collect user rest call stats alongside with bulk insertion every certain interval (previously inserted each entries)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
