### PR TITLE
(OraklNode) Update aggregator start func

### DIFF
--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -184,8 +184,8 @@ func (a *App) startAllAggregators(ctx context.Context) error {
 			log.Error().Str("Player", "Aggregator").Err(err).Str("name", aggregator.Name).Msg("failed to start aggregator")
 			return err
 		}
-		log.Info().Int("cnt", cnt).Msg("aggregator started successfully")
 		cnt++
+		log.Info().Int("cnt", cnt).Msg("aggregator started successfully")
 	}
 	return nil
 }

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"context"
-	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -178,15 +177,15 @@ func (a *App) startAggregatorById(ctx context.Context, id int32) error {
 }
 
 func (a *App) startAllAggregators(ctx context.Context) error {
+	cnt := 0
 	for _, aggregator := range a.Aggregators {
 		err := a.startAggregator(ctx, aggregator)
 		if err != nil {
 			log.Error().Str("Player", "Aggregator").Err(err).Str("name", aggregator.Name).Msg("failed to start aggregator")
 			return err
 		}
-		// starts with random sleep to avoid all aggregators starting at the same time
-		jitter := time.Duration(rand.Intn(100)) * time.Millisecond
-		time.Sleep(time.Millisecond*50 + jitter)
+		log.Info().Int("cnt", cnt).Msg("aggregator started successfully")
+		cnt++
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

- Remove time.sleep and jitter codes on starting aggregators
-> now it waits for localAggregates data to be ready which aren't produced at the same time
-> and even if it starts at same time, it has no external calls so aggregators shouldn't matter

- Add log to count started global aggregator

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
