### PR TITLE
(OraklNode) Add env for local run

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -45,6 +45,9 @@ BOOT_API_PORT=
 # (optional) required if utilizing boot api, defaults to http://localhost:8089
 BOOT_API_URL=
 
+# (optional) required to be true if running from local mac
+WITHOUT_PING_PRIVILIGED=
+
 # POR
 POR_REPORTER_PK=
 POR_CHAIN=

--- a/node/.env.example
+++ b/node/.env.example
@@ -46,7 +46,7 @@ BOOT_API_PORT=
 BOOT_API_URL=
 
 # (optional) required to be true if running from local mac
-WITHOUT_PING_PRIVILIGED=
+WITHOUT_PING_PRIVILEGED=
 
 # POR
 POR_REPORTER_PK=

--- a/node/README.md
+++ b/node/README.md
@@ -138,6 +138,9 @@ BOOT_API_PORT=<Your Boot API Port>
 # Boot API connection URL
 BOOT_API_URL=<Your Boot API URL>
 
+# Pinger priviliged set, not required from built image
+WITHOUT_PING_PRIVILIGED=<Set true if running local>
+
 # provider URLs referenced from fetcher, uses public JSON-RPC if not provided
 FETCHER_CYPRESS_PROVIDER_URL=<Your Cypress provider URL>
 FETCHER_ETHEREUM_PROVIDER_URL=<Your Ethereum provider URL>

--- a/node/README.md
+++ b/node/README.md
@@ -139,7 +139,7 @@ BOOT_API_PORT=<Your Boot API Port>
 BOOT_API_URL=<Your Boot API URL>
 
 # Pinger priviliged set, not required from built image
-WITHOUT_PING_PRIVILIGED=<Set true if running local>
+WITHOUT_PING_PRIVILEGED=<Set true if running local>
 
 # provider URLs referenced from fetcher, uses public JSON-RPC if not provided
 FETCHER_CYPRESS_PROVIDER_URL=<Your Cypress provider URL>

--- a/node/pkg/checker/ping/app.go
+++ b/node/pkg/checker/ping/app.go
@@ -2,6 +2,8 @@ package ping
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"time"
 
 	probing "github.com/prometheus-community/pro-bing"
@@ -96,7 +98,10 @@ func New(opts ...AppOption) (*App, error) {
 			return nil, err
 		}
 
-		pinger.SetPrivileged(true)
+		withoutPriviliged, err := strconv.ParseBool(os.Getenv("WITHOUT_PING_PRIVILIGED"))
+		if !withoutPriviliged || err != nil {
+			pinger.SetPrivileged(true)
+		}
 
 		pinger.OnRecv = func(pkt *probing.Packet) {
 			app.ResultsBuffer <- PingResult{

--- a/node/pkg/checker/ping/app.go
+++ b/node/pkg/checker/ping/app.go
@@ -98,7 +98,7 @@ func New(opts ...AppOption) (*App, error) {
 			return nil, err
 		}
 
-		withoutPriviliged, err := strconv.ParseBool(os.Getenv("WITHOUT_PING_PRIVILIGED"))
+		withoutPriviliged, err := strconv.ParseBool(os.Getenv("WITHOUT_PING_PRIVILEGED"))
 		if !withoutPriviliged || err != nil {
 			pinger.SetPrivileged(true)
 		}


### PR DESCRIPTION
# Description

Currently `privileged` setting for pinger isn't compatible in local environment, which runs without build and from mac. add option so that it can be customized in local

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
