### PR TITLE
feat: Uniswap V4 fetcher + Arbitrum chain (IDRP/JPYC/MYRC feeds)

### DIFF
--- a/node/pkg/chain/websocketchainreader/type.go
+++ b/node/pkg/chain/websocketchainreader/type.go
@@ -6,6 +6,7 @@ import (
 
 	"bisonai.com/miko/node/pkg/chain/utils"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 )
 
 type BlockchainType int
@@ -16,15 +17,17 @@ const (
 	BSC      BlockchainType = 3
 	Polygon  BlockchainType = 4
 	Base     BlockchainType = 5
+	Arbitrum BlockchainType = 6
 )
 
 type ChainReaderConfig struct {
-	KaiaWebsocketUrl    string
-	EthWebsocketUrl     string
-	BSCWebsocketUrl     string
-	PolygonWebsocketUrl string
-	BaseWebsocketUrl    string
-	RetryInterval       time.Duration
+	KaiaWebsocketUrl     string
+	EthWebsocketUrl      string
+	BSCWebsocketUrl      string
+	PolygonWebsocketUrl  string
+	BaseWebsocketUrl     string
+	ArbitrumWebsocketUrl string
+	RetryInterval        time.Duration
 }
 
 type ChainReaderOption func(*ChainReaderConfig)
@@ -59,6 +62,12 @@ func WithBaseWebsocketUrl(url string) ChainReaderOption {
 	}
 }
 
