### PR TITLE
(OraklNode) run ICMP checker after boot api connected

### DIFF
--- a/node/cmd/node/main.go
+++ b/node/cmd/node/main.go
@@ -21,17 +21,6 @@ import (
 func main() {
 	ctx := context.Background()
 
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Error().Any("panic", r).Msg("panic recovered from network checks")
-			}
-		}()
-		time.Sleep(5 * time.Second) // give some buffer until the app is ready
-		ping.Run(ctx)
-		os.Exit(1)
-	}()
-
 	err := logscribeconsumer.Start(ctx, "node")
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to start logscribe consumer")
@@ -58,6 +47,17 @@ func main() {
 		log.Error().Err(err).Msg("Failed to setup libp2p")
 		return
 	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Any("panic", r).Msg("panic recovered from network checks")
+			}
+		}()
+		time.Sleep(5 * time.Second) // give some buffer until the app is ready
+		ping.Run(ctx)
+		os.Exit(1)
+	}()
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
# Description

In local, the ping connection has been working at the very launch of the application, however from production, it seems to require some time until pinging public DNS works as expected,

I'm assuming it will start working after it connects to boot api, which it is also retried multiple times before app launch until the network is ready

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
