### PR TITLE
Sort proof rows before BulkUpsert to avoid deadlocks

### DIFF
--- a/node/pkg/aggregator/globalaggregatebulkwriter.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"bisonai.com/miko/node/pkg/common/keys"
@@ -182,6 +183,17 @@ func storeProofs(ctx context.Context, proofs []Proof) error {
 		seen[key] = struct{}{}
 		dedupRows = append(dedupRows, []any{proof.ConfigID, proof.Round, proof.Proof})
 	}
+
+	// Sort by (config_id, round) so concurrent BulkUpsert calls acquire row
+	// locks in the same order, avoiding 40P01 deadlocks on the ON CONFLICT
+	// path when batches share rows (e.g. P2P-replayed proofs).
+	sort.Slice(dedupRows, func(i, j int) bool {
+		ai, aj := dedupRows[i][0].(int32), dedupRows[j][0].(int32)
+		if ai != aj {
+			return ai < aj
+		}
+		return dedupRows[i][1].(int32) < dedupRows[j][1].(int32)
+	})
 
 	return db.BulkUpsert(ctx, "proofs", []string{"config_id", "round", "proof"}, dedupRows, []string{"config_id", "round"}, []string{"proof"})
 }


### PR DESCRIPTION
## Summary
- Sort `dedupRows` by `(config_id, round)` in `storeProofs` before calling `db.BulkUpsert`, so concurrent BulkUpserts acquire row locks in the same order and avoid PostgreSQL 40P01 deadlocks on the `ON CONFLICT` path.

## Background

Cypress `orakl-node` has been hitting recurring deadlocks on the proofs upsert (visible in the daily error reports):

```
ERROR: deadlock detected (SQLSTATE 40P01)
query: INSERT INTO proofs (config_id, round, proof)
       VALUES ($1, $2, $3), ($4, $5, $6), ... (750+ placeholders)
       ON CONFLICT (config_id, round) DO UPDATE SET proof = EXCLUDED.proof
```

Timestamps cluster at :29 UTC (e.g. 03:29:53, 03:29:54, 04:29:56, 04:29:57 — 4 occurrences over the inspected day; reports also reference 01:29).

## Root cause

[`bulkInsertJob`](https://github.com/Bisonai/orakl/blob/master/node/pkg/aggregator/globalaggregatebulkwriter.go) spawns a fresh goroutine on every 1-second tick with `go s.bulkInsert(ctx)`. When a previous upsert is slow, two `bulkInsert` goroutines can run concurrently — each drains disjoint `SubmissionData` items from the shared Buffer chan, but the same `(config_id, round)` can appear in both batches via P2P-replayed proofs or reporter retries.

`storeProofs` deduplicates within a batch but preserves input (arrival) order, which is non-deterministic across concurrent drains. The `ON CONFLICT (config_id, round) DO UPDATE` clause then acquires per-row locks in batch order. Two transactions touching the same rows in opposite orders → deadlock.

The `:29 UTC` clustering is probably coincidence — most configs have `submitInterval=60s`, so submissions naturally bunch at the start of each minute, and a few longer-interval feeds align at the top of each hour, raising concurrent batch overlap at those times.

## Fix

Sort `dedupRows` by `(config_id, round)` before `BulkUpsert`. With a deterministic order, all concurrent transactions take row locks in the same sequence and the deadlock cycle cannot form. Cost is `O(n log n)` on the per-second batch (typically a few hundred rows) — negligible.

## Alternatives considered (not in this PR)

- **Serialize bulkInsert with a mutex / `TryLock`.** Simpler but reduces throughput on backpressure; doesn't address the underlying lock-order issue if any other writer ever touches the table.
- **Retry on 40P01 with backoff.** Masks the symptom without fixing the root cause. Worth adding later as defense-in-depth if a different deadlock surface appears.

## Test plan

- [x] `go build ./pkg/aggregator/...` passes
- [x] `go vet ./pkg/aggregator/...` clean
- [ ] Deploy to cypress and confirm absence of `40P01` errors in the proofs path for at least one full day (the prior pattern would have produced 2+ deadlocks in that window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)