### PR TITLE
(OraklNode) Refresh fetcher when global aggregate and local aggregate price differ by more than 30%

### DIFF
--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -295,6 +295,7 @@ func (n *Aggregator) HandleProofMessage(ctx context.Context, msg raft.Message) e
 
 		n.mu.Lock()
 		defer n.mu.Unlock()
+		defer delete(n.roundLocalAggregate, proofMessage.RoundID)
 		if localAggregate, ok := n.roundLocalAggregate[proofMessage.RoundID]; ok {
 			if math.Abs(float64(localAggregate-globalAggregate.Value))/float64(globalAggregate.Value) > 0.3 {
 				log.Warn().Str("Player", "Aggregator").Str("Name", n.Name).Int32("roundId", proofMessage.RoundID).Int64("localAggregate", localAggregate).Int64("globalAggregate", globalAggregate.Value).Msg("local aggregate and global aggregate mismatch")
@@ -319,7 +320,6 @@ func (n *Aggregator) HandleProofMessage(ctx context.Context, msg raft.Message) e
 		if err != nil {
 			log.Error().Str("Player", "Aggregator").Err(err).Msg("failed to publish global aggregate and proof")
 		}
-		delete(n.roundLocalAggregate, proofMessage.RoundID)
 	}
 	return nil
 }

--- a/node/pkg/aggregator/aggregator.go
+++ b/node/pkg/aggregator/aggregator.go
@@ -63,6 +63,8 @@ func NewAggregator(
 		Signer:                signHelper,
 		LatestLocalAggregates: latestLocalAggregates,
 		bus:                   mb,
+
+		roundLocalAggregate: map[int32]int64{},
 	}
 	aggregator.Raft.LeaderJob = aggregator.LeaderJob
 	aggregator.Raft.HandleCustomMessage = aggregator.HandleCustomMessage
@@ -308,6 +310,8 @@ func (n *Aggregator) HandleProofMessage(ctx context.Context, msg raft.Message) e
 				if err != nil {
 					log.Warn().Str("Player", "Aggregator").Err(err).Msg("failed to publish fetcher refresh bus message")
 				}
+
+				return errorSentinel.ErrAggregatorGlobalLocalPriceMismatch
 			}
 		}
 

--- a/node/pkg/aggregator/aggregator_test.go
+++ b/node/pkg/aggregator/aggregator_test.go
@@ -23,14 +23,14 @@ func TestNewAggregator(t *testing.T) {
 		}
 	}()
 
-	_, err = NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap)
+	_, err = NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap, testItems.app.Bus)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
 }
 
 func TestNewAggregator_Error(t *testing.T) {
-	_, err := NewAggregator(nil, nil, "", Config{}, nil, nil)
+	_, err := NewAggregator(nil, nil, "", Config{}, nil, nil, nil)
 	assert.NotNil(t, err, "Expected error when creating new aggregator with nil parameters")
 }
 
@@ -46,7 +46,7 @@ func TestLeaderJob(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap, testItems.app.Bus)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -70,7 +70,7 @@ func TestGetLatestRoundId(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap, testItems.app.Bus)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}
@@ -98,7 +98,7 @@ func TestPublishGlobalAggregateAndProof(t *testing.T) {
 		}
 	}()
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap, testItems.app.Bus)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -127,7 +127,7 @@ func (a *App) initializeLoadedAggregators(ctx context.Context, loadedConfigs []C
 		}
 
 		topicString := config.Name + "-global-aggregator-topic-" + strconv.Itoa(int(config.AggregateInterval))
-		tmpNode, err := NewAggregator(h, ps, topicString, config, signer, a.LatestLocalAggregates)
+		tmpNode, err := NewAggregator(h, ps, topicString, config, signer, a.LatestLocalAggregates, a.Bus)
 		if err != nil {
 			return err
 		}

--- a/node/pkg/aggregator/globalaggregatebulkwriter_test.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter_test.go
@@ -86,7 +86,7 @@ func TestGlobalAggregateBulkWriterDataStore(t *testing.T) {
 	defer bulkWriter.Stop()
 	assert.NotEqual(t, nil, bulkWriter.ctx)
 
-	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap)
+	node, err := NewAggregator(testItems.app.Host, testItems.app.Pubsub, testItems.topicString, testItems.tmpData.config, testItems.signer, testItems.latestLocalAggMap, testItems.app.Bus)
 	if err != nil {
 		t.Fatal("error creating new node")
 	}

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	AGREEMENT_QUORUM = 0.5
+	GLOBAL_AGGREGATE_ERR_THRESHOLD = 0.3
+	AGREEMENT_QUORUM               = 0.5
 
 	Trigger   raft.MessageType = "trigger"
 	PriceData raft.MessageType = "priceData"

