### PR TITLE
fix(ci): pass required channel input to post.slack in tag+deploy

### DIFF
--- a/.github/workflows/tag+deploy.yaml
+++ b/.github/workflows/tag+deploy.yaml
@@ -110,6 +110,7 @@ jobs:
     with:
       status: "Success"
       slack-message: "*${{ needs.prepare.outputs.app_name }}* : *${{ needs.prepare.outputs.service }}* ${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }} is uploaded"
+      channel: "miko-notification"
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     if: ${{ success() }}
@@ -138,6 +139,7 @@ jobs:
     with:
       status: "Success"
       slack-message: "*${{ needs.prepare.outputs.app_name }}* : *${{ needs.prepare.outputs.service }}* new image tag ${{ needs.prepare.outputs.version }}.${{ needs.prepare.outputs.tag_date }}.${{ needs.prepare.outputs.tag_git_hash }} is updated"
+      channel: "miko-notification"
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -149,5 +151,6 @@ jobs:
     with:
       status: "Failed"
       slack-message: "*${{ needs.prepare.outputs.app_name }}* git action failed"
+      channel: "miko-notification"
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Follow-up to #2513 — the tag+deploy `Build and Deploy` workflow **still** fails with `startup_failure` because of a **second** unmet reusable-workflow contract.

## Cause

`post.slack.yaml` requires a `channel` input (no default), but all three `post-slack-*` jobs pass only `status` + `slack-message`. GitHub validates every referenced reusable workflow at **start-up** — even `if:`-gated jobs — so the missing input kills the whole run before `build` executes. (#2513 fixed the App-token secret half of the same start-up validation.)

## Fix

Add `channel: "miko-notification"` to the three calls, matching `deployment.yaml`.

## Verified

Programmatic check of every reusable call in `tag+deploy.yaml` — all now satisfy required inputs **and** secrets:

| job | reusable | inputs | secrets |
|---|---|---|---|
| post-slack-image-upload | post.slack | ✅ | ✅ |
| image-update | update.image-tag | ✅ | ✅ |
| post-slack-tag-update-success | post.slack | ✅ | ✅ |
| post-slack-tag-update-failure | post.slack | ✅ | ✅ |

After merge I'll re-tag `node/v0.0.1` to finally build+publish the node image (kucoin #2510 + mexc #2511) and canary-deploy baobab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)