### PR TITLE
Fix(aggregator): Drain in-flight bulkInsert in Stop() + retry proofs on 40P01

### DIFF
--- a/node/pkg/aggregator/globalaggregatebulkwriter.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter.go
@@ -2,14 +2,27 @@ package aggregator
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"time"
 
 	"bisonai.com/miko/node/pkg/common/keys"
 	"bisonai.com/miko/node/pkg/db"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rs/zerolog/log"
 )
+
+// PostgreSQL SQLSTATE for deadlock_detected — see
+// https://www.postgresql.org/docs/current/errcodes-appendix.html
+const pgDeadlockSQLState = "40P01"
+
+// storeProofsRetryAttempts caps the retry loop for transient deadlocks on
+// the proofs BulkUpsert. The handoff race in Stop()/Start() should
+// eliminate the common deadlock window already; this is defense in depth
+// for any remaining edge cases (concurrent ad-hoc admin writers, future
+// migrations running mid-flight, etc.).
+const storeProofsRetryAttempts = 3
 
 /*
 bulk insert proofs and aggregates into pgsql
@@ -109,6 +122,19 @@ func (s *GlobalAggregateBulkWriter) Stop() {
 	s.cancelFunc()
 	s.cancelFunc = nil
 	s.ctx = nil
+
+	// Wait for any in-flight bulkInsert to finish before returning. The
+	// REFRESH_AGGREGATOR_APP handler calls Stop() then immediately creates
+	// a new GlobalAggregateBulkWriter (with its own mutex) and starts it.
+	// Without this drain the old goroutine's BulkUpsert and the new one's
+	// next tick can both run concurrently against the proofs table — each
+	// holds its own per-instance mutex, so they don't serialize, and the
+	// ON CONFLICT (config_id, round) DO UPDATE path then deadlocks
+	// (SQLSTATE 40P01) when their batches share rows. Acquiring and
+	// releasing the mutex here ensures the in-flight query returns first,
+	// so the handoff to the next instance is sequential.
+	s.bulkInsertMu.Lock()
+	s.bulkInsertMu.Unlock()
 }
 
 func (s *GlobalAggregateBulkWriter) receive(ctx context.Context) {
@@ -215,7 +241,30 @@ func storeProofs(ctx context.Context, proofs []Proof) error {
 		return dedupRows[i][1].(int32) < dedupRows[j][1].(int32)
 	})
 
-	return db.BulkUpsert(ctx, "proofs", []string{"config_id", "round", "proof"}, dedupRows, []string{"config_id", "round"}, []string{"proof"})
+	// Retry on deadlock (SQLSTATE 40P01). Per PostgreSQL docs, "applications
+	// using transactions should be prepared to retry on serialization /
+	// deadlock failures." The handoff drain in Stop() removes the common
+	// source of deadlocks here, so this loop is defense in depth — at the
+	// observed pre-fix rate (~2–4/day) a single retry attempt is enough.
+	var lastErr error
+	for attempt := 1; attempt <= storeProofsRetryAttempts; attempt++ {
+		err := db.BulkUpsert(ctx, "proofs", []string{"config_id", "round", "proof"}, dedupRows, []string{"config_id", "round"}, []string{"proof"})
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != pgDeadlockSQLState {
+			return err
+		}
+		log.Warn().Err(err).Int("attempt", attempt).Msg("proofs BulkUpsert deadlock — retrying")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * 50 * time.Millisecond):
+		}
+	}
+	return lastErr
 }
 
 func storeGlobalAggregates(ctx context.Context, globalAggregates []GlobalAggregate) error {

--- a/node/pkg/aggregator/globalaggregatebulkwriter.go
+++ b/node/pkg/aggregator/globalaggregatebulkwriter.go
@@ -257,6 +257,13 @@ func storeProofs(ctx context.Context, proofs []Proof) error {
 		if !errors.As(err, &pgErr) || pgErr.Code != pgDeadlockSQLState {
 			return err
 		}
+
+		// Don't log "retrying" or sleep on the final attempt — we're
+		// about to return lastErr, not retry.
+		if attempt == storeProofsRetryAttempts {
+			break
+		}
+
 		log.Warn().Err(err).Int("attempt", attempt).Msg("proofs BulkUpsert deadlock — retrying")
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

Two changes that together eliminate the recurring `40P01` deadlocks on the proofs `BulkUpsert` path:

1. **Stop() now drains the in-flight `bulkInsert` goroutine** by acquiring + releasing `bulkInsertMu` before returning, so a subsequent `setGlobalAggregateBulkWriter` + `Start()` handoff (driven by `REFRESH_AGGREGATOR_APP`) cannot run concurrent upserts against `proofs`.
2. **`storeProofs` retries `BulkUpsert` on SQLSTATE `40P01`** up to 3 times with a small linear backoff. Defense in depth — the PostgreSQL-recommended pattern for serialization/deadlock failures.

## Why earlier fixes didn't close the case

| PR | Change | Cypress deadlocks / 24h |
|---|---|---|
| baseline | — | ~4 |
| #2503 | sort dedupRows by `(config_id, round)` | ~2 (5/17) |
| #2505 | per-instance mutex (`bulkInsertMu`) on bulkInsert | 6 (5/25 — 01:30, 02:29, 04:29, 05:29, 08:29 UTC) |

#2503 and #2505 both target steady-state concurrency on a single instance, but the deadlocks survived in a tight `:29–:30 UTC` hourly cluster.

## Root cause: refresh handoff race

`pkg/aggregator/app.go:296` handles `REFRESH_AGGREGATOR_APP`:

```go
case bus.REFRESH_AGGREGATOR_APP:
    a.stopGlobalAggregateBulkWriter()       // cancels old ctx, does NOT wait
    ... configs reload ...
    a.setGlobalAggregateBulkWriter(configs) // NEW struct, NEW mutex
    a.startGlobalAggregateBulkWriter(ctx)   // new ticker fires immediately
```

`Stop()` only calls `cancelFunc()`; the goroutine already inside `bulkInsert` (mid-`BulkUpsert`) continues to completion. Meanwhile the new instance's first tick acquires its own brand-new `bulkInsertMu` (different memory) and starts its own `BulkUpsert`. Two concurrent multi-row INSERTs … ON CONFLICT … against the same `proofs` rows → 40P01.

The deadlock query consistently shows ~1267 rows (3801 placeholders), matching what you'd expect when a backlogged Buffer is drained right after a refresh.

Verification:
- only `storeProofs → db.BulkUpsert("proofs", …)` writes to the table (`grep -rn` confirmed)
- 1 replica, dedicated DB at `172.0.100.70:25432/node` (KF cypress uses a separate DB at `10.242.145.2:5432/node`, proofs counts 3.0M vs 2.2M)
- `#2505` binary present in deployed image (`v0.0.1.20260518.0206.229c4f8.cypress`)

## Test plan

- [x] `go build ./pkg/aggregator/...` passes
- [x] `go vet ./pkg/aggregator/...` clean
- [ ] Deploy to cypress and confirm zero `40P01` errors over 48h in the proofs path

🤖 Generated with [Claude Code](https://claude.com/claude-code)