### PR TITLE
Add a HashKey Global websocket price source

### DIFF
--- a/node/pkg/websocketfetcher/app.go
+++ b/node/pkg/websocketfetcher/app.go
@@ -28,6 +28,7 @@ import (
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/gateio"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/gemini"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/gopax"
+	"bisonai.com/miko/node/pkg/websocketfetcher/providers/hashkey"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/huobi"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/korbit"
 	"bisonai.com/miko/node/pkg/websocketfetcher/providers/kraken"
@@ -146,6 +147,7 @@ func (a *App) Init(ctx context.Context, opts ...AppOption) error {
 		"xt":       xt.New,
 		"gopax":    gopax.New,
 		"orangex":  orangex.New,
+		"hashkey":  hashkey.New,
 	}
 
 	dexFactories := map[string]func(...common.DexFetcherOption) common.FetcherInterface{

--- a/node/pkg/websocketfetcher/providers/hashkey/hashkey.go
+++ b/node/pkg/websocketfetcher/providers/hashkey/hashkey.go
@@ -1,0 +1,110 @@
+package hashkey
+
+import (
+	"context"
+	"time"
+
+	"bisonai.com/miko/node/pkg/websocketfetcher/common"
+	"bisonai.com/miko/node/pkg/wss"
+	"github.com/rs/zerolog/log"
+)
+
+type HashkeyFetcher common.Fetcher
+
+// expected to receive a feedmap with keys in "<base><quote>" upper-case form
+func New(ctx context.Context, opts ...common.FetcherOption) (common.FetcherInterface, error) {
+	config := &common.FetcherConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	fetcher := &HashkeyFetcher{}
+	fetcher.FeedMap = config.FeedMaps.Combined
+	fetcher.FeedDataBuffer = config.FeedDataBuffer
+
+	// HashKey accepts one symbol per subscribe request, so send one per feed.
+	subscriptions := []any{}
+	for feed := range fetcher.FeedMap {
+		subscriptions = append(subscriptions, Subscription{
+			Topic:  "realtimes",
+			Event:  "sub",
+			Params: map[string]string{"symbol": feed},
+		})
+	}
+
+	ws, err := wss.NewWebsocketHelper(ctx,
+		wss.WithEndpoint(URL),
+		wss.WithSubscriptions(subscriptions),
+		wss.WithProxyUrl(config.Proxy))
+	if err != nil {
+		log.Error().Str("Player", "Hashkey").Err(err).Msg("error in hashkey.New")
+		return nil, err
+	}
+	fetcher.Ws = ws
+
+	return fetcher, nil
+}
+
+func (f *HashkeyFetcher) handleMessage(ctx context.Context, message map[string]any) error {
+	// Subscription acks carry an "event" field; a non-zero code means the sub
+	// was rejected. Log it loudly -- a silently rejected sub is a feed that
+	// never produces data.
+	if _, isAck := message["event"]; isAck {
+		if code, _ := message["code"].(string); code != "" && code != "0" {
+			log.Error().Str("Player", "Hashkey").
+				Any("code", message["code"]).
+				Any("msg", message["msg"]).
+				Any("params", message["params"]).
+				Msg("hashkey rejected a subscription")
+		}
+		return nil
+	}
+
+	response, err := common.MessageToStruct[Response](message)
+	if err != nil {
+		log.Error().Str("Player", "Hashkey").Err(err).Msg("error in hashkey.handleMessage")
+		return err
+	}
+
+	// Skips the server's pong frames and anything that isn't a ticker push.
+	if response.Topic != "realtimes" || response.Data.Symbol == "" {
+		return nil
+	}
+
+	feedDataList, err := ResponseToFeedDataList(response, f.FeedMap)
+	if err != nil {
+		log.Error().Str("Player", "Hashkey").Err(err).Msg("error in hashkey.handleMessage")
+		return err
+	}
+
+	for _, feedData := range feedDataList {
+		f.FeedDataBuffer <- feedData
+	}
+
+	return nil
+}
+
+func (f *HashkeyFetcher) Run(ctx context.Context) {
+	go f.pingJob(ctx)
+	f.Ws.Run(ctx, f.handleMessage)
+}
+
+// pingJob is the client keep-alive. HashKey never pings us and drops a silent
+// connection after ~30s; a `{"ping":<ms>}` every 10s keeps it open (pingJob is
+// the only writer, so this does not race with the read loop).
+func (f *HashkeyFetcher) pingJob(ctx context.Context) {
+	ticker := time.NewTicker(time.Duration(PingInterval) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := f.Ws.Write(ctx, Ping{Ping: time.Now().UnixMilli()}); err != nil {
+				log.Error().Str("Player", "Hashkey").Err(err).Msg("error in hashkey.pingJob")
+				return
+			}
+		}
+	}
+}

--- a/node/pkg/websocketfetcher/providers/hashkey/type.go
+++ b/node/pkg/websocketfetcher/providers/hashkey/type.go
@@ -1,0 +1,48 @@
+package hashkey
+
+const (
+	// HashKey Global (not HashKey Pro at stream-pro.hashkey.com) public spot
+	// market-data websocket, v2. v1 does not stream and the Pro host rejects the
+	// pairs we care about with "Parameter error".
+	URL = "wss://stream-glb.hashkey.com/quote/ws/v2"
+
+	// The server never pings us; if the client stays silent it drops the
+	// connection after ~30s. Sending a client ping every 10s (the interval the
+	// docs specify) keeps it alive -- the server answers each with a pong.
+	PingInterval = 10000
+)
+
+// Subscription is one `sub` request. HashKey takes a single symbol per request,
+// so we send one per feed. Symbol format is the concatenated "<base><quote>"
+// upper-case, e.g. GRNDUSDT -- the same key the Combined feed map uses.
+type Subscription struct {
+	Topic  string            `json:"topic"`
+	Event  string            `json:"event"`
+	Params map[string]string `json:"params"`
+}
+
+// Ping is the client keep-alive; the value is a millisecond timestamp.
+type Ping struct {
+	Ping int64 `json:"ping"`
+}
+
+// Response is a `realtimes` (24h ticker) push.
+//
+//	{"topic":"realtimes","params":{"symbol":"GRNDUSDT"},
+//	 "data":{"t":..,"s":"GRNDUSDT","o":..,"h":..,"l":..,"c":"0.01016",
+//	         "v":"1005953.72","qv":"10094.22","m":".."}}
+type Response struct {
+	Topic string     `json:"topic"`
+	Data  TickerData `json:"data"`
+}
+
+type TickerData struct {
+	Timestamp int64  `json:"t"`
+	Symbol    string `json:"s"`
+	Open      string `json:"o"`
+	High      string `json:"h"`
+	Low       string `json:"l"`
+	Price     string `json:"c"`  // close / current price
+	Volume    string `json:"v"`  // BASE-asset volume (coin amount) -- the one we want
+	QuoteVol  string `json:"qv"` // quote-asset volume (USDT turnover)
+}

--- a/node/pkg/websocketfetcher/providers/hashkey/utils.go
+++ b/node/pkg/websocketfetcher/providers/hashkey/utils.go
@@ -1,0 +1,43 @@
+package hashkey
+
+import (
+	"fmt"
+	"time"
+
+	"bisonai.com/miko/node/pkg/websocketfetcher/common"
+)
+
+func ResponseToFeedDataList(response Response, feedMap map[string][]int32) ([]*common.FeedData, error) {
+	d := response.Data
+
+	ids, exists := feedMap[d.Symbol]
+	if !exists {
+		return nil, fmt.Errorf("feed not found from hashkey for symbol: %s", d.Symbol)
+	}
+
+	value, err := common.PriceStringToFloat64(d.Price)
+	if err != nil {
+		return nil, err
+	}
+
+	// d.Volume is `v`, the base-asset volume; `qv` is the quote (USDT) turnover.
+	// FeedData.Volume is the base amount everywhere else, so use v (not qv).
+	volume, err := common.VolumeStringToFloat64(d.Volume)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := time.UnixMilli(d.Timestamp)
+
+	result := []*common.FeedData{}
+	for _, id := range ids {
+		feedData := new(common.FeedData)
+		feedData.FeedID = id
+		feedData.Value = value
+		feedData.Timestamp = &timestamp
+		feedData.Volume = volume
+		result = append(result, feedData)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Adds a CEX fetcher provider for **HashKey Global** so pairs it lists can be used as oracle sources.

## Why

GRND-USDT lost **OrangeX** and **LBank** (both delisted — see orakl-config #197/#198) and was left **single-source on gateio**. HashKey Global lists GRND-USDT with **~4x gateio's volume** ($10k vs $2.4k/24h) and ticks more often, so it's a good second source.

## Verified live against `wss://stream-glb.hashkey.com/quote/ws/v2`

- It's HashKey **Global** v2 — v1 doesn't stream, and the **Pro** host (`stream-pro.hashkey.com`) rejects these pairs with `Parameter error`.
- Subscribe per symbol: `{"topic":"realtimes","event":"sub","params":{"symbol":"GRNDUSDT"}}`. Symbol is concatenated `<base><quote>` upper-case — matches the Combined feed map key.
- **Heartbeat:** the server never pings us and drops a silent connection after ~30s. The provider sends a client `{"ping":<ms>}` every 10s (`pingJob`, the only writer — no write race).
- **Fields:** price = `c`, base-asset volume = `v` (**not** `qv`, the quote turnover — `FeedData.Volume` is the base amount everywhere else).

Drove the real `hashkey.New` + `Run` with a GRND feed map: the emitted `FeedData` matches `GET /quote/v1/ticker/24hr` **exactly** (price `0.01016`, volume `1010429.72`). `go build`/`vet`/`gofmt` clean.

## Follow-up

After this merges + a node image ships, orakl-config gets `hashkey-wss-GRND-USDT` added to GRND-USDT so it aggregates gateio + hashkey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)