### PR TITLE
(Sentinel) Increase timeout for DAL rest calls

### DIFF
--- a/node/pkg/checker/dal/app.go
+++ b/node/pkg/checker/dal/app.go
@@ -137,6 +137,7 @@ func checkDal(endpoint string, key string, alarmCount map[string]int) error {
 	resp, err := request.Request[[]OutgoingSubmissionData](
 		request.WithEndpoint(endpoint+"/latest-data-feeds/all"),
 		request.WithHeaders(map[string]string{"X-API-Key": key}),
+		request.WithTimeout(RestTimeout),
 	)
 	networkDelay := time.Since(now)
 

--- a/node/pkg/checker/dal/types.go
+++ b/node/pkg/checker/dal/types.go
@@ -19,6 +19,8 @@ timestamp > current_timestamp - INTERVAL '%d seconds' AND
 api_key NOT IN (SELECT key from keys WHERE description IN (%s))`
 	TrafficOldOffset    = 600
 	TrafficRecentOffset = 10
+
+	RestTimeout = 10 * time.Second
 )
 
 var (


### PR DESCRIPTION
# Description

instead of using default 2 seconds timeout, use 10 seconds from sentinel dal checks

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
