### PR TITLE
(OraklNode) Update redis publish key and related codes

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -282,7 +282,7 @@ func (n *Aggregator) HandleProofMessage(ctx context.Context, msg raft.Message) e
 		concatProof := bytes.Join(n.roundProofs.proofs[proofMessage.RoundID], nil)
 		proof := Proof{ConfigID: n.ID, Round: proofMessage.RoundID, Proof: concatProof}
 
-		err := PublishGlobalAggregateAndProof(ctx, globalAggregate, proof)
+		err := PublishGlobalAggregateAndProof(ctx, n.Name, globalAggregate, proof)
 		if err != nil {
 			log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to publish global aggregate and proof")
 		}

--- a/node/pkg/aggregator/aggregator_test.go
+++ b/node/pkg/aggregator/aggregator_test.go
@@ -121,7 +121,7 @@ func TestPublishGlobalAggregateAndProof(t *testing.T) {
 	}
 
 	ch := make(chan SubmissionData)
-	err = db.Subscribe(ctx, keys.SubmissionDataStreamKeyV2(node.Name), ch)
+	err = db.Subscribe(ctx, keys.SubmissionDataStreamKey(node.Name), ch)
 	if err != nil {
 		t.Fatal("error subscribing to stream")
 	}

--- a/node/pkg/aggregator/aggregator_test.go
+++ b/node/pkg/aggregator/aggregator_test.go
@@ -121,12 +121,12 @@ func TestPublishGlobalAggregateAndProof(t *testing.T) {
 	}
 
 	ch := make(chan SubmissionData)
-	err = db.Subscribe(ctx, keys.SubmissionDataStreamKey(node.ID), ch)
+	err = db.Subscribe(ctx, keys.SubmissionDataStreamKeyV2(node.Name), ch)
 	if err != nil {
 		t.Fatal("error subscribing to stream")
 	}
 
-	err = PublishGlobalAggregateAndProof(ctx, testItems.tmpData.globalAggregate, proof)
+	err = PublishGlobalAggregateAndProof(ctx, "test_pair", testItems.tmpData.globalAggregate, proof)
 	if err != nil {
 		t.Fatal("error publishing global aggregate and proof")
 	}

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -59,12 +59,12 @@ func (a *App) setGlobalAggregateBulkWriter(configs []Config) {
 		a.stopGlobalAggregateBulkWriter()
 	}
 
-	configIds := make([]int32, len(configs))
+	configNames := make([]string, len(configs))
 	for i, config := range configs {
-		configIds[i] = config.ID
+		configNames[i] = config.Name
 	}
 
-	a.GlobalAggregateBulkWriter = NewGlobalAggregateBulkWriter(WithConfigIds(configIds))
+	a.GlobalAggregateBulkWriter = NewGlobalAggregateBulkWriter(WithConfigNames(configNames))
 }
 
 func (a *App) startGlobalAggregateBulkWriter(ctx context.Context) {

--- a/node/pkg/aggregator/globalaggregatebulkwriter.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter.go
@@ -108,7 +108,7 @@ func (s *GlobalAggregateBulkWriter) receive(ctx context.Context) {
 }
 
 func (s *GlobalAggregateBulkWriter) receiveEach(ctx context.Context, configName string) {
-	err := db.Subscribe(ctx, keys.SubmissionDataStreamKeyV2(configName), s.ReceiveChannels[configName])
+	err := db.Subscribe(ctx, keys.SubmissionDataStreamKey(configName), s.ReceiveChannels[configName])
 	if err != nil {
 		log.Error().Err(err).Str("Player", "Aggregator").Msg("failed to subscribe to submission stream")
 	}

--- a/node/pkg/aggregator/globalaggregatebulkwriter_test.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter_test.go
@@ -22,7 +22,7 @@ func TestNewGlobalAggregateBulkWriter(t *testing.T) {
 		}
 	}()
 
-	_ = NewGlobalAggregateBulkWriter(WithConfigIds([]int32{testItems.tmpData.config.ID}))
+	_ = NewGlobalAggregateBulkWriter(WithConfigNames([]string{testItems.tmpData.config.Name}))
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -40,7 +40,7 @@ func TestGlobalAggregateBulkWriterStart(t *testing.T) {
 		}
 	}()
 
-	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigIds([]int32{testItems.tmpData.config.ID}))
+	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigNames([]string{testItems.tmpData.config.Name}))
 
 	bulkWriter.Start(ctx)
 
@@ -59,7 +59,7 @@ func TestGlobalAggregateBulkWriterStop(t *testing.T) {
 		}
 	}()
 
