### PR TITLE
Serialize bulkInsert ticks to eliminate residual proof deadlocks

### DIFF
--- a/node/pkg/aggregator/globalaggregatebulkwriter.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"sort"
+	"sync"
 	"time"
 
 	"bisonai.com/miko/node/pkg/common/keys"
@@ -23,6 +24,14 @@ type GlobalAggregateBulkWriter struct {
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc
+
+	// bulkInsertMu serializes bulkInsert calls so that a slow upsert
+	// doesn't allow the next tick to start a second concurrent run.
+	// Concurrent BulkUpserts on overlapping (config_id, round) rows
+	// were the residual source of 40P01 deadlocks even after the rows
+	// were pre-sorted (the ON CONFLICT path acquires locks beyond the
+	// caller-controlled order).
+	bulkInsertMu sync.Mutex
 }
 
 const DefaultPgsqlBulkInsertInterval = 1 * time.Second
@@ -132,7 +141,18 @@ func (s *GlobalAggregateBulkWriter) bulkInsertJob(ctx context.Context) {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				go s.bulkInsert(ctx)
+				// Skip this tick if a previous bulkInsert is still
+				// running. The buffered Buffer chan will simply hold
+				// more items until the next tick drains them, which
+				// is the same behavior as before but without the
+				// concurrent-writer deadlock window.
+				if !s.bulkInsertMu.TryLock() {
+					continue
+				}
+				go func() {
+					defer s.bulkInsertMu.Unlock()
+					s.bulkInsert(ctx)
+				}()
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary
- Add a `sync.Mutex` + `TryLock` around `bulkInsert` invocations so the 1-second ticker never starts a second concurrent run while a previous upsert is still in flight.

## Context

[#2503](https://github.com/Bisonai/orakl/pull/2503) sorted `dedupRows` by `(config_id, round)` to give every BulkUpsert a deterministic lock acquisition order. That cut the cypress 40P01 deadlocks roughly in half:

| | deadlocks / 24h on cypress orakl-node | timing |
|---|---|---|
| Before #2503 | 4 (5/14) | clustered at `:29 UTC` |
| After #2503 | 2 (5/17) | still clustered at `:29 UTC` |

The remaining cases (e.g. `2026-05-17T05:29:40Z`, batch with **$3801 placeholders** = 1267 rows) survive because `ON CONFLICT (config_id, round) DO UPDATE SET proof = EXCLUDED.proof` acquires unique-index / conflict locks beyond what caller-side row ordering controls. When two concurrent upserts share keys, those locks can still be acquired in opposite orders.

## Fix

`bulkInsertJob` ticks every 1s and currently calls `go s.bulkInsert(ctx)` — fire-and-forget, no serialization. If a previous upsert is slow, the next tick spawns a second concurrent goroutine and both can hit the conflict path on overlapping `(config_id, round)` rows.

Add a `sync.Mutex` on `GlobalAggregateBulkWriter`. On each tick:
- `TryLock` the mutex.
- If it's already held (previous bulkInsert still running), `continue` — the buffered `SubmissionData` chan just holds more items until the next tick drains them.
- Otherwise spawn the worker goroutine and `defer Unlock()`.

This eliminates concurrent writers entirely, which removes the remaining deadlock surface. The earlier sort is kept — it still helps for the single-writer path and is a cheap, defensive ordering invariant.

## Trade-off

Under sustained burst load where one upsert takes longer than 1s, every other tick will be skipped and that round's items accumulate for the next drain. The chan buffer is 2000 items, comfortably above the observed peak rate (~250 rows/sec across all configs combined), so backpressure shouldn't reach the producer side.

## Test plan

- [x] `go build ./pkg/aggregator/...` passes
- [x] `go vet ./pkg/aggregator/...` clean
- [ ] Deploy to cypress; confirm zero `40P01` errors in the proofs path over 48h (the prior pattern would have produced 2-4 deadlocks in that window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)