### PR TITLE
Update contract

### DIFF
--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -440,7 +440,7 @@ contract SubmissionProxy is Ownable {
         }
 
         if (lastSubmissionTimes[_feedHash] >= _timestamp) {
-            // answer is superseeded -> do not submit!
+            // answer is superseded -> do not submit!
             revert AnswerSuperseded();
         }
 
@@ -499,7 +499,7 @@ contract SubmissionProxy is Ownable {
 
     /**
      * @notice Submit a single submission to a feed. The submission is
-     * ignored if it has been superseeded. If the submission does not
+     * ignored if it has been superseded. If the submission does not
      * meet the rest of required conditions the submission is reverted.
      * @param _feedHash The hash of the feed
      * @param _answer The submission
@@ -513,7 +513,7 @@ contract SubmissionProxy is Ownable {
         bytes calldata _proof
     ) public {
         if (lastSubmissionTimes[_feedHash] >= _timestamp) {
-            // answer is superseeded -> skip submission
+            // answer is superseded -> skip submission
             return;
         }
 

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -483,7 +483,7 @@ contract SubmissionProxy is Ownable {
         int256[] calldata _answers,
         uint256[] calldata _timestamps,
         bytes[] calldata _proofs
-    ) public {
+    ) external {
         if (
             _feedHashes.length != _answers.length || _answers.length != _proofs.length
                 || _proofs.length != _timestamps.length || _feedHashes.length > maxSubmission

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -535,9 +535,6 @@ contract SubmissionProxy is Ownable {
 
         bytes32 message_ = keccak256(abi.encodePacked(_answer, _timestamp, _feedHash));
         if (validateProof(_feedHash, message_, proofs_)) {
-            if (lastSubmissionTimes[_feedHash] >= _timestamp) {
-                return;
-            }
             feeds[_feedHash].submit(_answer);
             lastSubmissionTimes[_feedHash] = _timestamp;
         } else {

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -450,6 +450,56 @@ contract SubmissionProxy is Ownable {
         }
     }
 
+    // works same as submit, but will only return error if the proof is invalid, ignore if answer is superseded
+    function updatePrices(bytes32[] calldata _feedHashes, int256[] calldata _answers, uint256[] calldata _timestamps, bytes[] calldata _proofs) public {
+        if (
+            _feedHashes.length != _answers.length || _answers.length != _proofs.length
+                || _proofs.length != _timestamps.length || _feedHashes.length > maxSubmission
+        ) {
+            revert InvalidSubmissionLength();
+        }
+
+        uint256 feedsLength_ = _feedHashes.length;
+        for (uint256 i = 0; i < feedsLength_; i++) {
+            updatePrice(_feedHashes[i], _answers[i], _timestamps[i], _proofs[i]);
+        }
+    }
+
+
+    function updatePrice(bytes32 _feedHash, int256 _answer, uint256 _timestamp, bytes calldata _proof) public {
+        if (_timestamp <= (block.timestamp - dataFreshness) * 1000 ) {
+            revert AnswerOutdated();
+        }
+
+        if (lastSubmissionTimes[_feedHash] >= _timestamp) {
+            return;
+        }
+
+        (bytes[] memory proofs_, bool success_) = splitProofs(_proof);
+        if (!success_) {
+            // splitting proofs failed -> do not submit!
+            revert InvalidProofFormat();
+        }
+
+        if (address(feeds[_feedHash]) == address(0)) {
+            // feedHash not registered -> do not submit!
+            revert FeedHashNotFound();
+        }
+
+        if (keccak256(abi.encodePacked(feeds[_feedHash].name())) != _feedHash) {
+            // feedHash not matching with registered feed -> do not submit!
+            revert InvalidFeedHash();
+        }
+
+        bytes32 message_ = keccak256(abi.encodePacked(_answer, _timestamp, _feedHash));
+        if (validateProof(_feedHash, message_, proofs_)) {
+            feeds[_feedHash].submit(_answer);
+            lastSubmissionTimes[_feedHash] = _timestamp;
+        } else {
+            revert InvalidProof();
+        }
+    }
+
     /**
      * @notice Return the version and type of the feed.
      * @return typeAndVersion The type and version of the feed.

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -406,7 +406,7 @@ contract SubmissionProxy is Ownable {
      * @param _timestamps The unixmilli timestamps of the proofs
      * @param _proofs The proofs
      */
-    function submitStrictBatch(
+    function submitStrict(
         bytes32[] calldata _feedHashes,
         int256[] calldata _answers,
         uint256[] calldata _timestamps,
@@ -471,14 +471,14 @@ contract SubmissionProxy is Ownable {
 
     /**
      * @notice Submit a batch of answers to multiple feeds. The answers are
-     * ignored if they have been superseeded. If any of the answers do not
+     * ignored if they have been superseded. If any of the answers do not
      * meet the rest of required conditions the whole batch is reverted.
      * @param _feedHashes The hashes of the feeds
      * @param _answers The submissions
      * @param _timestamps The unixmilli timestamps of the proofs
      * @param _proofs The proofs
      */
-    function updatePrices(
+    function submitWithoutSupersedValidation(
         bytes32[] calldata _feedHashes,
         int256[] calldata _answers,
         uint256[] calldata _timestamps,
@@ -493,7 +493,7 @@ contract SubmissionProxy is Ownable {
 
         uint256 feedsLength_ = _feedHashes.length;
         for (uint256 i = 0; i < feedsLength_; i++) {
-            updatePrice(_feedHashes[i], _answers[i], _timestamps[i], _proofs[i]);
+            submitSingleWithoutSupersedValidation(_feedHashes[i], _answers[i], _timestamps[i], _proofs[i]);
         }
     }
 
@@ -506,7 +506,12 @@ contract SubmissionProxy is Ownable {
      * @param _timestamp The unixmilli timestamp of the proof
      * @param _proof The proof
      */
-    function updatePrice(bytes32 _feedHash, int256 _answer, uint256 _timestamp, bytes calldata _proof) public {
+    function submitSingleWithoutSupersedValidation(
+        bytes32 _feedHash,
+        int256 _answer,
+        uint256 _timestamp,
+        bytes calldata _proof
+    ) public {
         if (lastSubmissionTimes[_feedHash] >= _timestamp) {
             // answer is superseeded -> skip submission
             return;

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -37,8 +37,8 @@ contract SubmissionProxy is Ownable {
 
     mapping(address => OracleInfo) public whitelist;
     mapping(bytes32 feedHash => IFeed feed) public feeds;
-    mapping(bytes32 feedHash => uint8 threshold) thresholds;
-    mapping(bytes32 feedHash => uint256 lastSubmissionTime) lastSubmissionTimes;
+    mapping(bytes32 feedHash => uint8 threshold) public thresholds;
+    mapping(bytes32 feedHash => uint256 lastSubmissionTime) public lastSubmissionTimes;
 
     event OracleAdded(address oracle, uint256 expirationTime);
     event OracleRemoved(address oracle);
@@ -417,6 +417,59 @@ contract SubmissionProxy is Ownable {
 
     function submitSingle(bytes32 _feedHash, int256 _answer, uint256 _timestamp, bytes calldata _proof) public {
         if (_timestamp <= (block.timestamp - dataFreshness) * 1000 || lastSubmissionTimes[_feedHash] >= _timestamp) {
+            revert AnswerTooOld();
+        }
+
+        (bytes[] memory proofs_, bool success_) = splitProofs(_proof);
+        if (!success_) {
+            // splitting proofs failed -> do not submit!
+            revert InvalidProofFormat();
+        }
+
+        if (address(feeds[_feedHash]) == address(0)) {
+            // feedHash not registered -> do not submit!
+            revert FeedHashNotFound();
+        }
+
+        if (keccak256(abi.encodePacked(feeds[_feedHash].name())) != _feedHash) {
+            // feedHash not matching with registered feed -> do not submit!
+            revert InvalidFeedHash();
+        }
+
+        bytes32 message_ = keccak256(abi.encodePacked(_answer, _timestamp, _feedHash));
+        if (validateProof(_feedHash, message_, proofs_)) {
+            feeds[_feedHash].submit(_answer);
+            lastSubmissionTimes[_feedHash] = _timestamp;
+        } else {
+            revert InvalidProof();
+        }
+    }
+
+    function submitOnlyNew(
+          bytes32[] calldata _feedHashes,
+        int256[] calldata _answers,
+        uint256[] calldata _timestamps,
+        bytes[] calldata _proofs
+    ) external {
+        if (
+            _feedHashes.length != _answers.length || _answers.length != _proofs.length
+                || _proofs.length != _timestamps.length || _feedHashes.length > maxSubmission
+        ) {
+            revert InvalidSubmissionLength();
+        }
+
+        uint256 feedsLength_ = _feedHashes.length;
+        for (uint256 i = 0; i < feedsLength_; i++) {
+            submitSingleIfNew(_feedHashes[i], _answers[i], _timestamps[i], _proofs[i]);
+        }
+    }
+
+    function submitSingleIfNew(bytes32 _feedHash, int256 _answer, uint256 _timestamp, bytes calldata _proof) public {
+        if (lastSubmissionTimes[_feedHash] >= _timestamp) {
+            return;
+        }
+
+        if (_timestamp <= (block.timestamp - dataFreshness) * 1000 ) {
             revert AnswerTooOld();
         }
 

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -471,10 +471,6 @@ contract SubmissionProxy is Ownable {
             revert AnswerOutdated();
         }
 
-        if (lastSubmissionTimes[_feedHash] >= _timestamp) {
-            return;
-        }
-
         (bytes[] memory proofs_, bool success_) = splitProofs(_proof);
         if (!success_) {
             // splitting proofs failed -> do not submit!
@@ -493,6 +489,9 @@ contract SubmissionProxy is Ownable {
 
         bytes32 message_ = keccak256(abi.encodePacked(_answer, _timestamp, _feedHash));
         if (validateProof(_feedHash, message_, proofs_)) {
+            if (lastSubmissionTimes[_feedHash] >= _timestamp) {
+                return;
+            }
             feeds[_feedHash].submit(_answer);
             lastSubmissionTimes[_feedHash] = _timestamp;
         } else {

--- a/contracts/v0.2/src/SubmissionProxy.sol
+++ b/contracts/v0.2/src/SubmissionProxy.sol
@@ -61,7 +61,8 @@ contract SubmissionProxy is Ownable {
     error InvalidSignatureLength();
     error InvalidFeed();
     error ZeroAddressGiven();
-    error AnswerTooOld();
+    error AnswerOutdated();
+    error AnswerSuperseded();
     error InvalidProofFormat();
     error InvalidProof();
     error FeedHashNotFound();
@@ -416,8 +417,12 @@ contract SubmissionProxy is Ownable {
     }
 
     function submitSingle(bytes32 _feedHash, int256 _answer, uint256 _timestamp, bytes calldata _proof) public {
-        if (_timestamp <= (block.timestamp - dataFreshness) * 1000 || lastSubmissionTimes[_feedHash] >= _timestamp) {
-            revert AnswerTooOld();
+        if (_timestamp <= (block.timestamp - dataFreshness) * 1000 ) {
+            revert AnswerOutdated();
+        }
+
+        if (lastSubmissionTimes[_feedHash] >= _timestamp) {
+            revert AnswerSuperseded();
         }
 
         (bytes[] memory proofs_, bool success_) = splitProofs(_proof);

--- a/contracts/v0.2/test/SubmissionProxy.t.sol
+++ b/contracts/v0.2/test/SubmissionProxy.t.sol
@@ -463,7 +463,7 @@ contract SubmissionProxyTest is Test {
         IFeed(feeds_[0]).latestRoundData();
     }
 
-    function test_submitWithoutSupersededValidation() public {
+    function test_submitWithoutSupersedValidation() public {
         (address alice_, uint256 aliceSk_) = makeAddrAndKey("alice");
         (address bob_, uint256 bobSk_) = makeAddrAndKey("bob");
         (address celine_, uint256 celineSk_) = makeAddrAndKey("celine");
@@ -493,7 +493,7 @@ contract SubmissionProxyTest is Test {
         IFeed(feeds_[0]).latestRoundData();
     }
 
-       function test_submitWithoutSupersededValidationIgnoreLateSubmission() public {
+       function test_submitWithoutSupersedValidationIgnoreLateSubmission() public {
 
 
         (address alice_, uint256 aliceSk_) = makeAddrAndKey("alice");

--- a/contracts/v0.2/test/SubmitStrict.t.sol
+++ b/contracts/v0.2/test/SubmitStrict.t.sol
@@ -27,7 +27,7 @@ contract SubmitStrictTest is Test {
 	console.logBytes(proofs[0]);
 
 	SubmissionProxy sp = SubmissionProxy(0x3a251c738e19806A546815eb6065e139A8D65B4b);
-	sp.submitStrict(
+	sp.submitStrictBatch(
 	    feedHashes,
 	    valuesInt,
 	    timestampsInt,

--- a/contracts/v0.2/test/SubmitStrict.t.sol
+++ b/contracts/v0.2/test/SubmitStrict.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Vm.sol";
 import {Test, console} from "forge-std/Test.sol";
-import { stdJson } from "forge-std/StdJson.sol";
+import {stdJson} from "forge-std/StdJson.sol";
 import {SubmissionProxy} from "../src/SubmissionProxy.sol";
 import {FeedRouter} from "../src/FeedRouter.sol";
 import "forge-std/console.sol";
@@ -12,73 +12,68 @@ contract SubmitStrictTest is Test {
     using stdJson for string;
 
     function run() public {
-	string memory json = vm.readFile("submission.json");
+        string memory json = vm.readFile("submission.json");
 
-	string[] memory symbols = getsymbols(json);
-	bytes32[] memory feedHashes = gethashes(json);
-	int256[] memory valuesInt = getvalues(json);
-	uint256[] memory timestampsInt = gettimestamps(json);
-	bytes[] memory proofs = getproofs(json);
+        string[] memory symbols = getsymbols(json);
+        bytes32[] memory feedHashes = gethashes(json);
+        int256[] memory valuesInt = getvalues(json);
+        uint256[] memory timestampsInt = gettimestamps(json);
+        bytes[] memory proofs = getproofs(json);
 
-	console.log("submission");
-	console.logBytes32(feedHashes[0]);
-	console.logInt(valuesInt[0]);
-	console.logUint(timestampsInt[0]);
-	console.logBytes(proofs[0]);
+        console.log("submission");
+        console.logBytes32(feedHashes[0]);
+        console.logInt(valuesInt[0]);
+        console.logUint(timestampsInt[0]);
+        console.logBytes(proofs[0]);
 
-	SubmissionProxy sp = SubmissionProxy(0x3a251c738e19806A546815eb6065e139A8D65B4b);
-	sp.submitStrictBatch(
-	    feedHashes,
-	    valuesInt,
-	    timestampsInt,
-	    proofs
-	);
+        SubmissionProxy sp = SubmissionProxy(0x3a251c738e19806A546815eb6065e139A8D65B4b);
+        sp.submitStrict(feedHashes, valuesInt, timestampsInt, proofs);
 
-	console.log(block.timestamp);
+        console.log(block.timestamp);
 
-	FeedRouter fr = FeedRouter(0x653078F0D3a230416A59aA6486466470Db0190A2);
-	(uint64 roundId, int256 answer, uint256 blockTimestamp) = fr.latestRoundData(symbols[0]);
+        FeedRouter fr = FeedRouter(0x653078F0D3a230416A59aA6486466470Db0190A2);
+        (uint64 roundId, int256 answer, uint256 blockTimestamp) = fr.latestRoundData(symbols[0]);
 
-	console.log("latestRoundData");
-	console.logUint(roundId);
-	console.logInt(answer);
-	console.logUint(blockTimestamp);
+        console.log("latestRoundData");
+        console.logUint(roundId);
+        console.logInt(answer);
+        console.logUint(blockTimestamp);
 
-	require(block.timestamp == blockTimestamp, "Timestamps do not match");
+        require(block.timestamp == blockTimestamp, "Timestamps do not match");
     }
 
     function getsymbols(string memory json) public pure returns (string[] memory) {
-	bytes memory rawSymbols = json.parseRaw(".symbols");
-	return abi.decode(rawSymbols, (string[]));
+        bytes memory rawSymbols = json.parseRaw(".symbols");
+        return abi.decode(rawSymbols, (string[]));
     }
 
     function gethashes(string memory json) public pure returns (bytes32[] memory) {
-	bytes memory rawFeedHashes = json.parseRaw(".feedHashes");
+        bytes memory rawFeedHashes = json.parseRaw(".feedHashes");
         return abi.decode(rawFeedHashes, (bytes32[]));
     }
 
     function getvalues(string memory json) public pure returns (int256[] memory) {
-	bytes memory rawValues = json.parseRaw(".values");
-	string[] memory values = abi.decode(rawValues, (string[]));
-	int256[] memory valuesInt = new int256[](values.length);
-	for (uint i = 0; i < values.length; i++) {
-	    valuesInt[i] = vm.parseInt(values[i]);
-	}
-	return valuesInt;
+        bytes memory rawValues = json.parseRaw(".values");
+        string[] memory values = abi.decode(rawValues, (string[]));
+        int256[] memory valuesInt = new int256[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            valuesInt[i] = vm.parseInt(values[i]);
+        }
+        return valuesInt;
     }
 
     function gettimestamps(string memory json) public pure returns (uint256[] memory) {
-	bytes memory rawTimestamps = json.parseRaw(".aggregateTimes");
-	string[] memory timestamps = abi.decode(rawTimestamps, (string[]));
-	uint256[] memory timestampsInt = new uint256[](timestamps.length);
-	for (uint i = 0; i < timestamps.length; i++) {
-	    timestampsInt[i] = vm.parseUint(timestamps[i]);
-	}
-	return timestampsInt;
+        bytes memory rawTimestamps = json.parseRaw(".aggregateTimes");
+        string[] memory timestamps = abi.decode(rawTimestamps, (string[]));
+        uint256[] memory timestampsInt = new uint256[](timestamps.length);
+        for (uint256 i = 0; i < timestamps.length; i++) {
+            timestampsInt[i] = vm.parseUint(timestamps[i]);
+        }
+        return timestampsInt;
     }
 
     function getproofs(string memory json) public pure returns (bytes[] memory) {
-	bytes memory rawProofs = json.parseRaw(".proofs");
-	return abi.decode(rawProofs, (bytes[]));
+        bytes memory rawProofs = json.parseRaw(".proofs");
+        return abi.decode(rawProofs, (bytes[]));
     }
 }


### PR DESCRIPTION
# Description

There have been a client request with submission proxy contract
This update tries to fix following scenario

1. `user a` and `user b` tries to submit in a same block.timestamp 10
2. `user a` received dal timestamp with 8 while `user b` received dal timestamp with 9
3. when `user a` and `user b` submits at the same time, if the execution order becomes b->a, `user a` fails to submit the price. 

if the submission fails, client can't tell whether it is caused by data freshness failure, or because if there was a newer submission ahead.

it is hard for client to make decision with the latest round data even if the submission error is ignored

there are 2 approaches that could be taken
1. make `lastSubmissionTimes` public so that client can utilize lastSubmissionTimes
2. add function that only updates if the data is newer, if not, just ignore

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Deployment

- [ ] Should publish npm package
- [ ] Should publish Docker image