-	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigIds([]int32{testItems.tmpData.config.ID}))
+	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigNames([]string{testItems.tmpData.config.Name}))
 
 	bulkWriter.Start(ctx)
 
@@ -80,7 +80,7 @@ func TestGlobalAggregateBulkWriterDataStore(t *testing.T) {
 		}
 	}()
 
-	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigIds([]int32{testItems.tmpData.globalAggregate.ConfigID}))
+	bulkWriter := NewGlobalAggregateBulkWriter(WithConfigNames([]string{testItems.tmpData.config.Name}))
 
 	bulkWriter.Start(ctx)
 	defer bulkWriter.Stop()
@@ -109,7 +109,7 @@ func TestGlobalAggregateBulkWriterDataStore(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 50)
-	err = PublishGlobalAggregateAndProof(ctx, testItems.tmpData.globalAggregate, proof)
+	err = PublishGlobalAggregateAndProof(ctx, "test_pair", testItems.tmpData.globalAggregate, proof)
 	if err != nil {
 		t.Fatal("error publishing global aggregate and proof")
 	}

--- a/node/pkg/aggregator/utils.go
+++ b/node/pkg/aggregator/utils.go
@@ -18,7 +18,7 @@ func FilterNegative(values []int64) []int64 {
 	return result
 }
 
