### PR TITLE
(OraklNode) WebsocketHelper improve auto reconnect

### DIFF
--- a/node/pkg/wss/types.go
+++ b/node/pkg/wss/types.go
@@ -1,0 +1,151 @@
+package wss
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"nhooyr.io/websocket"
+)
+
+type WebsocketHelper struct {
+	Conn              *websocket.Conn
+	Endpoint          string
+	Subscriptions     []any
+	Proxy             string
+	IsRunning         bool
+	Compression       bool
+	CustomDialFunc    *func(context.Context, string, *websocket.DialOptions) (*websocket.Conn, *http.Response, error)
+	CustomReadFunc    *func(context.Context, *websocket.Conn) (map[string]interface{}, error)
+	RequestHeaders    map[string]string
+	ReadLimit         int64
+	ReconnectInterval time.Duration
+	InactivityTimeout time.Duration
+	lastMessageTime   time.Time
+}
+
+type ConnectionConfig struct {
+	Endpoint          string
+	Proxy             string
+	Subscriptions     []any
+	Compression       bool
+	DialFunc          func(context.Context, string, *websocket.DialOptions) (*websocket.Conn, *http.Response, error)
+	ReadFunc          func(context.Context, *websocket.Conn) (map[string]interface{}, error)
+	RequestHeaders    map[string]string
+	ReadLimit         int64
+	ReconnectInterval time.Duration
+	InactivityTimeout time.Duration
+}
+
+type ConnectionOption func(*ConnectionConfig)
+
+const DefaultReconnectInterval = 12 * time.Hour
+const DefaultInactivityTimeout = 15 * time.Minute
+
+func WithEndpoint(endpoint string) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.Endpoint = endpoint
+	}
+}
+
+func WithProxyUrl(proxyUrl string) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		if proxyUrl == "" {
+			return
+		}
+		c.Proxy = proxyUrl
+	}
+}
+
+func WithSubscriptions(subscriptions []any) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.Subscriptions = subscriptions
+	}
+}
+
+func WithCustomDialFunc(dialFunc func(context.Context, string, *websocket.DialOptions) (*websocket.Conn, *http.Response, error)) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.DialFunc = dialFunc
+	}
+}
+
+func WithCustomReadFunc(readFunc func(context.Context, *websocket.Conn) (map[string]interface{}, error)) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.ReadFunc = readFunc
+	}
+}
+
+func WithCompressionMode() ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.Compression = true
+	}
+}
+
+func WithRequestHeaders(headers map[string]string) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.RequestHeaders = headers
+	}
+}
+
+func WithReadLimit(readLimit int64) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.ReadLimit = readLimit
+	}
+}
+
+func WithReconnectInterval(duration time.Duration) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.ReconnectInterval = duration
+	}
+}
+
+func WithInactivityTimeout(duration time.Duration) ConnectionOption {
+	return func(c *ConnectionConfig) {
+		c.InactivityTimeout = duration
+	}
+}
+
+func NewWebsocketHelper(ctx context.Context, opts ...ConnectionOption) (*WebsocketHelper, error) {
+	config := &ConnectionConfig{
+		ReconnectInterval: DefaultReconnectInterval,
+		InactivityTimeout: DefaultInactivityTimeout,
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if config.Endpoint == "" {
+		log.Error().Msg("endpoint is required")
+		return nil, fmt.Errorf("endpoint is required")
+	}
+
+	if config.Subscriptions == nil {
+		log.Warn().Msg("no subscriptions provided")
+	}
+
+	ws := &WebsocketHelper{
+		Endpoint:          config.Endpoint,
+		Subscriptions:     config.Subscriptions,
+		Proxy:             config.Proxy,
+		Compression:       config.Compression,
+		RequestHeaders:    config.RequestHeaders,
+		ReconnectInterval: config.ReconnectInterval,
+		InactivityTimeout: config.InactivityTimeout,
+	}
+
+	if config.DialFunc != nil {
+		ws.CustomDialFunc = &config.DialFunc
+	}
+
+	if config.ReadFunc != nil {
+		ws.CustomReadFunc = &config.ReadFunc
+	}
+
+	if config.ReadLimit > 0 {
+		ws.ReadLimit = config.ReadLimit
+	}
+
+	return ws, nil
+}

--- a/node/pkg/wss/utils.go
+++ b/node/pkg/wss/utils.go
@@ -92,6 +92,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 			select {
 			case <-ctx.Done():
 				log.Info().Str("endpoint", ws.Endpoint).Msg("context cancelled, stopping websocket")
+				ws.Close()
 				return
 			case <-reconnectTicker.C:
 				log.Info().Str("endpoint", ws.Endpoint).Msg("reconnect interval exceeded during read, closing websocket")

--- a/node/pkg/wss/utils.go
+++ b/node/pkg/wss/utils.go
@@ -95,13 +95,11 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 				return
 			case <-reconnectTicker.C:
 				log.Info().Str("endpoint", ws.Endpoint).Msg("reconnect interval exceeded during read, closing websocket")
-				ws.Close()
 				break innerLoop
 			case <-inactivityTimer.C:
 				inactivityTimer.Reset(ws.InactivityTimeout)
 				if time.Since(ws.lastMessageTime) > ws.InactivityTimeout {
 					log.Info().Str("endpoint", ws.Endpoint).Msg("inactivity timeout exceeded, closing websocket")
-					ws.Close()
 					break innerLoop
 				}
 			default:
@@ -123,6 +121,7 @@ func (ws *WebsocketHelper) Run(ctx context.Context, router func(context.Context,
 				}(ctx, data)
 			}
 		}
+		ws.Close()
 	}
 }
 