+func WithArbitrumWebsocketUrl(url string) ChainReaderOption {
+	return func(c *ChainReaderConfig) {
+		c.ArbitrumWebsocketUrl = url
+	}
+}
+
 func WithRetryInterval(interval time.Duration) ChainReaderOption {
 	return func(c *ChainReaderConfig) {
 		c.RetryInterval = interval
@@ -71,6 +80,7 @@ type ChainReader struct {
 	BscClient          utils.ClientInterface
 	PolygonClient      utils.ClientInterface
 	BaseClient         utils.ClientInterface
+	ArbitrumClient     utils.ClientInterface
 	RetryPeriod        time.Duration
 	ChainIdToChainType map[string]BlockchainType
 }
@@ -80,6 +90,15 @@ type SubscribeConfig struct {
 	Ch          chan<- types.Log
 	ChainType   BlockchainType
 	BlockNumber *big.Int
+	// Topics is an optional event-topic filter passed straight through to
+	// the chain's eth_subscribe/logs filter.  Empty (nil or zero-length)
+	// means "any topic" — same as before this field existed.  The slice
+	// follows go-ethereum FilterQuery semantics: each outer element
+	// constrains topic[i] (an inner OR of allowed values).  Used by the
+	// Uniswap V4 fetcher to subscribe to PoolManager Swap events filtered
+	// by the indexed pool id (otherwise we'd receive every swap on the
+	// chain, not just our target pools).
+	Topics [][]common.Hash
 }
 
 type SubscribeOption func(*SubscribeConfig)
@@ -105,5 +124,17 @@ func WithChainType(chainType BlockchainType) SubscribeOption {
 func WithStartBlockNumber(blockNumber *big.Int) SubscribeOption {
 	return func(c *SubscribeConfig) {
 		c.BlockNumber = blockNumber
+	}
+}
+
+// WithTopics sets the optional topic filter for the subscription.  The
+// outer slice is positional — element i constrains the i-th topic of the
+// log — and the inner slice is an OR of allowed values.  Pass a single
+// indexed value (e.g. PoolId) like
+//
+//	WithTopics([][]common.Hash{{eventSigHash}, {poolIdHash}})
+func WithTopics(topics [][]common.Hash) SubscribeOption {
+	return func(c *SubscribeConfig) {
+		c.Topics = topics
 	}
 }

--- a/node/pkg/chain/websocketchainreader/websocketreader.go
+++ b/node/pkg/chain/websocketchainreader/websocketreader.go
@@ -121,12 +121,34 @@ func New(opts ...ChainReaderOption) (*ChainReader, error) {
 		chainIdToChainType[baseChainId.String()] = Base
 	}
 
+	// Arbitrum is optional for the same reason as Base — environments
+	// without ARBITRUM_WEBSOCKET_URL keep working but DEX feeds on
+	// Arbitrum will be skipped at chain-type lookup time.
+	var (
+		arbitrumClient  *eth_client.EthClient
+		arbitrumChainId *big.Int
+	)
+	if config.ArbitrumWebsocketUrl != "" {
+		arbitrumClient, err = eth_client.Dial(config.ArbitrumWebsocketUrl)
+		if err != nil {
+			return nil, err
+		}
+
+		arbitrumChainId, err = arbitrumClient.ChainID(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		chainIdToChainType[arbitrumChainId.String()] = Arbitrum
+	}
+
 	return &ChainReader{
 		EthClient:          ethClient,
 		KaiaClient:         kaiaClient,
 		BscClient:          bscClient,
 		PolygonClient:      polygonClient,
 		BaseClient:         baseClient,
+		ArbitrumClient:     arbitrumClient,
 		RetryPeriod:        config.RetryInterval,
 		ChainIdToChainType: chainIdToChainType,
 	}, nil
@@ -174,6 +196,7 @@ func (c *ChainReader) handleSubscription(ctx context.Context, config *SubscribeC
 		query := kaia.FilterQuery{
 			FromBlock: blockNumber,
 			Addresses: []common.Address{common.HexToAddress(config.Address)},
+			Topics:    config.Topics,
 		}
 
 		logs := make(chan types.Log)
@@ -223,6 +246,10 @@ func (c *ChainReader) client(chainType BlockchainType) utils.ClientInterface {
 
 	if chainType == Base {
 		return c.BaseClient
+	}
+
+	if chainType == Arbitrum {
+		return c.ArbitrumClient
 	}
 
 	return c.KaiaClient

--- a/node/pkg/fetcher/localaggregator_test.go
+++ b/node/pkg/fetcher/localaggregator_test.go
@@ -99,6 +99,11 @@ func TestFilterStaleFeeds_AllFresh(t *testing.T) {
 	assert.Equal(t, 3, len(result), "all fresh feeds should be returned")
 }
 
+// All TestFilterStaleFeeds_* fixtures set Volume > 0 — filterStaleFeeds
+// short-circuits Volume == 0 feeds (DEX/HTTP) past the freshness check,
+// so omitting Volume here would mean the feeds bypass the filter entirely
+// and these tests would silently lose their assertion power.
+
 func TestFilterStaleFeeds_MixFreshAndStale(t *testing.T) {
 	la := newLocalAggregatorWithFreshness(intPtr(60000)) // 60 seconds
 
@@ -109,10 +114,10 @@ func TestFilterStaleFeeds_MixFreshAndStale(t *testing.T) {
 	stale2 := now.Add(-5 * time.Minute)
 
 	feeds := []*FeedData{
-		{FeedID: 1, Value: 100.0, Timestamp: &fresh1},
-		{FeedID: 2, Value: 0.0119, Timestamp: &stale1}, // stuck old price
-		{FeedID: 3, Value: 101.0, Timestamp: &fresh2},
-		{FeedID: 4, Value: 0.0119, Timestamp: &stale2}, // stuck old price
+		{FeedID: 1, Value: 100.0, Volume: 1, Timestamp: &fresh1},
+		{FeedID: 2, Value: 0.0119, Volume: 1, Timestamp: &stale1}, // stuck old price
+		{FeedID: 3, Value: 101.0, Volume: 1, Timestamp: &fresh2},
+		{FeedID: 4, Value: 0.0119, Volume: 1, Timestamp: &stale2}, // stuck old price
 	}
 
 	result := la.filterStaleFeeds(feeds)
@@ -131,9 +136,9 @@ func TestFilterStaleFeeds_AllStale(t *testing.T) {
 	stale3 := now.Add(-10 * time.Minute)
 
 	feeds := []*FeedData{
-		{FeedID: 1, Value: 100.0, Timestamp: &stale1},
-		{FeedID: 2, Value: 101.0, Timestamp: &stale2},
-		{FeedID: 3, Value: 102.0, Timestamp: &stale3},
+		{FeedID: 1, Value: 100.0, Volume: 1, Timestamp: &stale1},
+		{FeedID: 2, Value: 101.0, Volume: 1, Timestamp: &stale2},
+		{FeedID: 3, Value: 102.0, Volume: 1, Timestamp: &stale3},
 	}
 
 	result := la.filterStaleFeeds(feeds)
@@ -148,9 +153,9 @@ func TestFilterStaleFeeds_NilTimestampPassesThrough(t *testing.T) {
 	stale := now.Add(-5 * time.Minute)
 
 	feeds := []*FeedData{
-		{FeedID: 1, Value: 100.0, Timestamp: &fresh},
-		{FeedID: 2, Value: 101.0, Timestamp: nil},   // nil timestamp should pass
-		{FeedID: 3, Value: 102.0, Timestamp: &stale}, // stale
+		{FeedID: 1, Value: 100.0, Volume: 1, Timestamp: &fresh},
+		{FeedID: 2, Value: 101.0, Volume: 1, Timestamp: nil},   // nil timestamp should pass
+		{FeedID: 3, Value: 102.0, Volume: 1, Timestamp: &stale}, // stale
 	}
 
 	result := la.filterStaleFeeds(feeds)
@@ -171,8 +176,8 @@ func TestFilterStaleFeeds_BoundaryExactlyAtThreshold(t *testing.T) {
 	justOver := now.Add(-60001 * time.Millisecond)
 
 	feeds := []*FeedData{
-		{FeedID: 1, Value: 100.0, Timestamp: &justUnder},
-		{FeedID: 2, Value: 101.0, Timestamp: &justOver},
+		{FeedID: 1, Value: 100.0, Volume: 1, Timestamp: &justUnder},
+		{FeedID: 2, Value: 101.0, Volume: 1, Timestamp: &justOver},
 	}
 
 	result := la.filterStaleFeeds(feeds)

--- a/node/pkg/fetcher/types.go
+++ b/node/pkg/fetcher/types.go
@@ -150,6 +150,7 @@ type Definition struct {
 	Type           *string `json:"type"`
 	ChainID        *string `json:"chainId"`
 	Address        *string `json:"address"`
+	PoolID         *string `json:"poolId"`
 	Token0Decimals *int64  `json:"token0Decimals"`
 	Token1Decimals *int64  `json:"token1Decimals"`
 	Reciprocal     *bool   `json:"reciprocal"`

--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -38,6 +38,7 @@ import (
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/orangex"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/pancakeswap"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/uniswap"
+	"bisonai.com/miko/node/pkg/websocketfetcher/providers/uniswapv4"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/upbit"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/xt"
 	"github.com/rs/zerolog/log"
@@ -151,6 +152,7 @@ func (a *App) Init(ctx context.Context, opts ...AppOption) error {
 		"uniswap":     uniswap.New,
 		"capybara":    capybara.New,
 		"pancakeswap": pancakeswap.New,
+		"uniswapv4":   uniswapv4.New,
 	}
 
 	appConfig := &AppConfig{
@@ -230,8 +232,12 @@ func (a *App) initializeDex(ctx context.Context, appConfig AppConfig) error {
 	ethWebsocketUrl := secrets.GetSecret("ETH_WEBSOCKET_URL")
 	bscWebsocketUrl := secrets.GetSecret("BSC_WEBSOCKET_URL")
 	polygonWebsocketUrl := secrets.GetSecret("POLYGON_WEBSOCKET_URL")
-	// Base WSS is optional; only nodes that need Base DEX feeds set it.
+	// Base / Arbitrum WSS are optional; only nodes that need DEX feeds on
+	// those chains set them.  Missing URLs simply skip the dial and the
+	// chain won't appear in ChainIdToChainType, so feeds targeting them
+	// will fail their per-feed lookup (logged and skipped).
 	baseWebsocketUrl := secrets.GetSecret("BASE_WEBSOCKET_URL")
+	arbitrumWebsocketUrl := secrets.GetSecret("ARBITRUM_WEBSOCKET_URL")
 	if kaiaWebsocketUrl == "" || ethWebsocketUrl == "" || bscWebsocketUrl == "" || polygonWebsocketUrl == "" {
 		log.Error().Msg("KAIA_WEBSOCKET_URL, ETH_WEBSOCKET_URL, BSC_WEBSOCKET_URL, and POLYGON_WEBSOCKET_URL must be set")
 		return errors.New("KAIA_WEBSOCKET_URL, ETH_WEBSOCKET_URL, BSC_WEBSOCKET_URL, and POLYGON_WEBSOCKET_URL must be set")
@@ -243,6 +249,7 @@ func (a *App) initializeDex(ctx context.Context, appConfig AppConfig) error {
 		websocketchainreader.WithBSCWebsocketUrl(bscWebsocketUrl),
 		websocketchainreader.WithPolygonWebsocketUrl(polygonWebsocketUrl),
 		websocketchainreader.WithBaseWebsocketUrl(baseWebsocketUrl),
+		websocketchainreader.WithArbitrumWebsocketUrl(arbitrumWebsocketUrl),
 	)
 	if err != nil {
 		log.Error().Err(err).Msg("error in creating chain reader")

--- a/node/pkg/websocketfetcher/common/type.go
+++ b/node/pkg/websocketfetcher/common/type.go
@@ -67,6 +67,10 @@ type DexFeedDefinition struct {
 	Token0Decimals int    `json:"token0Decimals"`
 	Token1Decimals int    `json:"token1Decimals"`
 	Reciprocal     *bool  `json:"reciprocal"`
+	// PoolID is the 32-byte Uniswap V4 pool identifier (keccak256 of the
+	// PoolKey).  Populated only for type=="UniswapV4Pool" feeds — V3-style
+	// providers continue to use Address instead.
+	PoolID string `json:"poolId"`
 }
 
 type DexFeedDefinitionCapybara struct {

--- a/node/pkg/websocketfetcher/common/type.go
+++ b/node/pkg/websocketfetcher/common/type.go
@@ -68,8 +68,12 @@ type DexFeedDefinition struct {
 	Token1Decimals int    `json:"token1Decimals"`
 	Reciprocal     *bool  `json:"reciprocal"`
 	// PoolID is the 32-byte Uniswap V4 pool identifier (keccak256 of the
-	// PoolKey).  Populated only for type=="UniswapV4Pool" feeds — V3-style
+	// PoolKey).  Populated only for type=="Uniswapv4Pool" feeds — V3-style
 	// providers continue to use Address instead.
+	//
+	// The "Uniswapv4Pool" spelling (lowercase 'v') is what GetDexFeedsQuery
+	// builds when capitalizing the "uniswapv4" factory key, matching the
+	// existing convention for PancakeswapPool / CapybaraPool.
 	PoolID string `json:"poolId"`
 }
 

--- a/node/pkg/websocketfetcher/providers/uniswapv4/chains.go
+++ b/node/pkg/websocketfetcher/providers/uniswapv4/chains.go
@@ -1,0 +1,41 @@
+package uniswapv4
+
+import (
+	"bisonai.com/miko/node/pkg/chain/websocketchainreader"
+)
+
+// ChainConfig holds the per-chain Uniswap V4 contract addresses.  All V4
+// pools on a given chain live inside the singleton PoolManager and are
+// read through the StateView helper.  Source:
+// https://docs.uniswap.org/contracts/v4/deployments
+type ChainConfig struct {
+	StateView   string
+	PoolManager string
+}
+
+// chainConfigs maps the chain type used by the websocketchainreader to
+// the relevant V4 addresses.  Add new chains here as Uniswap deploys.
+var chainConfigs = map[websocketchainreader.BlockchainType]ChainConfig{
+	websocketchainreader.Ethereum: {
+		StateView:   "0x7ffe42c4a5deea5b0fec41c94c136cf115597227",
+		PoolManager: "0x000000000004444c5dc75cb358380d2e3de08a90",
+	},
+	websocketchainreader.Polygon: {
+		StateView:   "0x5ea1bd7974c8a611cbab0bdcafcb1d9cc9b3ba5a",
+		PoolManager: "0x67366782805870060151383f4bbff9dab53e5cd6",
+	},
+	websocketchainreader.Arbitrum: {
+		StateView:   "0x76fd297e2d437cd7f76d50f01afe6160f86e9990",
+		PoolManager: "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+	},
+	websocketchainreader.Base: {
+		StateView:   "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+		PoolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",
+	},
+}
+
+// LookupChainConfig returns the V4 addresses for chainType, if known.
+func LookupChainConfig(chainType websocketchainreader.BlockchainType) (ChainConfig, bool) {
+	cfg, ok := chainConfigs[chainType]
+	return cfg, ok
+}

--- a/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4.go
+++ b/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4.go
@@ -1,0 +1,356 @@
+package uniswapv4
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math"
+	"math/big"
+	"strings"
+	"time"
+
+	"bisonai.com/miko/node/pkg/chain/utils"
+	"bisonai.com/miko/node/pkg/chain/websocketchainreader"
+	errorSentinel "bisonai.com/miko/node/pkg/error"
+	"bisonai.com/miko/node/pkg/websocketfetcher/common"
+	"github.com/kaiachain/kaia/blockchain/types"
+	kaiacommon "github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/rs/zerolog/log"
+)
+
+// V4Fetcher is the Uniswap V4 implementation.  Unlike V3, every pool on a
+// given chain shares one PoolManager singleton — so pools are addressed by
+// a 32-byte poolId rather than a deployed contract address.  Reads go
+// through the read-only StateView helper (getSlot0(poolId)); live updates
+// come from PoolManager Swap events filtered by indexed poolId.
+type V4Fetcher common.DexFetcher
+
+const (
+	// GET_SLOT0 is the V4 StateView read interface.  Same shape as the
+	// V3 IUniswapV3Pool.slot0() output we already consume — just sourced
+	// through the helper contract instead of from the pool itself.
+	GET_SLOT0 = "function getSlot0(bytes32 poolId) external view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)"
+
+	// SWAP_EVENT is the PoolManager Swap event.  PoolId is bytes32 in the
+	// underlying ABI (the Solidity `type PoolId is bytes32` is purely a
+	// compiler nicety) so we name the topic "bytes32 indexed id" directly.
+	SWAP_EVENT = `event Swap(
+        bytes32 indexed id,
+        address indexed sender,
+        int128 amount0,
+        int128 amount1,
+        uint160 sqrtPriceX96,
+        uint128 liquidity,
+        int24 tick,
+        uint24 fee
+    )`
+
+	// SwapEventCanonicalSig is the canonical (no-whitespace, no-names)
+	// form of SWAP_EVENT used to compute topic[0].  Kept hard-coded so
+	// the hash is stable independent of the human-readable signature.
+	SwapEventCanonicalSig = "Swap(bytes32,address,int128,int128,uint160,uint128,int24,uint24)"
+)
+
+// New constructs a V4 fetcher from the standard DexFetcher options.
+func New(opts ...common.DexFetcherOption) common.FetcherInterface {
+	config := &common.DexFetcherConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	return &V4Fetcher{
+		Feeds:                config.Feeds,
+		FeedDataBuffer:       config.FeedDataBuffer,
+		WebsocketChainReader: config.WebsocketChainReader,
+		LatestEntries:        make(map[int32]*common.FeedData),
+	}
+}
+
+// Run launches one goroutine per feed, mirroring the V3 providers.  Each
+// run() does a one-shot StateView read for the initial price, kicks off a
+// best-effort Swap subscription in the background, then enters the
+// HeartbeatPoll loop in the foreground.
+func (f *V4Fetcher) Run(ctx context.Context) {
+	for _, feed := range f.Feeds {
+		go f.run(ctx, feed)
+		// Same RPC-rate-limit-avoidance sleep as V3 providers.
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (f *V4Fetcher) run(ctx context.Context, feed common.Feed) {
+	// 1. Initial read through StateView.getSlot0(poolId).
+	price, err := f.getInitialPrice(ctx, feed)
+	if err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).
+			Int32("feedID", feed.ID).Str("name", feed.Name).
+			Msg("error in uniswapv4.run, failed to get initial price")
+		return
+	}
+
+	now := time.Now()
+	initialFeedData := &common.FeedData{
+		FeedID:    feed.ID,
+		Value:     *price,
+		Timestamp: &now,
+	}
+	log.Debug().Str("Player", "UniswapV4").Any("feedData", initialFeedData).Msg("initial price fetched")
+	log.Info().Str("Player", "UniswapV4").Int32("feedID", feed.ID).Str("name", feed.Name).
+		Float64("price", *price).Msg("DIAG initial price fetched")
+	f.FeedDataBuffer <- initialFeedData
+
+	f.Mutex.Lock()
+	f.LatestEntries[feed.ID] = initialFeedData
+	f.Mutex.Unlock()
+
+	// 2. Best-effort PoolManager Swap subscription (background).  If the
+	// subscription fails or returns, the foreground heartbeat poll keeps
+	// supplying fresh data — same lifecycle pattern as V3 providers.
+	go func() {
+		if err := f.subscribeEvent(ctx, feed); err != nil {
+			log.Error().Str("Player", "UniswapV4").Err(err).
+				Int32("feedID", feed.ID).Str("name", feed.Name).
+				Msg("error in uniswapv4.run, subscribe event ended")
+		}
+	}()
+
+	// 3. Heartbeat poll in the foreground.
+	common.HeartbeatPoll(ctx, common.GetDexPollInterval(), "UniswapV4", feed.ID, feed.Name,
+		f.getInitialPriceFor(feed),
+		func(fd *common.FeedData) {
+			f.FeedDataBuffer <- fd
+			f.Mutex.Lock()
+			f.LatestEntries[feed.ID] = fd
+			f.Mutex.Unlock()
+		},
+	)
+}
+
+// getInitialPriceFor returns a function suitable for HeartbeatPoll that
+// invokes f.getInitialPrice with the feed bound in.
+func (f *V4Fetcher) getInitialPriceFor(feed common.Feed) func(context.Context) (*float64, error) {
+	return func(ctx context.Context) (*float64, error) {
+		return f.getInitialPrice(ctx, feed)
+	}
+}
+
+func (f *V4Fetcher) getInitialPrice(ctx context.Context, feed common.Feed) (*float64, error) {
+	definition := new(common.DexFeedDefinition)
+	if err := json.Unmarshal(feed.Definition, &definition); err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.getInitialPrice, failed to unmarshal definition")
+		return nil, err
+	}
+	return f.getPriceThroughSlot0(ctx, definition)
+}
+
+// getPriceThroughSlot0 calls StateView.getSlot0(poolId) and converts the
+// returned sqrtPriceX96 to a human-readable price.
+func (f *V4Fetcher) getPriceThroughSlot0(ctx context.Context, definition *common.DexFeedDefinition) (*float64, error) {
+	chainType, ok := f.WebsocketChainReader.ChainIdToChainType[definition.ChainId]
+	if !ok {
+		log.Error().Str("Player", "UniswapV4").Str("chainId", definition.ChainId).Msg("error in uniswapv4.getPriceThroughSlot0, chain type not found")
+		return nil, errorSentinel.ErrFetcherNoMatchingChainID
+	}
+
+	chainCfg, ok := LookupChainConfig(chainType)
+	if !ok {
+		log.Error().Str("Player", "UniswapV4").Str("chainId", definition.ChainId).Msg("error in uniswapv4.getPriceThroughSlot0, no V4 deployment for chain")
+		return nil, errorSentinel.ErrFetcherNoMatchingChainID
+	}
+
+	poolID, err := ParsePoolID(definition.PoolID)
+	if err != nil {
+		return nil, err
+	}
+
+	rawResult, err := f.WebsocketChainReader.ReadContractOnce(ctx, chainType, chainCfg.StateView, GET_SLOT0, poolID)
+	if err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.getPriceThroughSlot0, failed to read contract")
+		return nil, err
+	}
+
+	sqrtPrice, err := extractSqrtPriceX96(rawResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetTokenPrice(sqrtPrice, definition)
+}
+
+// subscribeEvent subscribes to PoolManager Swap events filtered by the
+// feed's indexed poolId.  Without the topic filter we'd receive every
+// swap on the chain (PoolManager handles all V4 pools), which is
+// untenable on busy chains.
+func (f *V4Fetcher) subscribeEvent(ctx context.Context, feed common.Feed) error {
+	definition := new(common.DexFeedDefinition)
+	if err := json.Unmarshal(feed.Definition, &definition); err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to unmarshal definition")
+		return err
+	}
+
+	chainType, ok := f.WebsocketChainReader.ChainIdToChainType[definition.ChainId]
+	if !ok {
+		log.Error().Str("Player", "UniswapV4").Str("chainId", definition.ChainId).Msg("error in uniswapv4.subscribeEvent, chain type not found")
+		return errorSentinel.ErrFetcherNoMatchingChainID
+	}
+
+	chainCfg, ok := LookupChainConfig(chainType)
+	if !ok {
+		return errorSentinel.ErrFetcherNoMatchingChainID
+	}
+
+	poolIDBytes, err := ParsePoolID(definition.PoolID)
+	if err != nil {
+		return err
+	}
+	poolIDHash := kaiacommon.BytesToHash(poolIDBytes[:])
+
+	eventName, input, _, err := utils.ParseMethodSignature(SWAP_EVENT)
+	if err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to parse method signature")
+		return err
+	}
+
+	swapEventABI, err := utils.GenerateEventABI(eventName, input)
+	if err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to generate event abi")
+		return err
+	}
+
+	// topic[0] is keccak256 of the canonical (whitespace-stripped) event
+	// signature.  Hard-code that string rather than reusing the
+	// human-readable SWAP_EVENT to make the hash stable across cosmetic
+	// edits.
+	eventSigHash := SwapEventTopic0()
+
+	logChannel := make(chan types.Log)
+	if err := f.WebsocketChainReader.Subscribe(
+		ctx,
+		websocketchainreader.WithAddress(chainCfg.PoolManager),
+		websocketchainreader.WithChannel(logChannel),
+		websocketchainreader.WithChainType(chainType),
+		websocketchainreader.WithTopics([][]kaiacommon.Hash{
+			{eventSigHash},
+			{poolIDHash},
+		}),
+	); err != nil {
+		log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to subscribe")
+		return err
+	}
+
+	for eventLog := range logChannel {
+		// Defensive: the subscription is already filtered by both the
+		// event signature and the pool id, but verify topic[1] matches
+		// in case a misbehaving relay forwards extra logs.
+		if len(eventLog.Topics) < 2 || eventLog.Topics[1] != poolIDHash {
+			continue
+		}
+
+		res, err := swapEventABI.Unpack(eventName, eventLog.Data)
+		if err != nil {
+			continue
+		}
+		// Non-indexed args, in declaration order:
+		// [amount0, amount1, sqrtPriceX96, liquidity, tick, fee]
+		if len(res) < 3 {
+			continue
+		}
+		sqrtPrice, ok := res[2].(*big.Int)
+		if !ok {
+			continue
+		}
+		price, err := GetTokenPrice(sqrtPrice, definition)
+		if err != nil {
+			log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to get token price")
+			continue
+		}
+		now := time.Now()
+		feedData := &common.FeedData{
+			FeedID:    feed.ID,
+			Value:     *price,
+			Timestamp: &now,
+		}
+		log.Debug().Str("Player", "UniswapV4").Any("feedData", feedData).Msg("price fetched")
+		f.FeedDataBuffer <- feedData
+		f.Mutex.Lock()
+		f.LatestEntries[feed.ID] = feedData
+		f.Mutex.Unlock()
+	}
+	return nil
+}
+
+// SwapEventTopic0 returns keccak256 of SwapEventCanonicalSig.  This is
+// what the chain places in topic[0] of every PoolManager Swap log.
+func SwapEventTopic0() kaiacommon.Hash {
+	return kaiacommon.BytesToHash(crypto.Keccak256([]byte(SwapEventCanonicalSig)))
+}
+
+// ParsePoolID accepts a hex-encoded 32-byte pool identifier (with or
+// without the "0x" prefix, case-insensitive) and returns it as a
+// fixed-size [32]byte suitable for ABI bytes32 packing.
+func ParsePoolID(s string) ([32]byte, error) {
+	var out [32]byte
+	if s == "" {
+		return out, errors.New("uniswapv4: empty poolId")
+	}
+	clean := strings.TrimPrefix(strings.ToLower(s), "0x")
+	if len(clean) != 64 {
+		return out, errors.New("uniswapv4: poolId must be 32 bytes (64 hex chars)")
+	}
+	raw, err := hex.DecodeString(clean)
+	if err != nil {
+		return out, err
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+// extractSqrtPriceX96 pulls the first element of an ABI getSlot0 tuple
+// result and casts it to *big.Int.  Returns a typed sentinel error so
+// callers can distinguish "result shape was wrong" from generic failure.
+func extractSqrtPriceX96(rawResult interface{}) (*big.Int, error) {
+	rawResultSlice, ok := rawResult.([]interface{})
+	if !ok || len(rawResultSlice) < 1 {
+		return nil, errorSentinel.ErrFetcherFailedToGetDexResultSlice
+	}
+	sqrtPrice, ok := rawResultSlice[0].(*big.Int)
+	if !ok {
+		return nil, errorSentinel.ErrFetcherFailedBigIntConvert
+	}
+	return sqrtPrice, nil
+}
+
+// GetTokenPrice converts a Uniswap-style sqrtPriceX96 into the
+// human-readable price of token0 expressed in token1 (or its reciprocal,
+// when definition.Reciprocal is true).
+//
+// Math is identical to the V3 providers — this lives here purely to keep
+// the V4 package self-contained.  See providers/uniswap/uniswap.go and
+// providers/pancakeswap/pancakeswap.go for the matching implementations.
+func GetTokenPrice(sqrtPrice *big.Int, definition *common.DexFeedDefinition) (*float64, error) {
+	if sqrtPrice == nil {
+		return nil, errorSentinel.ErrFetcherInvalidInput
+	}
+
+	decimal0 := definition.Token0Decimals
+	decimal1 := definition.Token1Decimals
+
+	sqrtPriceX96Float := new(big.Float).SetInt(sqrtPrice)
+	sqrtPriceX96Float.Quo(sqrtPriceX96Float, new(big.Float).SetFloat64(math.Pow(2, 96)))
+	sqrtPriceX96Float.Mul(sqrtPriceX96Float, sqrtPriceX96Float)
+
+	decimalDiff := new(big.Float).SetFloat64(math.Pow(10, float64(decimal1-decimal0)))
+	datum := sqrtPriceX96Float.Quo(sqrtPriceX96Float, decimalDiff)
+
+	if definition.Reciprocal != nil && *definition.Reciprocal {
+		if datum == nil || datum.Sign() == 0 {
+			return nil, errorSentinel.ErrFetcherDivisionByZero
+		}
+		datum = datum.Quo(new(big.Float).SetFloat64(1), datum)
+	}
+
+	result, _ := datum.Float64()
+	return &result, nil
+}

--- a/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4.go
+++ b/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4.go
@@ -240,45 +240,57 @@ func (f *V4Fetcher) subscribeEvent(ctx context.Context, feed common.Feed) error 
 		return err
 	}
 
-	for eventLog := range logChannel {
-		// Defensive: the subscription is already filtered by both the
-		// event signature and the pool id, but verify topic[1] matches
-		// in case a misbehaving relay forwards extra logs.
-		if len(eventLog.Topics) < 2 || eventLog.Topics[1] != poolIDHash {
-			continue
-		}
+	// Loop driven by select so we exit promptly on ctx cancellation.
+	// The websocketchainreader.Subscribe contract does not close
+	// logChannel on shutdown, so a `range` over it would leak this
+	// goroutine for the lifetime of the process even after ctx is
+	// cancelled.
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case eventLog, ok := <-logChannel:
+			if !ok {
+				return nil
+			}
+			// Defensive: the subscription is already filtered by both
+			// the event signature and the pool id, but verify topic[1]
+			// matches in case a misbehaving relay forwards extra logs.
+			if len(eventLog.Topics) < 2 || eventLog.Topics[1] != poolIDHash {
+				continue
+			}
 
-		res, err := swapEventABI.Unpack(eventName, eventLog.Data)
-		if err != nil {
-			continue
+			res, err := swapEventABI.Unpack(eventName, eventLog.Data)
+			if err != nil {
+				continue
+			}
+			// Non-indexed args, in declaration order:
+			// [amount0, amount1, sqrtPriceX96, liquidity, tick, fee]
+			if len(res) < 3 {
+				continue
+			}
+			sqrtPrice, ok := res[2].(*big.Int)
+			if !ok {
+				continue
+			}
+			price, err := GetTokenPrice(sqrtPrice, definition)
+			if err != nil {
+				log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to get token price")
+				continue
+			}
+			now := time.Now()
+			feedData := &common.FeedData{
+				FeedID:    feed.ID,
+				Value:     *price,
+				Timestamp: &now,
+			}
+			log.Debug().Str("Player", "UniswapV4").Any("feedData", feedData).Msg("price fetched")
+			f.FeedDataBuffer <- feedData
+			f.Mutex.Lock()
+			f.LatestEntries[feed.ID] = feedData
+			f.Mutex.Unlock()
 		}
-		// Non-indexed args, in declaration order:
-		// [amount0, amount1, sqrtPriceX96, liquidity, tick, fee]
-		if len(res) < 3 {
-			continue
-		}
-		sqrtPrice, ok := res[2].(*big.Int)
-		if !ok {
-			continue
-		}
-		price, err := GetTokenPrice(sqrtPrice, definition)
-		if err != nil {
-			log.Error().Str("Player", "UniswapV4").Err(err).Msg("error in uniswapv4.subscribeEvent, failed to get token price")
-			continue
-		}
-		now := time.Now()
-		feedData := &common.FeedData{
-			FeedID:    feed.ID,
-			Value:     *price,
-			Timestamp: &now,
-		}
-		log.Debug().Str("Player", "UniswapV4").Any("feedData", feedData).Msg("price fetched")
-		f.FeedDataBuffer <- feedData
-		f.Mutex.Lock()
-		f.LatestEntries[feed.ID] = feedData
-		f.Mutex.Unlock()
 	}
-	return nil
 }
 
 // SwapEventTopic0 returns keccak256 of SwapEventCanonicalSig.  This is

--- a/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4_test.go
+++ b/node/pkg/websocketfetcher/providers/uniswapv4/uniswapv4_test.go
@@ -1,0 +1,284 @@
+//nolint:all
+package uniswapv4
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"bisonai.com/miko/node/pkg/chain/websocketchainreader"
+	"bisonai.com/miko/node/pkg/websocketfetcher/common"
+	kaiacommon "github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- ParsePoolID ----------
+
+func TestParsePoolID_AcceptsCanonical0xPrefix(t *testing.T) {
+	in := "0x4643e3152a6ea3957e087cefbba74a1c628aa643e6b8a0edfae23a5796dde012"
+	got, err := ParsePoolID(in)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x46), got[0])
+	assert.Equal(t, byte(0x12), got[31])
+}
+
+func TestParsePoolID_AcceptsBarePrefix(t *testing.T) {
+	in := "4643e3152a6ea3957e087cefbba74a1c628aa643e6b8a0edfae23a5796dde012"
+	got, err := ParsePoolID(in)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x46), got[0])
+}
+
+func TestParsePoolID_AcceptsMixedCase(t *testing.T) {
+	upper := "0x4643E3152A6EA3957E087CEFBBA74A1C628AA643E6B8A0EDFAE23A5796DDE012"
+	lower := "0x4643e3152a6ea3957e087cefbba74a1c628aa643e6b8a0edfae23a5796dde012"
+	upperGot, err := ParsePoolID(upper)
+	require.NoError(t, err)
+	lowerGot, err := ParsePoolID(lower)
+	require.NoError(t, err)
+	assert.Equal(t, upperGot, lowerGot, "case must not affect parse")
+}
+
+func TestParsePoolID_RejectsEmpty(t *testing.T) {
+	_, err := ParsePoolID("")
+	require.Error(t, err)
+}
+
+func TestParsePoolID_RejectsWrongLength(t *testing.T) {
+	for _, bad := range []string{
+		"0x1234",
+		"0x" + strings.Repeat("ab", 16),               // 16 bytes
+		"0x" + strings.Repeat("ab", 33),               // 33 bytes
+		strings.Repeat("00", 31) + "00ff",             // 32 bytes encoded as 66 chars (no 0x) — too long when bare
+	} {
+		_, err := ParsePoolID(bad)
+		assert.Error(t, err, "expected error for %q", bad)
+	}
+}
+
+func TestParsePoolID_RejectsNonHex(t *testing.T) {
+	bad := "0xZZ" + strings.Repeat("00", 31)
+	_, err := ParsePoolID(bad)
+	require.Error(t, err)
+}
+
+func TestParsePoolID_RoundTripsToHash(t *testing.T) {
+	in := "0x4643e3152a6ea3957e087cefbba74a1c628aa643e6b8a0edfae23a5796dde012"
+	parsed, err := ParsePoolID(in)
+	require.NoError(t, err)
+	asHash := kaiacommon.BytesToHash(parsed[:])
+	assert.Equal(t, strings.ToLower(in), strings.ToLower(asHash.Hex()),
+		"parsed bytes must round-trip back to the original hex")
+}
+
+// ---------- GetTokenPrice ----------
+
+// TestGetTokenPrice_JPYCPoolMatchesOnchain anchors the math against a real
+// on-chain snapshot.  The sqrtPriceX96 below was read live from
+// StateView.getSlot0() for the JPYC/USDC 0.05% V4 pool on Polygon during
+// PR review (token0 = USDC 6 decimals, token1 = JPYC 18 decimals).
+//
+// 1 USD ≈ 150 JPY → raw price (token1/token0) should land near 150 JPYC
+// per USDC.  This test would catch regressions in the
+// sqrtPriceX96-to-human-price conversion.
+func TestGetTokenPrice_JPYCPoolMatchesOnchain(t *testing.T) {
+	// 0x00c1369007999520f401ab9813a21fb1
+	sqrtPrice, ok := new(big.Int).SetString("c1369007999520f401ab9813a21fb1", 16)
+	require.True(t, ok)
+
+	def := &common.DexFeedDefinition{
+		Token0Decimals: 6,
+		Token1Decimals: 18,
+	}
+	got, err := GetTokenPrice(sqrtPrice, def)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Plausibility band: 100..200 JPYC per USDC.  Anything outside this
+	// would mean the math drifted by orders of magnitude.
+	assert.Greater(t, *got, 100.0, "raw price should be ~150 JPYC per USDC")
+	assert.Less(t, *got, 200.0, "raw price should be ~150 JPYC per USDC")
+}
+
+// TestGetTokenPrice_ReciprocalInverts confirms that the reciprocal flag
+// inverts the price exactly — important because synthetic configs like
+// JPYC-USDT depend on this being a true 1/x.
+func TestGetTokenPrice_ReciprocalInverts(t *testing.T) {
+	sqrtPrice, ok := new(big.Int).SetString("c1369007999520f401ab9813a21fb1", 16)
+	require.True(t, ok)
+
+	base := &common.DexFeedDefinition{Token0Decimals: 6, Token1Decimals: 18}
+	reciprocal := *base
+	yes := true
+	reciprocal.Reciprocal = &yes
+
+	direct, err := GetTokenPrice(sqrtPrice, base)
+	require.NoError(t, err)
+	inverted, err := GetTokenPrice(sqrtPrice, &reciprocal)
+	require.NoError(t, err)
+
+	// direct * inverted ≈ 1.0 (within float64 rounding).
+	product := *direct * *inverted
+	assert.InDelta(t, 1.0, product, 1e-9, "reciprocal must invert the direct price")
+}
+
+// TestGetTokenPrice_RejectsNil ensures we fail loudly on a nil price
+// rather than panicking inside big.Float math.
+func TestGetTokenPrice_RejectsNil(t *testing.T) {
+	got, err := GetTokenPrice(nil, &common.DexFeedDefinition{})
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
+// TestGetTokenPrice_ReciprocalOfZeroErrors avoids a silent infinity.
+func TestGetTokenPrice_ReciprocalOfZeroErrors(t *testing.T) {
+	yes := true
+	def := &common.DexFeedDefinition{Token0Decimals: 6, Token1Decimals: 18, Reciprocal: &yes}
+	_, err := GetTokenPrice(big.NewInt(0), def)
+	require.Error(t, err, "reciprocal of zero must error, not produce infinity")
+}
+
+// TestGetTokenPrice_KnownSqrtPriceX96 is a deterministic sanity check:
+// when sqrtPriceX96 = 2^96 (i.e. price1/price0 = 1) and decimals match,
+// we must get exactly 1.0.
+func TestGetTokenPrice_UnitySqrtPrice(t *testing.T) {
+	one := new(big.Int).Lsh(big.NewInt(1), 96) // 2^96
+	def := &common.DexFeedDefinition{Token0Decimals: 18, Token1Decimals: 18}
+	got, err := GetTokenPrice(one, def)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, *got, 1e-12)
+}
+
+// TestGetTokenPrice_DecimalsApplied verifies the 10^(d1-d0) divisor.
+// At sqrtPriceX96 = 2^96 the raw token1/token0 ratio is exactly 1, so the
+// human price = 1 / 10^(d1-d0).  These two cases (positive and negative
+// exponent) cover both directions.
+func TestGetTokenPrice_DecimalsApplied(t *testing.T) {
+	one := new(big.Int).Lsh(big.NewInt(1), 96)
+
+	// d1 > d0: human = 1 / 10^(d1-d0)
+	got, err := GetTokenPrice(one, &common.DexFeedDefinition{Token0Decimals: 6, Token1Decimals: 18})
+	require.NoError(t, err)
+	assert.InDelta(t, math.Pow(10, -12), *got, 1e-18)
+
+	// d0 > d1: human = 10^(d0-d1)
+	got, err = GetTokenPrice(one, &common.DexFeedDefinition{Token0Decimals: 18, Token1Decimals: 6})
+	require.NoError(t, err)
+	assert.InDelta(t, math.Pow(10, 12), *got, 1e2)
+}
+
+// ---------- extractSqrtPriceX96 ----------
+
+func TestExtractSqrtPriceX96_Valid(t *testing.T) {
+	bi := big.NewInt(123)
+	tuple := []interface{}{bi, big.NewInt(0), big.NewInt(0), big.NewInt(0)}
+	got, err := extractSqrtPriceX96(tuple)
+	require.NoError(t, err)
+	assert.Same(t, bi, got)
+}
+
+func TestExtractSqrtPriceX96_RejectsWrongShape(t *testing.T) {
+	for _, bad := range []interface{}{
+		nil,
+		"not a tuple",
+		[]interface{}{},        // empty
+		[]string{"a", "b"},     // wrong slice element type
+	} {
+		_, err := extractSqrtPriceX96(bad)
+		assert.Error(t, err, "expected error for %v", bad)
+	}
+}
+
+func TestExtractSqrtPriceX96_RejectsNonBigInt(t *testing.T) {
+	tuple := []interface{}{"not a *big.Int", big.NewInt(0)}
+	_, err := extractSqrtPriceX96(tuple)
+	require.Error(t, err)
+}
+
+// ---------- SwapEventTopic0 ----------
+
+func TestSwapEventTopic0_Stable(t *testing.T) {
+	// keccak256("Swap(bytes32,address,int128,int128,uint160,uint128,int24,uint24)")
+	// was computed offline (and cross-checked against
+	// abi.Event.ID for the same canonical signature) to lock the
+	// expected value.  If anyone tweaks SWAP_EVENT or
+	// SwapEventCanonicalSig in a way that changes the topic[0], this
+	// test will fail loudly so the change is intentional.
+	got := SwapEventTopic0()
+
+	const expected = "0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f"
+	assert.Equal(t, expected, got.Hex(),
+		"V4 Swap topic[0] hash drifted; verify SwapEventCanonicalSig against PoolManager source")
+}
+
+func TestSwapEventTopic0_Deterministic(t *testing.T) {
+	// Same input, same output, every call.  Rules out hidden mutable
+	// state in the helper.
+	a := SwapEventTopic0()
+	b := SwapEventTopic0()
+	assert.Equal(t, a, b)
+}
+
+// ---------- LookupChainConfig ----------
+
+func TestLookupChainConfig_KnownChainsHaveAllFields(t *testing.T) {
+	// Every chain we've registered must expose both addresses;
+	// missing one would mean the pool would dial a zero address.
+	for _, ct := range []websocketchainreader.BlockchainType{
+		websocketchainreader.Ethereum,
+		websocketchainreader.Polygon,
+		websocketchainreader.Arbitrum,
+		websocketchainreader.Base,
+	} {
+		cfg, ok := LookupChainConfig(ct)
+		require.Truef(t, ok, "chain %v missing from V4 chain configs", ct)
+		assert.NotEmptyf(t, cfg.StateView, "chain %v has empty StateView", ct)
+		assert.NotEmptyf(t, cfg.PoolManager, "chain %v has empty PoolManager", ct)
+		assert.Truef(t, strings.HasPrefix(strings.ToLower(cfg.StateView), "0x"),
+			"chain %v StateView must be 0x-prefixed", ct)
+		assert.Truef(t, strings.HasPrefix(strings.ToLower(cfg.PoolManager), "0x"),
+			"chain %v PoolManager must be 0x-prefixed", ct)
+		assert.Lenf(t, cfg.StateView, 42, "chain %v StateView address has wrong length", ct)
+		assert.Lenf(t, cfg.PoolManager, 42, "chain %v PoolManager address has wrong length", ct)
+	}
+}
+
+func TestLookupChainConfig_UnknownChain(t *testing.T) {
+	// Kaia has no V4 deployment — make sure unknown chains report not-found
+	// rather than returning a zero-valued struct that would silently
+	// dial 0x000... contracts.
+	cfg, ok := LookupChainConfig(websocketchainreader.Kaia)
+	assert.False(t, ok)
+	assert.Equal(t, ChainConfig{}, cfg)
+
+	cfg, ok = LookupChainConfig(websocketchainreader.BlockchainType(999))
+	assert.False(t, ok)
+	assert.Equal(t, ChainConfig{}, cfg)
+}
+
+// ---------- New ----------
+
+// TestNew_PropagatesOptions verifies that DexFetcherOption configures the
+// underlying common.DexFetcher as expected — pulled from common.New
+// behavior, this guards against future refactors silently dropping
+// fields the V4 fetcher relies on (Feeds, FeedDataBuffer, ChainReader).
+func TestNew_PropagatesOptions(t *testing.T) {
+	feeds := []common.Feed{{ID: 1, Name: "JPYC-USDT"}}
+	buf := make(chan *common.FeedData, 4)
+	cr := &websocketchainreader.ChainReader{}
+
+	f := New(
+		common.WithFeeds(feeds),
+		common.WithDexFeedDataBuffer(buf),
+		common.WithWebsocketChainReader(cr),
+	)
+	v4, ok := f.(*V4Fetcher)
+	require.True(t, ok)
+	assert.Equal(t, feeds, v4.Feeds)
+	assert.Equal(t, buf, v4.FeedDataBuffer)
+	assert.Same(t, cr, v4.WebsocketChainReader)
+	assert.NotNil(t, v4.LatestEntries)
+	assert.Empty(t, v4.LatestEntries)
+}


### PR DESCRIPTION
## Summary

Wires up two new DEX integrations end-to-end so we can add IDRP-USDT, JPYC-USDT, and MYRC-USDT feeds on baobab:

- **Uniswap V4 fetcher** (\`pkg/websocketfetcher/providers/uniswapv4/\`) — pools share a singleton PoolManager per chain and are addressed by 32-byte poolId.  Reads go through the StateView helper (\`getSlot0\`); live updates subscribe to PoolManager \`Swap\` events filtered by the indexed poolId.  Same hybrid lifecycle (initial fetch + WSS + heartbeat poll) as existing V3 providers.
- **Arbitrum One** (chainId 42161) added to \`websocketchainreader\` using the same optional pattern Base uses — nodes without an Arbitrum RPC keep starting fine; feeds targeting Arbitrum just fail their per-feed lookup.

Companion changes (this PR):
- \`websocketchainreader.Subscribe\` gains \`WithTopics\` so V4's subscription can filter on the indexed poolId. Without that we'd receive every swap on the chain via PoolManager.
- \`DexFeedDefinition.PoolID\` + \`Definition.PoolID\` so V4 feeds are configured by poolId hash instead of contract address. V3 feeds keep using \`address\`.
- \`uniswapv4\` registered in \`dexFactories\` map → feeds whose \`definition.type == "UniswapV4Pool"\` route to the V4 provider.

## Companion changes (separate repos, will land alongside)

- \`orakl-config\`: \`config/baobab/{IDRP-USDT,JPYC-USDT,MYRC-USDT}.config.json\` + recompiled \`baobab_configs.json\`.
- \`orakl-helm-charts\`: \`node/values.baobab.yaml\` adds \`ARBITRUM_WEBSOCKET_URL\` (public node fallback; user can override via Vault).

## Pool sources

| Feed | Pool | Type |
| --- | --- | --- |
| IDRP-USDT | DGSwap V3 \`0x9c76d9...\` (Kaia 8217) | UniswapPool |
| JPYC-USDT | UniswapV4 \`0x4643e3...\` (Polygon, 0.05%) | UniswapV4Pool, reciprocal × USDC-USDT |
| JPYC-USDT | UniswapV4 \`0x3befb3...\` (Polygon, 0.125%) | UniswapV4Pool, reciprocal × USDC-USDT |
| JPYC-USDT | UniswapV4 \`0x04607d...\` (Ethereum) | UniswapV4Pool, reciprocal × USDC-USDT |
| MYRC-USDT | UniswapV3 \`0x98e410...\` (Arbitrum) | UniswapPool, direct (token1 is USD₮0 ≈ USDT) |

V4 contract addresses are sourced from the [official Uniswap deployments page](https://developers.uniswap.org/contracts/v4/deployments) and were verified against on-chain \`StateView.getSlot0\` for the JPYC pools during PR prep — the JPYC pool's sqrtPriceX96 round-trips to ~150–160 JPYC per USDC, matching the spot FX rate.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./pkg/...\` clean
- [x] \`go test ./pkg/websocketfetcher/providers/uniswapv4/...\` — 21 unit tests (ParsePoolID format/case/length/hex validation, GetTokenPrice JPYC snapshot, reciprocal inversion, decimal scaling, unity/zero edges, extractSqrtPriceX96 shape errors, SwapEventTopic0 stable hash with independent keccak verification, LookupChainConfig completeness, New() option propagation) — all PASS
- [x] V4 Swap event topic[0] hash independently computed via \`crypto.Keccak256\` and pinned in test — drift would fail loudly
- [x] All three JPYC V4 pools queried live via \`StateView.getSlot0\` to confirm reachability before adding configs
- [ ] Post-deploy on baobab: confirm IDRP/JPYC/MYRC appear in DAL collector + reporter 1m batch (matches IDRX-USDT verification flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)