### PR TITLE
(Node) Remove max delay logic, instead use alpha with avg

### DIFF
--- a/node/pkg/checker/ping/app.go
+++ b/node/pkg/checker/ping/app.go
@@ -117,7 +117,7 @@ func New(opts ...AppOption) (*App, error) {
 			return nil, err
 		}
 
-		if !withoutPrivileged || err != nil {
+		if !withoutPrivileged {
 			pinger.SetPrivileged(true)
 		}
 
@@ -181,7 +181,7 @@ func (app *App) Start(ctx context.Context) {
 				if _, exists := app.RTTAvg[result.Address]; !exists {
 					app.RTTAvg[result.Address] = float64(result.Delay)
 				} else {
-					app.RTTAvg[result.Address] = app.RTTAvg[result.Address]*app.Alpha + float64(result.Delay)*(1-app.Alpha)
+					app.RTTAvg[result.Address] = app.Alpha*float64(result.Delay) + (1-app.Alpha)*app.RTTAvg[result.Address]
 				}
 
 				if result.Delay > time.Duration(app.ThresholdFactor*app.RTTAvg[result.Address]) {


### PR DESCRIPTION
# Description

Instead of simply comparing RTT with absolute delay, 
Use average delay and check sudden increase of delay

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
