### PR TITLE
downgrade sentinel peer count error to warn

### DIFF
--- a/node/pkg/checker/peers/app.go
+++ b/node/pkg/checker/peers/app.go
@@ -56,7 +56,7 @@ func Start() error {
 		newPeerCount, err := checkPeerCounts()
 		log.Debug().Int("peer count", newPeerCount).Msg("peer count")
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to check peer count")
+			log.Warn().Err(err).Msg("Failed to check peer count")
 			failCount++
 			if failCount > 10 {
 				alert.SlackAlert(fmt.Sprintf("failed to check peer count %d times. Check miko Sentinel logs", failCount))


### PR DESCRIPTION
# Description

Since sentinel sends slack message if peer count fails more than 10 times, it should be safe to downgrade the error level to warn to avoid spamming logscribe.

Fixes https://github.com/Bisonai/orakl/issues/2194

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
