### PR TITLE
Test for `submitStrict` method

### DIFF
--- a/contracts/v0.2/package.json
+++ b/contracts/v0.2/package.json
@@ -37,7 +37,8 @@
     "deploy:baobab:SubmissionProxy": "forge script DeploySubmissionProxy --broadcast --gas-estimate-multiplier 300 --rpc-url https://public-en-kairos.node.kaia.io",
     "deploy:cypress:Feed": "forge script DeployFeed --broadcast --gas-estimate-multiplier 300 --rpc-url http://100.75.43.49:8551",
     "deploy:cypress:FeedRouter": "forge script DeployFeedRouter --broadcast --gas-estimate-multiplier 300 --rpc-url http://100.75.43.49:8551",
-    "deploy:cypress:SubmissionProxy": "forge script DeploySubmissionProxy --broadcast --gas-estimate-multiplier 300 --rpc-url http://100.75.43.49:8551"
+    "deploy:cypress:SubmissionProxy": "forge script DeploySubmissionProxy --broadcast --gas-estimate-multiplier 300 --rpc-url http://100.75.43.49:8551",
+    "submit-strict-test": "forge script -vvv SubmitStrictTest --broadcast --gas-estimate-multiplier 300 --rpc-url https://public-en.klaytnfinder.io/v1/cypress"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^11.1.2",

--- a/contracts/v0.2/test/SubmitStrict.t.sol
+++ b/contracts/v0.2/test/SubmitStrict.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Vm.sol";
+import {Test, console} from "forge-std/Test.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import {SubmissionProxy} from "../src/SubmissionProxy.sol";
+import {FeedRouter} from "../src/FeedRouter.sol";
+import "forge-std/console.sol";
+
+contract SubmitStrictTest is Test {
+    using stdJson for string;
+
+    function run() public {
+	string memory json = vm.readFile("submission.json");
+
+	string[] memory symbols = getsymbols(json);
+	bytes32[] memory feedHashes = gethashes(json);
+	int256[] memory valuesInt = getvalues(json);
+	uint256[] memory timestampsInt = gettimestamps(json);
+	bytes[] memory proofs = getproofs(json);
+
+	console.log("submission");
+	console.logBytes32(feedHashes[0]);
+	console.logInt(valuesInt[0]);
+	console.logUint(timestampsInt[0]);
+	console.logBytes(proofs[0]);
+
+	SubmissionProxy sp = SubmissionProxy(0x3a251c738e19806A546815eb6065e139A8D65B4b);
+	sp.submitStrict(
+	    feedHashes,
+	    valuesInt,
+	    timestampsInt,
+	    proofs
+	);
+
+	console.log(block.timestamp);
+
+	FeedRouter fr = FeedRouter(0x653078F0D3a230416A59aA6486466470Db0190A2);
+	(uint64 roundId, int256 answer, uint256 blockTimestamp) = fr.latestRoundData(symbols[0]);
+
+	console.log("latestRoundData");
+	console.logUint(roundId);
+	console.logInt(answer);
+	console.logUint(blockTimestamp);
+
+	require(block.timestamp == blockTimestamp, "Timestamps do not match");
+    }
+
+    function getsymbols(string memory json) public pure returns (string[] memory) {
+	bytes memory rawSymbols = json.parseRaw(".symbols");
+	return abi.decode(rawSymbols, (string[]));
+    }
+
+    function gethashes(string memory json) public pure returns (bytes32[] memory) {
+	bytes memory rawFeedHashes = json.parseRaw(".feedHashes");
+        return abi.decode(rawFeedHashes, (bytes32[]));
+    }
+
+    function getvalues(string memory json) public pure returns (int256[] memory) {
+	bytes memory rawValues = json.parseRaw(".values");
+	string[] memory values = abi.decode(rawValues, (string[]));
+	int256[] memory valuesInt = new int256[](values.length);
+	for (uint i = 0; i < values.length; i++) {
+	    valuesInt[i] = vm.parseInt(values[i]);
+	}
+	return valuesInt;
+    }
+
+    function gettimestamps(string memory json) public pure returns (uint256[] memory) {
+	bytes memory rawTimestamps = json.parseRaw(".aggregateTimes");
+	string[] memory timestamps = abi.decode(rawTimestamps, (string[]));
+	uint256[] memory timestampsInt = new uint256[](timestamps.length);
+	for (uint i = 0; i < timestamps.length; i++) {
+	    timestampsInt[i] = vm.parseUint(timestamps[i]);
+	}
+	return timestampsInt;
+    }
+
+    function getproofs(string memory json) public pure returns (bytes[] memory) {
+	bytes memory rawProofs = json.parseRaw(".proofs");
+	return abi.decode(rawProofs, (bytes[]));
+    }
+}


### PR DESCRIPTION
# Description

