### PR TITLE
(Sentinel) Add missing msg for delayed websocket counts

### DIFF
--- a/node/pkg/checker/dal/app.go
+++ b/node/pkg/checker/dal/app.go
@@ -230,6 +230,7 @@ func extractWsDelayAlarms(ctx context.Context, alarmCount map[string]int) []stri
 		return nil
 	}
 
+	delayedSymbolCount := 0
 	delayedSymbols := map[string]any{}
 	resultMsgs := []string{}
 	for _, entry := range rawMsgs {
@@ -240,7 +241,13 @@ func extractWsDelayAlarms(ctx context.Context, alarmCount map[string]int) []stri
 		if alarmCount[symbol] > AlarmOffsetPerPair {
 			resultMsgs = append(resultMsgs, entry)
 			alarmCount[symbol] = 0
+		} else if alarmCount[symbol] > AlarmOffsetInTotal {
+			delayedSymbolCount++
 		}
+	}
+
+	if delayedSymbolCount > 0 {
+		resultMsgs = append(resultMsgs, fmt.Sprintf("Websocket delayed for %d symbols", delayedSymbolCount))
 	}
 
 	for symbol := range alarmCount {


### PR DESCRIPTION
# Description

add missing alarm msg with number of delayed websocket counts

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
