### PR TITLE
(OraklNode) Update restartFetcher

### DIFF
--- a/node/pkg/admin/fetcher/controller.go
+++ b/node/pkg/admin/fetcher/controller.go
@@ -52,39 +52,3 @@ func refresh(c *fiber.Ctx) error {
 	}
 	return c.SendString("fetcher refreshed: " + strconv.FormatBool(resp.Success))
 }
-
-func activate(c *fiber.Ctx) error {
-	id := c.Params("id")
-
-	msg, err := utils.SendMessage(c, bus.FETCHER, bus.ACTIVATE_FETCHER, map[string]any{"id": id})
-	if err != nil {
-		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to fetcher")
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to send activate message to fetcher: " + err.Error())
-	}
-
-	resp := <-msg.Response
-	if !resp.Success {
-		log.Error().Str("Player", "Admin").Msg("failed to activate fetcher")
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to activate adapter: " + resp.Args["error"].(string))
-	}
-
-	return c.JSON(resp)
-}
-
-func deactivate(c *fiber.Ctx) error {
-	id := c.Params("id")
-
-	msg, err := utils.SendMessage(c, bus.FETCHER, bus.DEACTIVATE_FETCHER, map[string]any{"id": id})
-	if err != nil {
-		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to fetcher")
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to send deactivate message to fetcher: " + err.Error())
-	}
-
-	resp := <-msg.Response
-	if !resp.Success {
-		log.Error().Str("Player", "Admin").Msg("failed to deactivate fetcher")
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to deactivate adapter: " + resp.Args["error"].(string))
-	}
-
-	return c.JSON(resp)
-}

--- a/node/pkg/admin/fetcher/router.go
+++ b/node/pkg/admin/fetcher/router.go
@@ -10,6 +10,4 @@ func Routes(router fiber.Router) {
 	fetcher.Post("/start", start)
 	fetcher.Post("/stop", stop)
 	fetcher.Post("/refresh", refresh)
-	fetcher.Post("/activate/:id", activate)
-	fetcher.Post("/deactivate/:id", deactivate)
 }

--- a/node/pkg/admin/tests/fetcher_test.go
+++ b/node/pkg/admin/tests/fetcher_test.go
@@ -3,7 +3,6 @@ package tests
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"bisonai.com/miko/node/pkg/bus"
@@ -65,39 +64,4 @@ func TestFetcherRefresh(t *testing.T) {
 	}
 
 	assert.Equal(t, string(result), "fetcher refreshed: true")
-}
-
-func TestFetcherDeactivate(t *testing.T) {
-	ctx := context.Background()
-	cleanup, testItems, err := setup(ctx)
-	if err != nil {
-		t.Fatalf("error setting up test: %v", err)
-	}
-	defer cleanup()
-
-	channel := testItems.mb.Subscribe(bus.FETCHER)
-	waitForMessage(t, channel, bus.ADMIN, bus.FETCHER, bus.DEACTIVATE_FETCHER)
-
-	_, err = RawPostRequest(testItems.app, "/api/v1/fetcher/deactivate/"+strconv.Itoa(int(testItems.tmpData.config.ID)), nil)
-	if err != nil {
-		t.Fatalf("error deactivating adapter: %v", err)
-	}
-}
-
-func TestAdapterActivate(t *testing.T) {
-	ctx := context.Background()
-	cleanup, testItems, err := setup(ctx)
-	if err != nil {
-		t.Fatalf("error setting up test: %v", err)
-	}
-	defer cleanup()
-
-	channel := testItems.mb.Subscribe(bus.FETCHER)
-	waitForMessage(t, channel, bus.ADMIN, bus.FETCHER, bus.ACTIVATE_FETCHER)
-
-	// activate
-	_, err = RawPostRequest(testItems.app, "/api/v1/fetcher/activate/"+strconv.Itoa(int(testItems.tmpData.config.ID)), nil)
-	if err != nil {
-		t.Fatalf("error activating adapter: %v", err)
-	}
 }


### PR DESCRIPTION
# Description

- Remove admin endpoint
> - activate/deactivate: fetcher start/stop based on config id isn't compatible anymore for websocket fetcher

- Remove fetcher bus message command
> - `ACTIVATE_FETCHER` & `DEACTIVATE_FETCHER`: command no more compatible to run based on configID

- Add WebsocketFetcher `Stop` func: include websocketFetcher Stop in fetcher app StopAll func

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
