### PR TITLE
(OraklNode) Subscribe to new header to avoid unexpected disconnection

### DIFF
--- a/node/pkg/chain/eth_client/eth_client.go
+++ b/node/pkg/chain/eth_client/eth_client.go
@@ -244,7 +244,7 @@ func (ec *EthClient) SyncProgress(ctx context.Context) (*klaytn.SyncProgress, er
 }
 
 func (ec *EthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (klaytn.Subscription, error) {
-	return ec.c.KlaySubscribe(ctx, ch, "newHeads")
+	return ec.c.Subscribe(ctx, "eth", ch, "newHeads")
 }
 
 func (ec *EthClient) NetworkID(ctx context.Context) (*big.Int, error) {

--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -79,6 +79,7 @@ type ClientInterface interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	BlockNumber(ctx context.Context) (*big.Int, error)
 	SubscribeFilterLogs(ctx context.Context, q klaytn.FilterQuery, ch chan<- types.Log) (klaytn.Subscription, error)
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (klaytn.Subscription, error)
 }
 
 type JsonRpcError interface {


### PR DESCRIPTION
# Description

reference: https://community.infura.io/t/websocket-close-1006-abnormal-closure-unexpected-eof/5210/7

- Updates websocket json rpc fetcher to also subscribe to latest block so that it doesn't get disconnected due to long idle connection
- Reduce log level which ended up in multiple 
`[Websocket: close 1006 (abnormal closure): unexpected EOF](https://community.infura.io/t/websocket-close-1006-abnormal-closure-unexpected-eof/5210)`, since it auto reconnects to the wss json rpc url, it should be okay with `Warn` level


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
