### PR TITLE
fix(ci): pass GitHub App token to image-update in tag+deploy

### DIFF
--- a/.github/workflows/tag+deploy.yaml
+++ b/.github/workflows/tag+deploy.yaml
@@ -126,7 +126,8 @@ jobs:
       tag_date: ${{ needs.prepare.outputs.tag_date }}
       tag_git_hash: ${{ needs.prepare.outputs.tag_git_hash }}
     secrets:
-      PAT: ${{ secrets.PAT }}
+      GH_ORAKL_BOT_APP_ID: ${{ secrets.GH_ORAKL_BOT_APP_ID }}
+      GH_ORAKL_BOT_PRIVATE_KEY: ${{ secrets.GH_ORAKL_BOT_PRIVATE_KEY }}
     if: ${{ success() }}
 
   post-slack-tag-update-success:


### PR DESCRIPTION
## Problem

Pushing a release tag (e.g. `node/v0.0.1`) fails immediately with **`startup_failure`** — the whole `Build and Deploy` workflow never starts, so **no image is built and nothing deploys**. This is why node images stopped being published after the last release (running nodes are still the 2026-05-26 image).

## Root cause

#2495 ("replace PAT with GitHub App token") changed `update.image-tag.yaml`'s required secrets from `PAT` to `GH_ORAKL_BOT_APP_ID` / `GH_ORAKL_BOT_PRIVATE_KEY`, and updated `deployment.yaml` to match — but **`tag+deploy.yaml`'s `image-update` job was missed** and still passes `PAT`.

GitHub validates a called reusable workflow's required-secrets contract at **start-up**, so the mismatch fails the entire run before any job (including `build`) executes.

## Fix

Pass the App token secrets, exactly as `deployment.yaml` already does:

```diff
     secrets:
-      PAT: ${{ secrets.PAT }}
+      GH_ORAKL_BOT_APP_ID: ${{ secrets.GH_ORAKL_BOT_APP_ID }}
+      GH_ORAKL_BOT_PRIVATE_KEY: ${{ secrets.GH_ORAKL_BOT_PRIVATE_KEY }}
```

## After merge

Re-tag `node/v0.0.1` on the new master HEAD (which now includes this fix + the kucoin #2510 / mexc #2511 fetcher fixes) to build & publish the node image and canary-deploy baobab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)