-func PublishGlobalAggregateAndProof(ctx context.Context, globalAggregate GlobalAggregate, proof Proof) error {
+func PublishGlobalAggregateAndProof(ctx context.Context, name string, globalAggregate GlobalAggregate, proof Proof) error {
 	if globalAggregate.Value == 0 || globalAggregate.Timestamp.IsZero() {
 		return nil
 	}
@@ -26,8 +26,7 @@ func PublishGlobalAggregateAndProof(ctx context.Context, globalAggregate GlobalA
 		GlobalAggregate: globalAggregate,
 		Proof:           proof,
 	}
-
-	return db.Publish(ctx, keys.SubmissionDataStreamKey(globalAggregate.ConfigID), data)
+	return db.Publish(ctx, keys.SubmissionDataStreamKeyV2(name), data)
 }
 
 func getLatestRoundId(ctx context.Context, configId int32) (int32, error) {

--- a/node/pkg/aggregator/utils.go
+++ b/node/pkg/aggregator/utils.go
@@ -26,7 +26,7 @@ func PublishGlobalAggregateAndProof(ctx context.Context, name string, globalAggr
 		GlobalAggregate: globalAggregate,
 		Proof:           proof,
 	}
-	return db.Publish(ctx, keys.SubmissionDataStreamKeyV2(name), data)
+	return db.Publish(ctx, keys.SubmissionDataStreamKey(name), data)
 }
 
 func getLatestRoundId(ctx context.Context, configId int32) (int32, error) {

--- a/node/pkg/common/keys/keys.go
+++ b/node/pkg/common/keys/keys.go
@@ -1,5 +1,5 @@
 package keys
 
-func SubmissionDataStreamKeyV2(name string) string {
-	return "submissionDataSteram:" + name
+func SubmissionDataStreamKey(name string) string {
+	return "submissionDataStream:" + name
 }

--- a/node/pkg/common/keys/keys.go
+++ b/node/pkg/common/keys/keys.go
@@ -1,9 +1,5 @@
 package keys
 
-import (
-	"strconv"
-)
-
-func SubmissionDataStreamKey(configId int32) string {
-	return "submissionDataStream:" + strconv.Itoa(int(configId))
+func SubmissionDataStreamKeyV2(name string) string {
+	return "submissionDataSteram:" + name
 }

--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -31,7 +31,7 @@ const (
 type Config = types.Config
 
 type Collector struct {
-	OutgoingStream   map[int32]chan *dalcommon.OutgoingSubmissionData
+	OutgoingStream   map[string]chan *dalcommon.OutgoingSubmissionData
 	Symbols          map[int32]string
 	FeedHashes       map[int32][]byte
 	LatestTimestamps map[int32]time.Time
@@ -92,7 +92,7 @@ func NewCollector(ctx context.Context, configs []Config) (*Collector, error) {
 	}
 
 	collector := &Collector{
-		OutgoingStream:              make(map[int32]chan *dalcommon.OutgoingSubmissionData, len(configs)),
+		OutgoingStream:              make(map[string]chan *dalcommon.OutgoingSubmissionData, len(configs)),
 		Symbols:                     make(map[int32]string, len(configs)),
 		FeedHashes:                  make(map[int32][]byte, len(configs)),
 		LatestTimestamps:            make(map[int32]time.Time),
@@ -104,7 +104,7 @@ func NewCollector(ctx context.Context, configs []Config) (*Collector, error) {
 
 	redisTopics := []string{}
 	for _, config := range configs {
-		collector.OutgoingStream[config.ID] = make(chan *dalcommon.OutgoingSubmissionData, 1000)
+		collector.OutgoingStream[config.Name] = make(chan *dalcommon.OutgoingSubmissionData, 1000)
 		collector.Symbols[config.ID] = config.Name
 		collector.FeedHashes[config.ID] = crypto.Keccak256([]byte(config.Name))
 		redisTopics = append(redisTopics, keys.SubmissionDataStreamKey(config.Name))
@@ -228,12 +228,12 @@ func (c *Collector) processIncomingData(ctx context.Context, data *aggregator.Su
 			return
 		}
 
-		defer func(data *dalcommon.OutgoingSubmissionData) {
+		defer func(result *dalcommon.OutgoingSubmissionData) {
 			c.mu.Lock()
 			defer c.mu.Unlock()
-			c.LatestData[data.Symbol] = data
+			c.LatestData[result.Symbol] = result
 		}(result)
-		c.OutgoingStream[data.GlobalAggregate.ConfigID] <- result
+		c.OutgoingStream[result.Symbol] <- result
 	}
 }
 

--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -107,7 +107,7 @@ func NewCollector(ctx context.Context, configs []Config) (*Collector, error) {
 		collector.OutgoingStream[config.ID] = make(chan *dalcommon.OutgoingSubmissionData, 1000)
 		collector.Symbols[config.ID] = config.Name
 		collector.FeedHashes[config.ID] = crypto.Keccak256([]byte(config.Name))
-		redisTopics = append(redisTopics, keys.SubmissionDataStreamKeyV2(config.Name))
+		redisTopics = append(redisTopics, keys.SubmissionDataStreamKey(config.Name))
 	}
 
 	baseRediscribe, err := db.NewRediscribe(

--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -107,17 +107,24 @@ func NewCollector(ctx context.Context, configs []Config) (*Collector, error) {
 		collector.OutgoingStream[config.ID] = make(chan *dalcommon.OutgoingSubmissionData, 1000)
 		collector.Symbols[config.ID] = config.Name
 		collector.FeedHashes[config.ID] = crypto.Keccak256([]byte(config.Name))
-		redisTopics = append(redisTopics, keys.SubmissionDataStreamKey(config.ID))
+		redisTopics = append(redisTopics, keys.SubmissionDataStreamKeyV2(config.Name))
 	}
 
-	baseRediscribe, err := db.NewRediscribe(ctx, db.WithRedisHost(baseRedisHost), db.WithRedisPort(baseRedisPort), db.WithRedisTopics(redisTopics), db.WithRedisRouter(collector.redisRouter))
+	baseRediscribe, err := db.NewRediscribe(
+		ctx,
+		db.WithRedisHost(baseRedisHost),
+		db.WithRedisPort(baseRedisPort),
+		db.WithRedisTopics(redisTopics),
+		db.WithRedisRouter(collector.redisRouter))
 	if err != nil {
 		return nil, err
 	}
 	collector.baseRediscribe = baseRediscribe
 
 	if subRedisHost != "" && subRedisPort != "" {
-		subRediscribe, err := db.NewRediscribe(ctx, db.WithRedisHost(subRedisHost), db.WithRedisPort(subRedisPort), db.WithRedisTopics(redisTopics), db.WithRedisRouter(collector.redisRouter))
+		subRediscribe, err := db.NewRediscribe(
+			ctx,
+			db.WithRedisHost(subRedisHost), db.WithRedisPort(subRedisPort), db.WithRedisTopics(redisTopics), db.WithRedisRouter(collector.redisRouter))
 		if err != nil {
 			return nil, err
 		}

--- a/node/pkg/dal/hub/hub.go
+++ b/node/pkg/dal/hub/hub.go
@@ -139,23 +139,9 @@ func (h *Hub) removeClient(client *websocket.Conn) {
 }
 
 func (h *Hub) initializeBroadcastChannels(collector *collector.Collector) {
-	for configId, stream := range collector.OutgoingStream {
-		symbol := h.configIdToSymbol(configId)
-		if symbol == "" {
-			continue
-		}
-
+	for symbol, stream := range collector.OutgoingStream {
 		h.broadcast[symbol] = stream
 	}
-}
-
-func (h *Hub) configIdToSymbol(id int32) string {
-	for symbol, config := range h.Configs {
-		if config.ID == id {
-			return symbol
-		}
-	}
-	return ""
 }
 
 func (h *Hub) broadcastDataForSymbol(ctx context.Context, symbol string) {

--- a/node/pkg/dal/tests/api_test.go
+++ b/node/pkg/dal/tests/api_test.go
@@ -96,7 +96,7 @@ func TestApiGetLatestAll(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = testPublishData(ctx, *sampleSubmissionData)
+	err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestApiGetLatest(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = testPublishData(ctx, *sampleSubmissionData)
+	err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestApiGetLatestTransposeAll(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = testPublishData(ctx, *sampleSubmissionData)
+	err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestApiGetLatestTranspose(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = testPublishData(ctx, *sampleSubmissionData)
+	err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestApiWebsocket(t *testing.T) {
 			t.Fatalf("error generating sample submission data: %v", err)
 		}
 
-		err = testPublishData(ctx, *sampleSubmissionData)
+		err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 		if err != nil {
 			t.Fatalf("error publishing sample submission data: %v", err)
 		}
@@ -473,7 +473,7 @@ func TestApiWebsocket(t *testing.T) {
 		}
 
 		// Publish data
-		err = testPublishData(ctx, *expectedData)
+		err = testPublishData(ctx, "test-aggregate", *expectedData)
 		if err != nil {
 			t.Fatalf("error publishing sample submission data: %v", err)
 		}

--- a/node/pkg/dal/tests/collector_test.go
+++ b/node/pkg/dal/tests/collector_test.go
@@ -85,7 +85,7 @@ func TestCollectorStream(t *testing.T) {
 	}
 
 	log.Debug().Msg("Publishing data")
-	err = testPublishData(ctx, *sampleSubmissionData)
+	err = testPublishData(ctx, "test-aggregate", *sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing data: %v", err)
 	}

--- a/node/pkg/dal/tests/main_test.go
+++ b/node/pkg/dal/tests/main_test.go
@@ -37,7 +37,7 @@ type TestItems struct {
 }
 
 func testPublishData(ctx context.Context, name string, submissionData aggregator.SubmissionData) error {
-	return db.Publish(ctx, keys.SubmissionDataStreamKeyV2(name), submissionData)
+	return db.Publish(ctx, keys.SubmissionDataStreamKey(name), submissionData)
 }
 
 func generateSampleSubmissionData(configId int32, value int64, timestamp time.Time, round int32, symbol string) (*aggregator.SubmissionData, error) {

--- a/node/pkg/dal/tests/main_test.go
+++ b/node/pkg/dal/tests/main_test.go
@@ -36,8 +36,8 @@ type TestItems struct {
 	StatsApp   *stats.StatsApp
 }
 
-func testPublishData(ctx context.Context, submissionData aggregator.SubmissionData) error {
-	return db.Publish(ctx, keys.SubmissionDataStreamKey(submissionData.GlobalAggregate.ConfigID), submissionData)
+func testPublishData(ctx context.Context, name string, submissionData aggregator.SubmissionData) error {
+	return db.Publish(ctx, keys.SubmissionDataStreamKeyV2(name), submissionData)
 }
 
 func generateSampleSubmissionData(configId int32, value int64, timestamp time.Time, round int32, symbol string) (*aggregator.SubmissionData, error) {

--- a/node/pkg/reporter/app_test.go
+++ b/node/pkg/reporter/app_test.go
@@ -61,7 +61,7 @@ func TestWsDataHandling(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = db.Publish(ctx, keys.SubmissionDataStreamKeyV2("test-aggregate"), sampleSubmissionData)
+	err = db.Publish(ctx, keys.SubmissionDataStreamKey("test-aggregate"), sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}

--- a/node/pkg/reporter/app_test.go
+++ b/node/pkg/reporter/app_test.go
@@ -61,7 +61,7 @@ func TestWsDataHandling(t *testing.T) {
 		t.Fatalf("error generating sample submission data: %v", err)
 	}
 
-	err = db.Publish(ctx, keys.SubmissionDataStreamKey(sampleSubmissionData.GlobalAggregate.ConfigID), sampleSubmissionData)
+	err = db.Publish(ctx, keys.SubmissionDataStreamKeyV2("test-aggregate"), sampleSubmissionData)
 	if err != nil {
 		t.Fatalf("error publishing sample submission data: %v", err)
 	}


### PR DESCRIPTION
# Description

It has been revealed that even though `DAL` was subscribing to multiple nodes, there were data delay when deploying bisonai node. After investigating this issue, it has been found that there were wrong implementation regarding redis pubsub

## AS-IS
Publish & Subscription redis key was based on config id

## TO-BE
Publish & Subscription base on symbol name

## Why is it required?
Config id is not a consistent value among different nodes
Through this update it will properly utilize data from multiple nodes from DAL

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
