### PR TITLE
(POR) Increase timeout for por request

### DIFF
--- a/node/pkg/fetcher/utils.go
+++ b/node/pkg/fetcher/utils.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"strings"
+	"time"
 
 	"bisonai.com/miko/node/pkg/db"
 	errorSentinel "bisonai.com/miko/node/pkg/error"
@@ -13,7 +14,11 @@ import (
 )
 
 func FetchSingle(ctx context.Context, definition *Definition) (float64, error) {
-	rawResult, err := request.Request[interface{}](request.WithEndpoint(*definition.Url), request.WithHeaders(definition.Headers))
+	rawResult, err := request.Request[interface{}](
+		request.WithEndpoint(*definition.Url),
+		request.WithHeaders(definition.Headers),
+		request.WithTimeout(10*time.Second),
+	)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
# Description

`FetchSingle()` is a function referenced only from POR
Instead of using 2 seconds default timeout, pass 10 seconds timeout so that it can be more tolerant to slow responses

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
