### PR TITLE
(OraklNode) Remove pinger count option

### DIFF
--- a/node/pkg/checker/ping/app.go
+++ b/node/pkg/checker/ping/app.go
@@ -98,7 +98,6 @@ func New(opts ...AppOption) (*App, error) {
 		}
 
 		pinger.Timeout = DefaultPingerTimeout
-		pinger.Count = 0
 		pinger.SetPrivileged(true)
 
 		pinger.OnRecv = func(pkt *probing.Packet) {


### PR DESCRIPTION
# Description

Count option should not be specified to make it run indefinitely
https://pkg.go.dev/github.com/prometheus-community/pro-bing@v0.4.1#Pinger.Count

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