--- a/node/pkg/aggregator/types.go
+++ b/node/pkg/aggregator/types.go
@@ -186,10 +186,12 @@ type Aggregator struct {
 	Raft *raft.Raft
 
 	LatestLocalAggregates *LatestLocalAggregates
-	roundTriggers         *RoundTriggers
-	roundPrices           *RoundPrices
-	roundPriceFixes       *RoundPriceFixes
-	roundProofs           *RoundProofs
+	roundLocalAggregate   map[int32]int64
+
+	roundTriggers   *RoundTriggers
+	roundPrices     *RoundPrices
+	roundPriceFixes *RoundPriceFixes
+	roundProofs     *RoundProofs
 
 	RoundID int32
 	Signer  *helper.Signer
@@ -198,7 +200,8 @@ type Aggregator struct {
 	nodeCancel context.CancelFunc
 	isRunning  bool
 
-	mu sync.RWMutex
+	mu  sync.RWMutex
+	bus *bus.MessageBus
 }
 
 type PriceDataMessage struct {

--- a/node/pkg/error/sentinel.go
+++ b/node/pkg/error/sentinel.go
@@ -156,6 +156,7 @@ var (
 	ErrFetcherFailedToGetDexResultSlice       = &CustomError{Service: Fetcher, Code: InternalError, Message: "Failed to get dex result slice"}
 	ErrFetcherFailedBigIntConvert             = &CustomError{Service: Fetcher, Code: InternalError, Message: "Failed to convert to fetched data to big.Int"}
 	ErrFetcherFeedNotFound                    = &CustomError{Service: Fetcher, Code: InvalidInputError, Message: "Feed not found"}
+	ErrFetcherRefreshCooldown                 = &CustomError{Service: Fetcher, Code: InternalError, Message: "Failed to refresh data: cooldown period not over"}
 
 	ErrLibP2pEmptyNonLocalAddress = &CustomError{Service: Others, Code: InternalError, Message: "Host has no non-local addresses"}
 	ErrLibP2pAddressSplitFail     = &CustomError{Service: Others, Code: InternalError, Message: "Failed to split address"}

--- a/node/pkg/error/sentinel.go
+++ b/node/pkg/error/sentinel.go
@@ -92,6 +92,7 @@ var (
 	ErrAggregatorNotFound                 = &CustomError{Service: Aggregator, Code: InternalError, Message: "Aggregator not found"}
 	ErrAggregatorCancelNotFound           = &CustomError{Service: Aggregator, Code: InternalError, Message: "Aggregator cancel function not found"}
 	ErrAggregatorEmptyProof               = &CustomError{Service: Aggregator, Code: InternalError, Message: "Empty proof"}
+	ErrAggregatorGlobalLocalPriceMismatch = &CustomError{Service: Aggregator, Code: InternalError, Message: "Global and local price mismatch"}
 
 	ErrBootAPIDbPoolNotFound = &CustomError{Service: BootAPI, Code: InternalError, Message: "db pool not found"}
 

--- a/node/pkg/fetcher/app.go
+++ b/node/pkg/fetcher/app.go
@@ -64,7 +64,7 @@ func (a *App) subscribe(ctx context.Context) {
 }
 
 func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
-	if msg.From != bus.ADMIN || msg.From != bus.ACTIVATE_AGGREGATOR {
+	if msg.From != bus.ADMIN && msg.From != bus.ACTIVATE_AGGREGATOR {
 		log.Debug().Str("Player", "Fetcher").Msg("fetcher received message from non-admin")
 		return
 	}

--- a/node/pkg/fetcher/app.go
+++ b/node/pkg/fetcher/app.go
@@ -64,7 +64,7 @@ func (a *App) subscribe(ctx context.Context) {
 }
 
 func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
-	if msg.From != bus.ADMIN && msg.From != bus.ACTIVATE_AGGREGATOR {
+	if msg.From != bus.ADMIN && msg.From != bus.AGGREGATOR {
 		log.Debug().Str("Player", "Fetcher").Msg("fetcher received message from non-admin")
 		return
 	}

--- a/node/pkg/fetcher/main_test.go
+++ b/node/pkg/fetcher/main_test.go
@@ -262,7 +262,7 @@ func cleanup(ctx context.Context, testItems *TestItems) func() error {
 			return err
 		}
 
-		err = testItems.app.stopAllFetchers(ctx)
+		err = testItems.app.stopAll(ctx)
 		if err != nil {
 			return err
 		}

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -25,6 +25,7 @@ const (
 	DefaultLocalAggregateInterval         = 200 * time.Millisecond
 	DefaultFeedDataDumpChannelSize        = 20000
 	MaxOutlierRemovalRatio                = 0.25
+	RefreshCooldownInterval               = 5 * time.Minute
 )
 
 type Feed = types.Feed
@@ -91,6 +92,7 @@ type App struct {
 	LatestFeedDataMap        *LatestFeedDataMap
 	Proxies                  []Proxy
 	FeedDataDumpChannel      chan *FeedData
+	LastRefreshTime          time.Time
 }
 
 type Definition struct {

--- a/node/pkg/fetcher/utils_test.go
+++ b/node/pkg/fetcher/utils_test.go
@@ -117,6 +117,8 @@ func TestCopyFeedData(t *testing.T) {
 		}
 	}()
 
+	testItems.app.initialize(ctx)
+
 	feeds := testItems.insertedFeeds
 	feedData := []*FeedData{}
 


### PR DESCRIPTION
# Description

It'll auto restart fetcher if difference over 30% between local aggregate and global aggregate is detected
The problem with this approach is, that it will restart fetchers from properly working nodes too.

better approach might be comparing with given local aggregate values from other nodes. yet there aren't enough nodes atm to check if current node's value is majority or not

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
