### PR TITLE
downgrade sentinel url check log error to warn

### DIFF
--- a/node/pkg/checker/health/app.go
+++ b/node/pkg/checker/health/app.go
@@ -134,7 +134,7 @@ func checkUrl(ctx context.Context, healthCheckUrl HealthCheckUrl) bool {
 func checkHttp(url string) bool {
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to check URL: %s", url)
+		log.Warn().Err(err).Msgf("Failed to check URL: %s", url)
 		return false
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
# Description

Since we are sending `service is down` message to slack, we can downgrade this to `warn` to avoid spamming logscribe.

Fixes https://github.com/Bisonai/orakl/issues/2200

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