--- a/node/pkg/wss/utils_test.go
+++ b/node/pkg/wss/utils_test.go
@@ -4,6 +4,7 @@ package wss
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -37,31 +38,14 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestReadWriteAndClose(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/ws", echoHandler)
-	// Create an http.Server object
-	srv := &http.Server{
-		Addr:    ":8088",
-		Handler: mux,
-	}
-	// Start the server in a goroutine
-	go func() {
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			// unexpected error
-			log.Fatal().Err(err).Msg("failed to start server")
-		}
-	}()
-	defer func() {
-		if err := srv.Close(); err != nil {
-			// unexpected error
-			t.Fatalf("Server Shutdown: %v", err)
-		}
-	}()
+	server := httptest.NewServer(http.HandlerFunc(echoHandler))
+	defer server.Close()
+	wsURL := "ws" + server.URL[len("http"):] + "/ws"
 
 	time.Sleep(time.Second)
 
 	// Create a WebSocket connection
-	conn, err := NewWebsocketHelper(context.Background(), WithEndpoint("ws://localhost:8088/ws"))
+	conn, err := NewWebsocketHelper(context.Background(), WithEndpoint(wsURL))
 	assert.NoError(t, err)
 	assert.NotNil(t, conn)
 
@@ -81,4 +65,111 @@ func TestReadWriteAndClose(t *testing.T) {
 	// Test Close
 	err = conn.Close()
 	assert.NoError(t, err)
+}
+
+type mockWebsocketHelper struct {
+	*WebsocketHelper
+	dialCount int
+}
+
+func (m *mockWebsocketHelper) Dial(ctx context.Context) error {
+	m.dialCount++
+	return nil
+}
+
+func (m *mockWebsocketHelper) Write(ctx context.Context, message interface{}) error {
+	return nil
+}
+
+func (m *mockWebsocketHelper) Close() error {
+	m.Conn = nil
+	return nil
+}
+
+func (m *mockWebsocketHelper) dialAndSubscribe(ctx context.Context) error {
+	m.dialCount++
+	return nil
+}
+
+func TestReconnectTicker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(echoHandler))
+	defer server.Close()
+	wsURL := "ws" + server.URL[len("http"):] + "/ws"
+
+	time.Sleep(time.Second)
+
+	wsHelper := &mockWebsocketHelper{
+		WebsocketHelper: &WebsocketHelper{
+			Endpoint:          wsURL,
+			ReconnectInterval: 100 * time.Millisecond, // Short interval for testing
+			InactivityTimeout: 500 * time.Millisecond,
+		},
+	}
+
+	go wsHelper.Run(ctx, func(context.Context, map[string]any) error {
+		return nil
+	})
+
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 1, wsHelper.dialCount, "Expected initial dial")
+
+	time.Sleep(150 * time.Millisecond) // Wait for reconnect
+	assert.Equal(t, 2, wsHelper.dialCount, "Expected reconnect after interval")
+}
+
+func TestInactivityTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(echoHandler))
+	defer server.Close()
+	wsURL := "ws" + server.URL[len("http"):] + "/ws"
+
+	time.Sleep(time.Second)
+
+	wsHelper := &mockWebsocketHelper{
+		WebsocketHelper: &WebsocketHelper{
+			Endpoint:          wsURL,
+			ReconnectInterval: 500 * time.Millisecond,
+			InactivityTimeout: 100 * time.Millisecond, // Short timeout for testing
+		},
+	}
+
+	go wsHelper.Run(ctx, func(context.Context, map[string]any) error {
+		return nil
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, wsHelper.dialCount, "Expected initial dial due to inactivity")
+}
+
+func TestResetInactivityOnMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(echoHandler))
+	defer server.Close()
+	wsURL := "ws" + server.URL[len("http"):] + "/ws"
+
+	wsHelper := &mockWebsocketHelper{
+		WebsocketHelper: &WebsocketHelper{
+			Endpoint:          wsURL,
+			ReconnectInterval: 500 * time.Millisecond,
+			InactivityTimeout: 100 * time.Millisecond,
+		},
+	}
+
+	// Simulate incoming messages to reset inactivity
+	go wsHelper.Run(ctx, func(context.Context, map[string]any) error {
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	wsHelper.lastMessageTime = time.Now() // Simulate message received
+
+	time.Sleep(50 * time.Millisecond) // Wait to ensure timer resets
+	assert.Equal(t, 0, wsHelper.dialCount, "Expected no dial due to message activity")
 }


### PR DESCRIPTION
# Description

It'll now reconnect on following 2 conditions
- if it has been running for more than `reconnectInterval` (default 12hr)
- if there were no incoming messages over `inactivityTimeout` (default 15min)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