This PR includes a test that allows for long-term testing of a single feed through [`submitStrict`](https://github.com/Bisonai/orakl/blob/a91e164e724e37653a33544930e5efa2dec8f983/contracts/v0.2/src/SubmissionProxy.sol#L399-L416) method. The contract call is executed in forked environment for each new submission.

The test is composed of three steps:
1. Cleanup of previous generated file `submission.json`.
2. Fetch the latest submission data from DAL to `submission.json`.
3. Simulation of submission execution to Orakl Network, and reading the latest submitted round followed by comparison of the block timestamp of the latest submission as shown below.

```
require(block.timestamp == blockTimestamp, "Timestamps do not match");
```

## Prerequisites

* forge
* yarn

## Test

Execute from `contracts/v0.2` directory.

The test will run thousand iteration of the test as defined in the description desction using Klaytn's JSON-RPC https://public-en.klaytnfinder.io/v1/cypress.

```shell
DAL_API_KEY=YOUR_API_KEY
for i in {1..1000}; do
  rm -f submission.json && \
  curl --location 'https://dal.cypress.orakl.network/latest-data-feeds/transpose/PEPE-USDT' --header "X-API-Key: $DAL_API_KEY" > submission.json && \
  yarn submit-strict-test;
done
```

## Findings

* During all tests we did not encounter `"Timestamps do not match"` error.
* Submissions using outdated data raise `AnswerTooOld` error, which we did not encounter during the execution of the long-term test, only during manual executions.

```
yarn submit-strict-test
yarn run v1.22.19
$ forge script -vvv SubmitStrictTest --broadcast --gas-estimate-multiplier 300 --rpc-url https://public-en.klaytnfinder.io/v1/cypress
[⠊] Compiling...
No files changed, compilation skipped
Traces:
  [1730634] → new SubmitStrictTest@0x5b73C5498c1E3b4dbA84de0F1833c4a029d90519
    └─ ← [Return] 8423 bytes of code

  [42373] SubmitStrictTest::run()
    ├─ [0] VM::readFile("submission.json") [staticcall]
    │   └─ ← [Return] <file>
    ├─ [0] VM::parseJson("<JSON file>", ".symbols") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] VM::parseJson("<JSON file>", ".feedHashes") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] VM::parseJson("<JSON file>", ".values") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] VM::parseInt("816") [staticcall]
    │   └─ ← [Return] 816
    ├─ [0] VM::parseJson("<JSON file>", ".aggregateTimes") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] VM::parseUint("1724401976243") [staticcall]
    │   └─ ← [Return] 1724401976243 [1.724e12]
    ├─ [0] VM::parseJson("<JSON file>", ".proofs") [staticcall]
    │   └─ ← [Return] <encoded JSON value>
    ├─ [0] console::log("submission") [staticcall]
    │   └─ ← [Stop]
    ├─ [0] console::logBytes32(0x455314fa66a1287be93e6f2d43ee572d47b716b7c69361df3409a28f3c1b7546) [staticcall]
    │   └─ ← [Stop]
    ├─ [0] console::logInt(816) [staticcall]
    │   └─ ← [Stop]
    ├─ [0] console::log(1724401976243 [1.724e12]) [staticcall]
    │   └─ ← [Stop]
    ├─ [0] console::logBytes(0xfb8feed34e91ae5e1a0637ca1cc409f3f33db24961dc10a31b646d50f10072b93a109e22a3d0cf583efdc5d3e103d3311f097d328145c0ef74272d338a114d821b2120e5b7d0f6aca1abef9546c17fe5da9e00449e56dd73d2fdce08c82a1d9872039b4f1dda45cbe6be83b28382893117b92aa30c531b98f1572671a2b7c780641b) [staticcall]
    │   └─ ← [Stop]
    ├─ [6273] 0x3a251c738e19806A546815eb6065e139A8D65B4b::submitStrict([0x455314fa66a1287be93e6f2d43ee572d47b716b7c69361df3409a28f3c1b7546], [816], [1724401976243 [1.724e12]], [0xfb8feed34e91ae5e1a0637ca1cc409f3f33db24961dc10a31b646d50f10072b93a109e22a3d0cf583efdc5d3e103d3311f097d328145c0ef74272d338a114d821b2120e5b7d0f6aca1abef9546c17fe5da9e00449e56dd73d2fdce08c82a1d9872039b4f1dda45cbe6be83b28382893117b92aa30c531b98f1572671a2b7c780641b])
    │   └─ ← [Revert] AnswerTooOld()
    └─ ← [Revert] AnswerTooOld()



== Logs ==
  submission
  0x455314fa66a1287be93e6f2d43ee572d47b716b7c69361df3409a28f3c1b7546
  816
  1724401976243
  0xfb8feed34e91ae5e1a0637ca1cc409f3f33db24961dc10a31b646d50f10072b93a109e22a3d0cf583efdc5d3e103d3311f097d328145c0ef74272d338a114d821b2120e5b7d0f6aca1abef9546c17fe5da9e00449e56dd73d2fdce08c82a1d9872039b4f1dda45cbe6be83b28382893117b92aa30c531b98f1572671a2b7c780641b
Error:
script failed: AnswerTooOld()
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

* From time to time, we encountered error during forking Klaytn caused unsynced Klaytn JSON-RPC.

```
yarn run v1.22.19
$ forge script -vvv SubmitStrictTest --broadcast --gas-estimate-multiplier 300 --rpc-url https://public-en.klaytnfinder.io/v1/cypress
[⠊] Compiling...
No files changed, compilation skipped
2024-08-23T08:32:04.706318Z ERROR foundry_evm_core::fork::init: It looks like you're trying to fork from an older block with a non-archive node which is not supported. Please try to change your RPC url to an archive node if the issue persists.
Error:
Could not instantiate forked environment with fork url: https://public-en.klaytnfinder.io/v1/cypress

Context:
- Failed to get block for block number: 162405911
latest block number: 162405911
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```