### PR TITLE
Make signer-key rotation crash-safe and self-reconciling

### DIFF
--- a/node/migrations/node/000041_signer_key.down.sql
+++ b/node/migrations/node/000041_signer_key.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS signer_key;

--- a/node/migrations/node/000041_signer_key.down.sql
+++ b/node/migrations/node/000041_signer_key.down.sql
@@ -1,1 +1,7 @@
-DROP TABLE IF EXISTS signer_key;
+-- Intentionally non-destructive: keep signer_key on rollback so the durable keyring (the active
+-- key plus any in-flight pending keys) survives a downgrade and a subsequent re-upgrade. Pre-fix
+-- binaries ignore this additive table, so retaining it is safe, and recovery after an interrupted
+-- rotation depends on not losing these locally-held keys (issue #2516). A subsequent up-migration
+-- is a no-op (CREATE TABLE IF NOT EXISTS + seed WHERE NOT EXISTS), preserving the rows.
+-- To fully remove the table, drop it manually: DROP TABLE IF EXISTS signer_key;
+SELECT 1;

--- a/node/migrations/node/000041_signer_key.up.sql
+++ b/node/migrations/node/000041_signer_key.up.sql
@@ -17,8 +17,12 @@ CREATE TABLE IF NOT EXISTS signer_key (
 CREATE UNIQUE INDEX IF NOT EXISTS signer_key_one_active ON signer_key ((state)) WHERE state = 'active';
 CREATE UNIQUE INDEX IF NOT EXISTS signer_key_addr       ON signer_key (address)  WHERE address IS NOT NULL;
 
--- Seed exactly once from the existing single `signer` row as the active key.
--- address stays NULL here (partial index tolerates NULL); the app backfills it on first reconcile.
+-- Seed exactly once from the existing single `signer` row as the active key. This is only a
+-- bootstrap: at runtime reconcile (loadCandidates) always also considers the current legacy
+-- `signer` row as a candidate and, if it is the on-chain oracle, imports it into signer_key via
+-- ensureActive. So a key a pre-fix binary writes to `signer` later is still discovered/adopted —
+-- the one-time seed does not need to catch it. address stays NULL here (partial index tolerates
+-- NULL); the app backfills it on first reconcile.
 INSERT INTO signer_key (pk, state)
     SELECT pk, 'active' FROM signer
     WHERE pk IS NOT NULL AND pk <> '' AND NOT EXISTS (SELECT 1 FROM signer_key);

--- a/node/migrations/node/000041_signer_key.up.sql
+++ b/node/migrations/node/000041_signer_key.up.sql
@@ -1,0 +1,24 @@
+-- Additive migration for crash-safe signer-key rotation (issue #2516).
+-- The legacy `signer` table, its single row, and its `unique_dummy` constraint are
+-- intentionally left in place: the pre-fix binary and the bootstrap/rollback path still
+-- read/write it via LOAD_SIGNER / STORE_SIGNER. This migration only ADDS a new table.
+CREATE TABLE IF NOT EXISTS signer_key (
+    id          SERIAL PRIMARY KEY,
+    address     TEXT,                            -- lowercased 0x address; NULL until the app backfills (pk is encrypted, cannot derive in SQL)
+    pk          TEXT NOT NULL,                   -- encrypted with the same encryptor as the legacy signer.pk
+    state       TEXT NOT NULL DEFAULT 'pending', -- 'active' | 'pending' | 'retired'
+    tx_hash     TEXT,                            -- updateOracle tx hash for this candidate (advisory, nullable)
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- At most one active row. Deliberately NO unique index on state='pending'
+-- (a one-pending index would wedge rotation forever if a pending never lands).
+CREATE UNIQUE INDEX IF NOT EXISTS signer_key_one_active ON signer_key ((state)) WHERE state = 'active';
+CREATE UNIQUE INDEX IF NOT EXISTS signer_key_addr       ON signer_key (address)  WHERE address IS NOT NULL;
+
+-- Seed exactly once from the existing single `signer` row as the active key.
+-- address stays NULL here (partial index tolerates NULL); the app backfills it on first reconcile.
+INSERT INTO signer_key (pk, state)
+    SELECT pk, 'active' FROM signer
+    WHERE pk IS NOT NULL AND pk <> '' AND NOT EXISTS (SELECT 1 FROM signer_key);

--- a/node/pkg/admin/aggregator/controller.go
+++ b/node/pkg/admin/aggregator/controller.go
@@ -1,14 +1,10 @@
 package aggregator
 
 import (
-	"errors"
-	"os"
 	"strconv"
 
 	"bisonai.com/miko/node/pkg/admin/utils"
 	"bisonai.com/miko/node/pkg/bus"
-	chainutils "bisonai.com/miko/node/pkg/chain/utils"
-	errorsentinel "bisonai.com/miko/node/pkg/error"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
 )
@@ -106,22 +102,23 @@ func renewSigner(c *fiber.Ctx) error {
 	return c.SendString("s refreshed: " + strconv.FormatBool(resp.Success))
 }
 
+// getSigner reports the signer the node is ACTUALLY using (the in-memory active key, plus
+// whether it is currently usable / rotating), sourced from the running Signer via the bus —
+// not the DB row. Reading the DB was the misleading symptom in the 2026-07-25 incident, where
+// the endpoint showed a key different from the one the node was signing with.
 func getSigner(c *fiber.Ctx) error {
-	signerpk, err := chainutils.LoadSignerPk(c.Context())
-	if err != nil && !errors.Is(err, errorsentinel.ErrChainSignerPKNotFound) {
-		return c.Status(fiber.StatusInternalServerError).SendString("failed to get signer: " + err.Error())
-	}
-
-	if signerpk == "" {
-		signerpk = os.Getenv("SIGNER_PK")
-		if signerpk == "" {
-			return c.Status(fiber.StatusInternalServerError).SendString("failed to get signer, no signer set")
-		}
-	}
-
-	addr, err := chainutils.StringPkToAddressHex(signerpk)
+	msg, err := utils.SendMessage(c, bus.AGGREGATOR, bus.GET_SIGNER, nil)
 	if err != nil {
+		log.Error().Err(err).Str("Player", "Admin").Msg("failed to send message to aggregator")
 		return c.Status(fiber.StatusInternalServerError).SendString("failed to get signer: " + err.Error())
 	}
-	return c.JSON(fiber.Map{"signer": addr})
+	resp := <-msg.Response
+	if !resp.Success {
+		errMsg := "unknown error"
+		if e, ok := resp.Args["error"].(string); ok {
+			errMsg = e
+		}
+		return c.Status(fiber.StatusInternalServerError).SendString("failed to get signer: " + errMsg)
+	}
+	return c.JSON(resp.Args)
 }

--- a/node/pkg/admin/tests/aggregator_test.go
+++ b/node/pkg/admin/tests/aggregator_test.go
@@ -115,6 +115,16 @@ func TestAggregatorGetSigner(t *testing.T) {
 	}
 	defer cleanup()
 
+	// getSigner now reports the in-memory signer via the bus (not a DB read), so stand in for the
+	// aggregator and answer the GET_SIGNER request with a signer payload.
+	channel := testItems.mb.Subscribe(bus.AGGREGATOR)
+	waitForMessageWithResponse(t, channel, bus.ADMIN, bus.AGGREGATOR, bus.GET_SIGNER, map[string]any{
+		"signer":    "0x0000000000000000000000000000000000000001",
+		"usable":    true,
+		"rotating":  false,
+		"expiresAt": int64(0),
+	})
+
 	res, err := GetRequest[signer](testItems.app, "/api/v1/aggregator/signer", nil)
 	if err != nil {
 		t.Fatalf("error getting signer: %v", err)

--- a/node/pkg/admin/tests/aggregator_test.go
+++ b/node/pkg/admin/tests/aggregator_test.go
@@ -106,7 +106,10 @@ func TestAggregatorDeactivate(t *testing.T) {
 
 func TestAggregatorGetSigner(t *testing.T) {
 	type signer struct {
-		Signer string `json:"signer"`
+		Signer    string `json:"signer"`
+		Usable    bool   `json:"usable"`
+		Rotating  bool   `json:"rotating"`
+		ExpiresAt int64  `json:"expiresAt"`
 	}
 	ctx := context.Background()
 	cleanup, testItems, err := setup(ctx)
@@ -132,4 +135,7 @@ func TestAggregatorGetSigner(t *testing.T) {
 
 	assert.NotNil(t, res)
 	assert.NotEmpty(t, res.Signer)
+	assert.True(t, res.Usable)
+	assert.False(t, res.Rotating)
+	assert.Equal(t, int64(0), res.ExpiresAt)
 }

--- a/node/pkg/aggregator/app.go
+++ b/node/pkg/aggregator/app.go
@@ -27,6 +27,14 @@ func New(bus *bus.MessageBus, h host.Host, ps *pubsub.PubSub) *App {
 }
 
 func (a *App) Run(ctx context.Context) error {
+	// Create the singleton Signer BEFORE subscribing to the bus, so a.Signer is assigned
+	// single-threaded before any GET_SIGNER/RENEW_SIGNER handler goroutine can read it. This
+	// closes both the double-create race and the plain-field data race on a.Signer (issue #2516).
+	if err := a.ensureSigner(ctx); err != nil {
+		log.Error().Err(err).Str("Player", "Aggregator").Msg("failed to initialize signer")
+		return err
+	}
+
 	a.subscribe(ctx)
 
 	configs, err := a.getConfigs(ctx)
@@ -100,34 +108,49 @@ func (a *App) clearAggregators() error {
 	return nil
 }
 
-func (a *App) initializeLoadedAggregators(ctx context.Context, loadedConfigs []Config, h host.Host, ps *pubsub.PubSub) error {
-	signerOptions := []helper.SignerOption{}
-
-	signerRenewIntervalRaw := os.Getenv("SIGNER_RENEW_INTERVAL")
-	duration, err := time.ParseDuration(signerRenewIntervalRaw)
-	if err == nil {
-		signerOptions = append(signerOptions, helper.WithRenewInterval(duration))
+// ensureSigner builds the singleton Signer exactly once. It is called from Run (before the bus
+// subscription starts, so the write is single-threaded and happens-before any handler read) and
+// again from initializeLoadedAggregators, where it is a no-op because a.Signer is already set.
+func (a *App) ensureSigner(ctx context.Context) error {
+	if a.Signer != nil {
+		return nil
 	}
 
-	signerRenewThresholdRaw := os.Getenv("SIGNER_RENEW_THRESHOLD")
-	threshold, err := time.ParseDuration(signerRenewThresholdRaw)
-	if err == nil {
-		signerOptions = append(signerOptions, helper.WithRenewThreshold(threshold))
+	signerOptions := []helper.SignerOption{}
+	if raw := os.Getenv("SIGNER_RENEW_INTERVAL"); raw != "" {
+		if duration, err := time.ParseDuration(raw); err == nil {
+			signerOptions = append(signerOptions, helper.WithRenewInterval(duration))
+		}
+	}
+	if raw := os.Getenv("SIGNER_RENEW_THRESHOLD"); raw != "" {
+		if threshold, err := time.ParseDuration(raw); err == nil {
+			signerOptions = append(signerOptions, helper.WithRenewThreshold(threshold))
+		}
 	}
 
 	signer, err := helper.NewSigner(ctx, signerOptions...)
 	if err != nil {
 		return err
 	}
-
 	a.Signer = signer
+	return nil
+}
+
+func (a *App) initializeLoadedAggregators(ctx context.Context, loadedConfigs []Config, h host.Host, ps *pubsub.PubSub) error {
+	// The Signer is a singleton for the app lifetime (created in Run before the bus starts). Reuse
+	// it here; never build a second one on config refresh (a second reconcile goroutine rotating
+	// the same on-chain oracle was a root cause of issue #2516).
+	if err := a.ensureSigner(ctx); err != nil {
+		return err
+	}
+
 	for _, config := range loadedConfigs {
 		if a.Aggregators[config.ID] != nil {
 			continue
 		}
 
 		topicString := config.Name + "-global-aggregator-topic-" + strconv.Itoa(int(config.AggregateInterval))
-		tmpNode, err := NewAggregator(h, ps, topicString, config, signer, a.LatestLocalAggregates)
+		tmpNode, err := NewAggregator(h, ps, topicString, config, a.Signer, a.LatestLocalAggregates)
 		if err != nil {
 			return err
 		}
@@ -342,12 +365,28 @@ func (a *App) handleMessage(ctx context.Context, msg bus.Message) {
 		msg.Response <- bus.MessageResponse{Success: true}
 	case bus.RENEW_SIGNER:
 		log.Debug().Str("Player", "Aggregator").Msg("refresh signer msg received")
+		if a.Signer == nil {
+			bus.HandleMessageError(errorSentinel.ErrChainSignerPKNotFound, msg, "signer not initialized")
+			return
+		}
 		err := a.renewSigner(ctx)
 		if err != nil {
 			bus.HandleMessageError(err, msg, "failed to refresh signer")
 			return
 		}
 		msg.Response <- bus.MessageResponse{Success: true}
+	case bus.GET_SIGNER:
+		if a.Signer == nil {
+			bus.HandleMessageError(errorSentinel.ErrChainSignerPKNotFound, msg, "signer not initialized")
+			return
+		}
+		status := a.Signer.Status()
+		msg.Response <- bus.MessageResponse{Success: true, Args: map[string]any{
+			"signer":    status.ActiveSigner,
+			"usable":    status.Usable,
+			"rotating":  status.Rotating,
+			"expiresAt": status.ExpiresAt,
+		}}
 	case bus.STREAM_LOCAL_AGGREGATE:
 
 		localAggregate := msg.Content.Args["value"].(*LocalAggregate)

--- a/node/pkg/aggregator/main_test.go
+++ b/node/pkg/aggregator/main_test.go
@@ -79,7 +79,10 @@ func setup(ctx context.Context) (func() error, *TestItems, error) {
 	}
 	testItems.tmpData = tmpData
 
-	signHelper, err := helper.NewSigner(ctx)
+	// Static mode (WithSignerPk): the aggregator tests only need a working signer that produces
+	// proofs; static mode bypasses the on-chain whitelist gate so they don't depend on live chain
+	// state (the managed reconcile/rotate path is covered by helper unit + integration tests).
+	signHelper, err := helper.NewSigner(ctx, helper.WithSignerPk("27894b84849f129e08f37634be4e8ccc4c7267d824eb8cfd285185854ba5b78d"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/node/pkg/bus/types.go
+++ b/node/pkg/bus/types.go
@@ -28,6 +28,7 @@ const (
 	DEACTIVATE_AGGREGATOR = "deactivate_aggregator"
 
 	RENEW_SIGNER = "renew_signer"
+	GET_SIGNER   = "get_signer"
 
 	ACTIVATE_REPORTER   = "activate_reporter"
 	DEACTIVATE_REPORTER = "deactivate_reporter"

--- a/node/pkg/chain/helper/signer.go
+++ b/node/pkg/chain/helper/signer.go
@@ -93,22 +93,23 @@ func NewSigner(ctx context.Context, opts ...SignerOption) (*Signer, error) {
 		opt(&config)
 	}
 
+	// Explicit static-key mode: an operator-supplied key (WithSignerPk) is used directly, with no
+	// keyring, no rotation and no on-chain whitelist gate. It does no chain/DB I/O, so it must NOT
+	// require SUBMISSION_PROXY_CONTRACT — the env check below is only for the managed path.
+	// Production (the aggregator) never sets WithSignerPk and always uses the managed reconcile
+	// path below; this branch is for explicit overrides and tests.
+	if config.pk != "" {
+		return newStaticSigner(config)
+	}
+
 	submissionProxyContractAddr := os.Getenv("SUBMISSION_PROXY_CONTRACT")
 	if submissionProxyContractAddr == "" {
 		log.Error().Str("Player", "Signer").Msg("SUBMISSION_PROXY_CONTRACT not found, signer initialization failed")
 		return nil, errorSentinel.ErrChainSubmissionProxyContractNotFound
 	}
 
-	// Explicit static-key mode: an operator-supplied key (WithSignerPk) is used directly, with no
-	// keyring, no rotation and no on-chain whitelist gate. Production (the aggregator) never sets
-	// WithSignerPk and always uses the managed reconcile path below; this branch is for explicit
-	// overrides and tests, and preserves their pre-fix behavior.
-	if config.pk != "" {
-		return newStaticSigner(config)
-	}
-
 	// Seed the keyring from a bootstrap key if it is empty (fresh node). Existing nodes already
-	// have the legacy key migrated into signer_key by migration 000027.
+	// have the legacy key migrated into signer_key by migration 000041.
 	initialPkHex, err := ensureKeyring(ctx, config)
 	if err != nil {
 		return nil, err
@@ -491,7 +492,7 @@ func (s *Signer) setUnusable(reason string) {
 	s.usable = false
 	s.rotating = false
 	s.mu.Unlock()
-	_ = reason
+	log.Warn().Str("Player", "Signer").Str("reason", reason).Msg("signer marked unusable — refusing to sign")
 }
 
 func (s *Signer) renewalRequired(exp time.Time) bool {
@@ -552,6 +553,9 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 		}
 		select {
 		case <-ctx.Done():
+			s.mu.Lock()
+			s.rotating = false // don't leave the sign gate wedged on shutdown/cancel
+			s.mu.Unlock()
 			return ctx.Err()
 		case <-time.After(s.verifyPollInterval):
 		}
@@ -583,6 +587,9 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 	if rErr == nil && fromExp.After(time.Now()) {
 		s.usable = true
 		s.cachedExpiration = fromExp
+		// This read is a positive on-chain confirmation of `from`; stamp it so the sign gate's
+		// confirmationTTL check does not immediately refuse after a slow (~60s) rotation attempt.
+		s.lastConfirmedAt = time.Now()
 	} else {
 		s.usable = false
 	}

--- a/node/pkg/chain/helper/signer.go
+++ b/node/pkg/chain/helper/signer.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"math/big"
 	"os"
 	"strings"
@@ -15,8 +14,6 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/rs/zerolog/log"
 )
-
-const maxTxSubmissionRetries = 3
 
 type SignerConfig struct {
 	pk             string
@@ -44,6 +41,29 @@ func WithRenewThreshold(renewThreshold time.Duration) SignerOption {
 	}
 }
 
+// whitelist status of a candidate key, as observed on-chain.
+type wlStatus int
+
+const (
+	wlUnknown     wlStatus = iota // on-chain read failed (transient RPC error)
+	wlWhitelisted                 // expirationTime > now
+	wlNot                         // expirationTime <= now (deactivated or never set)
+)
+
+// signerCandidate is a private key the node holds and could sign with. id is nil for a key
+// that lives only in the legacy `signer` row and has not yet been copied into signer_key.
+type signerCandidate struct {
+	id     *int64
+	addr   common.Address
+	pkHex  string // decrypted, 0x-trimmed
+	state  string // signer_key.state, or "legacy"
+	exp    time.Time
+	status wlStatus
+}
+
+// getSignerPk returns a bootstrap private key (0x-trimmed) from, in order: an operator-supplied
+// key, the legacy `signer` row, or the Vault SIGNER_PK secret. It is used ONLY to seed an empty
+// keyring; it does not decide which key signs (the on-chain whitelist does — see reconcile).
 func getSignerPk(ctx context.Context, config SignerConfig) (string, error) {
 	if config.pk != "" {
 		return strings.TrimPrefix(config.pk, "0x"), nil
@@ -53,19 +73,15 @@ func getSignerPk(ctx context.Context, config SignerConfig) (string, error) {
 	if err != nil {
 		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to load signer from pgs")
 	}
-
-	if pk == "" {
-		pk = secrets.GetSecret(SignerPk)
-		if pk == "" {
-			log.Error().Str("Player", "Signer").Msg("signer pk not set")
-			return "", errorSentinel.ErrChainSignerPKNotFound
-		}
-		err = utils.StoreSignerPk(ctx, pk)
-		if err != nil {
-			log.Warn().Str("Player", "Signer").Err(err).Msg("failed to store pk")
-		}
+	if pk != "" {
+		return strings.TrimPrefix(pk, "0x"), nil
 	}
 
+	pk = secrets.GetSecret(SignerPk)
+	if pk == "" {
+		log.Error().Str("Player", "Signer").Msg("signer pk not set")
+		return "", errorSentinel.ErrChainSignerPKNotFound
+	}
 	return strings.TrimPrefix(pk, "0x"), nil
 }
 
@@ -78,165 +94,552 @@ func NewSigner(ctx context.Context, opts ...SignerOption) (*Signer, error) {
 		opt(&config)
 	}
 
-	pk, err := getSignerPk(ctx, config)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to get signer pk")
-		return nil, err
-	}
-
-	privateKey, err := utils.StringToPk(pk)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to convert pk")
-		return nil, err
-	}
-
-	chainHelper, err := NewChainHelper(
-		ctx,
-		WithReporterPk(pk))
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set chainHelper for signHelper")
-		return nil, err
-	}
-
 	submissionProxyContractAddr := os.Getenv("SUBMISSION_PROXY_CONTRACT")
 	if submissionProxyContractAddr == "" {
 		log.Error().Str("Player", "Signer").Msg("SUBMISSION_PROXY_CONTRACT not found, signer initialization failed")
 		return nil, errorSentinel.ErrChainSubmissionProxyContractNotFound
 	}
 
-	signHelper := &Signer{
-		PK: privateKey,
-
-		chainHelper:                 chainHelper,
-		submissionProxyContractAddr: submissionProxyContractAddr,
-		renewInterval:               config.renewInterval,
-		renewThreshold:              config.renewThreshold,
+	// Explicit static-key mode: an operator-supplied key (WithSignerPk) is used directly, with no
+	// keyring, no rotation and no on-chain whitelist gate. Production (the aggregator) never sets
+	// WithSignerPk and always uses the managed reconcile path below; this branch is for explicit
+	// overrides and tests, and preserves their pre-fix behavior.
+	if config.pk != "" {
+		return newStaticSigner(ctx, config, submissionProxyContractAddr)
 	}
 
-	go signHelper.autoRenew(ctx)
+	// Seed the keyring from a bootstrap key if it is empty (fresh node). Existing nodes already
+	// have the legacy key migrated into signer_key by migration 000027.
+	initialPkHex, err := ensureKeyring(ctx, config)
+	if err != nil {
+		return nil, err
+	}
 
-	return signHelper, nil
+	initialPK, err := utils.StringToPk(initialPkHex)
+	if err != nil {
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to convert pk")
+		return nil, err
+	}
+
+	chainHelper, err := NewChainHelper(ctx, WithReporterPk(initialPkHex))
+	if err != nil {
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set chainHelper for signHelper")
+		return nil, err
+	}
+
+	livenessInterval := DefaultSignerLivenessInterval
+	if raw := os.Getenv("SIGNER_LIVENESS_INTERVAL"); raw != "" {
+		if d, perr := time.ParseDuration(raw); perr == nil {
+			livenessInterval = d
+		}
+	}
+	skewMargin := DefaultSignerSkewMargin
+	if raw := os.Getenv("SIGNER_SKEW_MARGIN"); raw != "" {
+		if d, perr := time.ParseDuration(raw); perr == nil {
+			skewMargin = d
+		}
+	}
+
+	s := &Signer{
+		PK:                          initialPK,
+		chainHelper:                 chainHelper,
+		submissionProxyContractAddr: submissionProxyContractAddr,
+		activeAddr:                  crypto.PubkeyToAddress(initialPK.PublicKey),
+		usable:                      false, // remains false until reconcile confirms a whitelisted key
+		bootstrapPk:                 config.pk,
+		renewThreshold:              config.renewThreshold,
+		livenessInterval:            livenessInterval,
+		skewMargin:                  skewMargin,
+		// If the active key cannot be positively re-confirmed whitelisted within this window
+		// (e.g. sustained RPC failures while the oracle was removed out-of-band), the sign gate
+		// refuses — bounding any stale-signing window instead of trusting a far-future cache.
+		confirmationTTL: 3 * livenessInterval,
+	}
+
+	// Establish the truth (which held key is on-chain-whitelisted) BEFORE we start signing or
+	// ticking. Skip rotation on this initial pass (allowRotate=false) so a due renewal cannot
+	// block startup for up to the ~60s on-chain verify budget; the liveness loop rotates. A
+	// branch-b outcome (no whitelisted key yet) is not fatal — the node stays up, refuses to
+	// sign, and self-heals on the liveness loop.
+	if rErr := s.reconcile(ctx, false); rErr != nil {
+		log.Error().Str("Player", "Signer").Err(rErr).Msg("initial signer reconcile failed; starting anyway, will retry")
+	}
+
+	go s.reconcileLoop(ctx)
+
+	return s, nil
 }
 
+// ensureKeyring guarantees at least one key exists in signer_key and returns a key (0x-trimmed)
+// suitable for building the initial read/write chainHelper. reconcile then picks the real active key.
+func ensureKeyring(ctx context.Context, config SignerConfig) (string, error) {
+	keys, err := utils.LoadSignerKeys(ctx)
+	if err != nil {
+		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to load signer keys during init")
+	}
+	if len(keys) > 0 {
+		for _, k := range keys {
+			if k.State == "active" {
+				return k.PK, nil
+			}
+		}
+		return keys[0].PK, nil
+	}
+
+	// Empty keyring: seed from a bootstrap key.
+	pk, err := getSignerPk(ctx, config)
+	if err != nil {
+		return "", err
+	}
+	addrHex, err := utils.StringPkToAddressHex(pk)
+	if err != nil {
+		return "", err
+	}
+	id, err := utils.InsertPendingKey(ctx, addrHex, pk)
+	if err != nil {
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to seed signer keyring")
+		return "", err
+	}
+	if err := utils.PromotePendingToActive(ctx, id, pk); err != nil {
+		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to activate seeded signer key")
+	}
+	return pk, nil
+}
+
+// newStaticSigner builds a Signer that signs with a fixed operator-supplied key, bypassing the
+// keyring, rotation and on-chain gate. Used only when WithSignerPk is set (explicit override / tests).
+func newStaticSigner(ctx context.Context, config SignerConfig, submissionProxyContractAddr string) (*Signer, error) {
+	pkHex := strings.TrimPrefix(config.pk, "0x")
+	pk, err := utils.StringToPk(pkHex)
+	if err != nil {
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to convert pk")
+		return nil, err
+	}
+	chainHelper, err := NewChainHelper(ctx, WithReporterPk(pkHex))
+	if err != nil {
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set chainHelper for static signer")
+		return nil, err
+	}
+	return &Signer{
+		PK:                          pk,
+		chainHelper:                 chainHelper,
+		submissionProxyContractAddr: submissionProxyContractAddr,
+		activeAddr:                  crypto.PubkeyToAddress(pk.PublicKey),
+		usable:                      true,
+		staticMode:                  true,                          // no reconcile/rotation/confirmation gate
+		cachedExpiration:            time.Now().AddDate(100, 0, 0), // static key: effectively never expires
+		lastConfirmedAt:             time.Now().AddDate(100, 0, 0),
+		renewThreshold:              config.renewThreshold,
+		skewMargin:                  DefaultSignerSkewMargin,
+	}, nil
+}
+
+// MakeGlobalAggregateProof signs a global aggregate. It is the authoritative fail-loud gate:
+// it refuses (returns an error, so no proof is published) whenever the node is not certain it
+// holds a currently-whitelisted key — never silently signing with a stale/deactivated key.
 func (s *Signer) MakeGlobalAggregateProof(val int64, timestamp time.Time, name string) ([]byte, error) {
 	s.mu.RLock()
-	pk := s.PK
+	usable, rotating, static, exp, confirmedAt, pk := s.usable, s.rotating, s.staticMode, s.cachedExpiration, s.lastConfirmedAt, s.PK
 	s.mu.RUnlock()
+
+	now := time.Now()
+	staleConfirmation := !static && s.confirmationTTL > 0 && now.Sub(confirmedAt) > s.confirmationTTL
+	if !usable || rotating || pk == nil || now.Add(s.skewMargin).After(exp) || staleConfirmation {
+		return nil, errorSentinel.ErrChainSignerNoWhitelistedKey
+	}
 	return utils.MakeValueSignature(val, timestamp.UnixMilli(), name, pk)
 }
 
-func (s *Signer) autoRenew(ctx context.Context) {
-	autoRenewTicker := time.NewTicker(s.renewInterval)
-	err := s.CheckAndUpdateSignerPK(ctx)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to renew signer pk")
-	}
+func (s *Signer) reconcileLoop(ctx context.Context) {
+	ticker := time.NewTicker(s.livenessInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-autoRenewTicker.C:
-			err = s.CheckAndUpdateSignerPK(ctx)
-			if err != nil {
-				log.Error().Str("Player", "Signer").Err(err).Msg("failed to renew signer pk")
+		case <-ticker.C:
+			if err := s.reconcile(ctx, true); err != nil {
+				log.Warn().Str("Player", "Signer").Err(err).Msg("liveness reconcile error")
 			}
 		}
 	}
 }
 
+// CheckAndUpdateSignerPK is the public entry point (bus RENEW_SIGNER / admin). It simply drives
+// a reconcile, which both self-heals the active key and rotates when near expiry.
 func (s *Signer) CheckAndUpdateSignerPK(ctx context.Context) error {
-	if s.expirationDate == nil || s.expirationDate.IsZero() {
-		_, err := s.LoadExpiration(ctx)
-		if err != nil {
-			log.Error().Str("Player", "Signer").Err(err).Msg("failed to load expiration date")
-			return err
+	return s.reconcile(ctx, true)
+}
+
+func (s *Signer) reconcile(ctx context.Context, allowRotate bool) error {
+	if s.staticMode {
+		return nil
+	}
+	if !s.rotateMu.TryLock() {
+		// a reconcile/rotation is already in progress; skip (avoids pile-up and cross-trigger races)
+		return nil
+	}
+	defer s.rotateMu.Unlock()
+	return s.reconcileLocked(ctx, allowRotate)
+}
+
+func (s *Signer) reconcileLocked(ctx context.Context, allowRotate bool) error {
+	cands, err := s.loadCandidates(ctx)
+	if err != nil {
+		// Transient DB error: keep current signing state; the sign gate + cachedExpiration still protect us.
+		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to load signer candidates; keeping current state")
+		return err
+	}
+	if len(cands) == 0 {
+		// Should not happen after NewSigner seeds the keyring; treat as loud, non-fatal.
+		s.setUnusable("no signer keys held")
+		return errorSentinel.ErrChainSignerNoWhitelistedKey
+	}
+
+	// Classify every held key against the on-chain whitelist.
+	anyUnknown := false
+	var whitelisted []*signerCandidate
+	for _, c := range cands {
+		exp, rErr := s.readExpiration(ctx, c.addr)
+		if rErr != nil {
+			c.status = wlUnknown
+			anyUnknown = true
+			continue
+		}
+		c.exp = exp
+		if exp.After(time.Now()) {
+			c.status = wlWhitelisted
+			whitelisted = append(whitelisted, c)
+		} else {
+			c.status = wlNot
 		}
 	}
 
-	if !s.IsRenewalRequired() {
+	if len(whitelisted) > 0 {
+		chosen := pickChosen(whitelisted)
+		if err := s.ensureActive(ctx, chosen); err != nil {
+			log.Error().Str("Player", "Signer").Err(err).Msg("failed to adopt whitelisted key")
+			return err
+		}
+		// Renew only FROM a currently-whitelisted key, and only when near expiry. Rotation is
+		// skipped on the startup pass (allowRotate=false) so it never blocks boot.
+		if allowRotate && s.renewalRequired(chosen.exp) {
+			reuse := pickReusablePending(cands, chosen.addr)
+			if rErr := s.rotateLocked(ctx, chosen, reuse); rErr != nil {
+				log.Warn().Str("Player", "Signer").Err(rErr).Msg("rotation attempt did not complete; will retry")
+			}
+		}
 		return nil
 	}
 
-	newPK, newPkHex, err := utils.NewPk(ctx)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to generate new pk")
-		return err
+	// No held key is whitelisted. Determine the ACTIVE key's own on-chain status specifically —
+	// a positively-deactivated active key must stop signing immediately even if some OTHER
+	// candidate's read failed (otherwise a single transient read error would mask a real removal).
+	s.mu.RLock()
+	activeAddr := s.activeAddr
+	s.mu.RUnlock()
+	activeStatus := wlUnknown
+	for _, c := range cands {
+		if c.addr == activeAddr {
+			activeStatus = c.status
+			break
+		}
 	}
 
-	return s.Renew(ctx, newPK, newPkHex)
+	if activeStatus == wlUnknown && anyUnknown {
+		// Could not positively confirm the active key (transient RPC failure). Keep current state,
+		// but the sign gate's confirmationTTL bounds how long the node will sign without a fresh
+		// on-chain confirmation, so a sustained outage still fails loud rather than signing forever.
+		log.Warn().Str("Player", "Signer").Msg("whitelist reads inconclusive; keeping current signer state (bounded by confirmationTTL)")
+		return nil
+	}
+
+	// The active key is positively not whitelisted (or every held key definitively isn't):
+	// refuse to sign, keep all keys durably, and alarm loudly.
+	addrs := make([]string, 0, len(cands))
+	for _, c := range cands {
+		addrs = append(addrs, c.addr.Hex())
+	}
+	s.setUnusable("no held signer key is whitelisted on-chain")
+	log.Error().Str("Player", "Signer").Strs("heldKeys", addrs).Str("activeSigner", activeAddr.Hex()).
+		Msg("no held signer key is whitelisted on-chain — refusing to sign until owner re-whitelists a held key")
+	return nil
 }
 
-func (s *Signer) LoadExpiration(ctx context.Context) (*time.Time, error) {
-	publicKey := s.PK.Public()
-	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
-	if !ok {
-		log.Error().Str("Player", "Signer").Err(errorSentinel.ErrChainPubKeyToECDSAFail).Msg("failed to convert pk")
-		return nil, errorSentinel.ErrChainPubKeyToECDSAFail
-	}
-	addr := crypto.PubkeyToAddress(*publicKeyECDSA)
-
-	readResult, err := s.chainHelper.ReadContract(ctx, s.submissionProxyContractAddr, SignerDetailFuncSignature, addr)
+// loadCandidates returns all held keys: the signer_key keyring plus the legacy `signer` row (so
+// the new binary can discover and adopt a key an old binary rotated in). Backfills NULL addresses.
+func (s *Signer) loadCandidates(ctx context.Context) ([]*signerCandidate, error) {
+	keys, err := utils.LoadSignerKeys(ctx)
 	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to read contract")
 		return nil, err
 	}
 
-	values, ok := readResult.([]interface{})
-	if !ok {
-		log.Error().Str("Player", "Signer").Err(errorSentinel.ErrChainFailedToParseContractResult).Msg("failed to parse contract result")
-		return nil, errorSentinel.ErrChainFailedToParseContractResult
+	cands := make([]*signerCandidate, 0, len(keys)+1)
+	seen := map[common.Address]bool{}
+	for i := range keys {
+		k := keys[i]
+		var addr common.Address
+		if k.Address != nil && *k.Address != "" {
+			addr = common.HexToAddress(*k.Address)
+		} else {
+			ah, e := utils.StringPkToAddressHex(k.PK)
+			if e != nil {
+				log.Warn().Str("Player", "Signer").Err(e).Int64("id", k.ID).Msg("skipping undecodable keyring key")
+				continue
+			}
+			addr = common.HexToAddress(ah)
+			if bErr := utils.BackfillKeyAddress(ctx, k.ID, addr.Hex()); bErr != nil {
+				log.Warn().Str("Player", "Signer").Err(bErr).Msg("failed to backfill signer_key address")
+			}
+		}
+		if seen[addr] {
+			continue
+		}
+		seen[addr] = true
+		id := k.ID
+		cands = append(cands, &signerCandidate{id: &id, addr: addr, pkHex: k.PK, state: k.State})
 	}
 
-	rawTimestamp, ok := values[1].(*big.Int)
-	if !ok {
-		log.Error().Str("Player", "Signer").Err(errorSentinel.ErrChainFailedToParseContractResult).Msg("failed to parse result to bigInt")
-		return nil, errorSentinel.ErrChainFailedToParseContractResult
+	if legacyPk, lErr := utils.LoadSignerPk(ctx); lErr == nil && legacyPk != "" {
+		if ah, e := utils.StringPkToAddressHex(legacyPk); e == nil {
+			addr := common.HexToAddress(ah)
+			if !seen[addr] {
+				cands = append(cands, &signerCandidate{addr: addr, pkHex: strings.TrimPrefix(legacyPk, "0x"), state: "legacy"})
+			}
+		}
 	}
 
-	expirationDate := time.Unix(int64(rawTimestamp.Int64()), 0)
-	s.expirationDate = &expirationDate
-	return s.expirationDate, nil
+	return cands, nil
 }
 
-func (s *Signer) IsRenewalRequired() bool {
-	return time.Until(*s.expirationDate) < s.renewThreshold
+// pickChosen prefers an already-active row (avoids churn), otherwise any whitelisted candidate.
+func pickChosen(whitelisted []*signerCandidate) *signerCandidate {
+	for _, c := range whitelisted {
+		if c.state == "active" {
+			return c
+		}
+	}
+	return whitelisted[0]
 }
 
-func (s *Signer) Renew(ctx context.Context, newPK *ecdsa.PrivateKey, newPkHex string) error {
-	newPublicAddr, err := utils.StringPkToAddressHex(newPkHex)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to convert pk")
-		return err
+// pickReusablePending finds a pending key that has never been an on-chain oracle (expiration == 0)
+// so an interrupted rotation is resumed instead of accumulating pending rows / minting a new key.
+func pickReusablePending(cands []*signerCandidate, exclude common.Address) *signerCandidate {
+	for _, c := range cands {
+		if c.state == "pending" && c.status == wlNot && c.exp.Unix() == 0 && c.addr != exclude && c.id != nil {
+			return c
+		}
 	}
-	addr := common.HexToAddress(newPublicAddr)
+	return nil
+}
 
-	err = s.signerUpdate(ctx, addr)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to update signer")
+// ensureActive makes the chosen (whitelisted) candidate the durable active key and adopts it in
+// memory. Idempotent: if it is already the active in-memory key it only refreshes the cached
+// expiration.
+func (s *Signer) ensureActive(ctx context.Context, chosen *signerCandidate) error {
+	s.mu.RLock()
+	alreadyActive := s.usable && !s.rotating && s.activeAddr == chosen.addr
+	s.mu.RUnlock()
+	if alreadyActive {
+		s.mu.Lock()
+		s.cachedExpiration = chosen.exp
+		s.lastConfirmedAt = time.Now() // active key freshly re-confirmed whitelisted on-chain
+		s.mu.Unlock()
+		return nil
+	}
+
+	// Persist the chosen key as the single active row (copying a legacy-only key into the keyring first).
+	id := chosen.id
+	if id == nil {
+		newID, err := utils.InsertPendingKey(ctx, chosen.addr.Hex(), chosen.pkHex)
+		if err != nil {
+			return err
+		}
+		id = &newID
+	}
+	if err := utils.PromotePendingToActive(ctx, *id, chosen.pkHex); err != nil {
+		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to promote chosen key in DB")
+	}
+
+	if err := s.adopt(ctx, chosen.pkHex, chosen.addr, chosen.exp); err != nil {
 		return err
 	}
-	log.Debug().Str("Player", "Signer").Msg("signer renewed from the contract")
+	log.Info().Str("Player", "Signer").Str("activeSigner", chosen.addr.Hex()).
+		Msg("adopted on-chain-whitelisted signer key")
+	return nil
+}
+
+// adopt swaps the in-memory signing key and its tx chainHelper to the given key and marks the
+// signer usable. Caller must hold rotateMu.
+func (s *Signer) adopt(ctx context.Context, pkHex string, addr common.Address, exp time.Time) error {
+	pk, err := utils.StringToPk(pkHex)
+	if err != nil {
+		return err
+	}
+	newCH, err := NewChainHelper(ctx, WithReporterPk(pkHex))
+	if err != nil {
+		return err
+	}
 
 	s.mu.Lock()
-	s.PK = newPK
+	old := s.chainHelper
+	s.PK = pk
+	s.activeAddr = addr
+	s.cachedExpiration = exp
+	s.lastConfirmedAt = time.Now() // adopting a key we just confirmed whitelisted on-chain
+	s.usable = true
+	s.rotating = false
+	s.chainHelper = newCH
 	s.mu.Unlock()
 
-	s.chainHelper.Close()
-	newChainHelper, err := NewChainHelper(
-		ctx,
-		WithReporterPk(newPkHex))
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to create new chain helper")
-		return err
+	if old != nil && old != newCH {
+		old.Close()
 	}
-	s.chainHelper = newChainHelper
+	return nil
+}
 
-	_, err = s.LoadExpiration(ctx)
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to load expiration date")
-		return err
+func (s *Signer) setUnusable(reason string) {
+	s.mu.Lock()
+	s.usable = false
+	s.rotating = false
+	s.mu.Unlock()
+	_ = reason
+}
+
+func (s *Signer) renewalRequired(exp time.Time) bool {
+	return time.Until(exp) < s.renewThreshold
+}
+
+// rotateLocked rotates the signer key. Caller holds rotateMu and `from` is currently whitelisted.
+// Ordering is crash-safe: the new key is durably persisted BEFORE the on-chain updateOracle, the
+// signer refuses to sign for the in-flight window (bias to no-proof over stale-key), success is
+// judged by on-chain state (not the RPC ack), and the in-memory swap happens before the DB promote.
+func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse *signerCandidate) error {
+	var newHex string
+	var newAddr common.Address
+	var id int64
+
+	if reuse != nil {
+		newHex, newAddr, id = reuse.pkHex, reuse.addr, *reuse.id
+	} else {
+		_, freshHex, err := utils.NewPk(ctx)
+		if err != nil {
+			return err
+		}
+		addrHex, err := utils.StringPkToAddressHex(freshHex)
+		if err != nil {
+			return err
+		}
+		newHex = strings.TrimPrefix(freshHex, "0x")
+		newAddr = common.HexToAddress(addrHex)
+		// PERSIST-FIRST: the new key is durable before any chain call, so it can never be lost.
+		newID, err := utils.InsertPendingKey(ctx, newAddr.Hex(), newHex)
+		if err != nil {
+			return err
+		}
+		id = newID
 	}
-	return utils.StoreSignerPk(ctx, newPkHex)
+
+	// Stop signing for the in-flight window: updateOracle deactivates `from` the moment it mines,
+	// so from here we must not sign with `from`.
+	s.mu.Lock()
+	s.rotating = true
+	s.mu.Unlock()
+
+	// updateOracle(newAddr) is submitted with `from`'s (whitelisted) key. The RPC ack is UNTRUSTED
+	// (WaitMined routinely errors on txs that actually mined — the original incident).
+	if err := s.signerUpdate(ctx, newAddr); err != nil {
+		log.Warn().Str("Player", "Signer").Err(err).Msg("updateOracle ack error (ignored; verifying by chain state)")
+	}
+
+	// Confirm by reading chain state, not by trusting the ack.
+	var newExp time.Time
+	landed := false
+	for i := 0; i < signerVerifyPollMax; i++ {
+		exp, rErr := s.readExpiration(ctx, newAddr)
+		if rErr == nil && exp.After(time.Now()) {
+			newExp = exp
+			landed = true
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(signerVerifyPollInterval):
+		}
+	}
+
+	if landed {
+		// Adopt the new key in memory FIRST (source of on-chain truth), then persist to DB.
+		if err := s.adopt(ctx, newHex, newAddr, newExp); err != nil {
+			// Clear rotating so the node isn't stuck refusing forever; the next liveness reconcile
+			// re-adopts the now-whitelisted new key (adopt is the only place rotating is cleared).
+			s.mu.Lock()
+			s.rotating = false
+			s.mu.Unlock()
+			return err
+		}
+		if err := utils.PromotePendingToActive(ctx, id, newHex); err != nil {
+			log.Warn().Str("Player", "Signer").Err(err).Msg("failed to promote rotated key in DB; will reconcile")
+		}
+		_ = utils.GCRetiredKeys(ctx)
+		log.Info().Str("Player", "Signer").Str("newSigner", newAddr.Hex()).Msg("signer key rotated")
+		return nil
+	}
+
+	// Not observed on-chain within budget: NEVER delete the pending key (it may still mine). Resume
+	// signing with the old key if it is still whitelisted, else refuse until the next reconcile.
+	fromExp, rErr := s.readExpiration(ctx, from.addr)
+	s.mu.Lock()
+	s.rotating = false
+	if rErr == nil && fromExp.After(time.Now()) {
+		s.usable = true
+		s.cachedExpiration = fromExp
+	} else {
+		s.usable = false
+	}
+	s.mu.Unlock()
+	return errorSentinel.ErrChainTransactionFail
+}
+
+func (s *Signer) readExpiration(ctx context.Context, addr common.Address) (time.Time, error) {
+	s.mu.RLock()
+	ch := s.chainHelper
+	s.mu.RUnlock()
+
+	readResult, err := ch.ReadContract(ctx, s.submissionProxyContractAddr, SignerDetailFuncSignature, addr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	values, ok := readResult.([]interface{})
+	if !ok || len(values) < 2 {
+		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
+	}
+	rawTimestamp, ok := values[1].(*big.Int)
+	if !ok {
+		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
+	}
+	return time.Unix(rawTimestamp.Int64(), 0), nil
+}
+
+// SignerStatus is the in-memory truth reported by the admin endpoint (not a DB read), so the
+// endpoint can never disagree with the key that is actually signing (the 2026-07-25 symptom).
+type SignerStatus struct {
+	ActiveSigner string `json:"signer"`
+	Usable       bool   `json:"usable"`
+	Rotating     bool   `json:"rotating"`
+	ExpiresAt    int64  `json:"expiresAt"`
+}
+
+func (s *Signer) Status() SignerStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return SignerStatus{
+		ActiveSigner: s.activeAddr.Hex(),
+		Usable:       s.usable,
+		Rotating:     s.rotating,
+		ExpiresAt:    s.cachedExpiration.Unix(),
+	}
 }
 
 func (s *Signer) signerUpdate(ctx context.Context, newAddr common.Address) error {

--- a/node/pkg/chain/helper/signer.go
+++ b/node/pkg/chain/helper/signer.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-	"math/big"
 	"os"
 	"strings"
 	"time"
@@ -105,7 +104,7 @@ func NewSigner(ctx context.Context, opts ...SignerOption) (*Signer, error) {
 	// WithSignerPk and always uses the managed reconcile path below; this branch is for explicit
 	// overrides and tests, and preserves their pre-fix behavior.
 	if config.pk != "" {
-		return newStaticSigner(ctx, config, submissionProxyContractAddr)
+		return newStaticSigner(config)
 	}
 
 	// Seed the keyring from a bootstrap key if it is empty (fresh node). Existing nodes already
@@ -121,9 +120,9 @@ func NewSigner(ctx context.Context, opts ...SignerOption) (*Signer, error) {
 		return nil, err
 	}
 
-	chainHelper, err := NewChainHelper(ctx, WithReporterPk(initialPkHex))
+	chain, err := newRealOracleChain(ctx, submissionProxyContractAddr, initialPkHex)
 	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set chainHelper for signHelper")
+		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set up on-chain oracle client")
 		return nil, err
 	}
 
@@ -141,19 +140,21 @@ func NewSigner(ctx context.Context, opts ...SignerOption) (*Signer, error) {
 	}
 
 	s := &Signer{
-		PK:                          initialPK,
-		chainHelper:                 chainHelper,
-		submissionProxyContractAddr: submissionProxyContractAddr,
-		activeAddr:                  crypto.PubkeyToAddress(initialPK.PublicKey),
-		usable:                      false, // remains false until reconcile confirms a whitelisted key
-		bootstrapPk:                 config.pk,
-		renewThreshold:              config.renewThreshold,
-		livenessInterval:            livenessInterval,
-		skewMargin:                  skewMargin,
+		PK:               initialPK,
+		chain:            chain,
+		store:            realSignerStore{},
+		activeAddr:       crypto.PubkeyToAddress(initialPK.PublicKey),
+		usable:           false, // remains false until reconcile confirms a whitelisted key
+		bootstrapPk:      config.pk,
+		renewThreshold:   config.renewThreshold,
+		livenessInterval: livenessInterval,
+		skewMargin:       skewMargin,
 		// If the active key cannot be positively re-confirmed whitelisted within this window
 		// (e.g. sustained RPC failures while the oracle was removed out-of-band), the sign gate
 		// refuses — bounding any stale-signing window instead of trusting a far-future cache.
-		confirmationTTL: 3 * livenessInterval,
+		confirmationTTL:    3 * livenessInterval,
+		verifyPollInterval: signerVerifyPollInterval,
+		verifyPollMax:      signerVerifyPollMax,
 	}
 
 	// Establish the truth (which held key is on-chain-whitelisted) BEFORE we start signing or
@@ -207,30 +208,25 @@ func ensureKeyring(ctx context.Context, config SignerConfig) (string, error) {
 }
 
 // newStaticSigner builds a Signer that signs with a fixed operator-supplied key, bypassing the
-// keyring, rotation and on-chain gate. Used only when WithSignerPk is set (explicit override / tests).
-func newStaticSigner(ctx context.Context, config SignerConfig, submissionProxyContractAddr string) (*Signer, error) {
+// keyring, rotation and on-chain gate. Used only when WithSignerPk is set (explicit override /
+// tests). It does no chain or DB I/O — signing uses PK directly — so chain/store stay nil and
+// reconcile is a no-op (guarded by staticMode).
+func newStaticSigner(config SignerConfig) (*Signer, error) {
 	pkHex := strings.TrimPrefix(config.pk, "0x")
 	pk, err := utils.StringToPk(pkHex)
 	if err != nil {
 		log.Error().Str("Player", "Signer").Err(err).Msg("failed to convert pk")
 		return nil, err
 	}
-	chainHelper, err := NewChainHelper(ctx, WithReporterPk(pkHex))
-	if err != nil {
-		log.Error().Str("Player", "Signer").Err(err).Msg("failed to set chainHelper for static signer")
-		return nil, err
-	}
 	return &Signer{
-		PK:                          pk,
-		chainHelper:                 chainHelper,
-		submissionProxyContractAddr: submissionProxyContractAddr,
-		activeAddr:                  crypto.PubkeyToAddress(pk.PublicKey),
-		usable:                      true,
-		staticMode:                  true,                          // no reconcile/rotation/confirmation gate
-		cachedExpiration:            time.Now().AddDate(100, 0, 0), // static key: effectively never expires
-		lastConfirmedAt:             time.Now().AddDate(100, 0, 0),
-		renewThreshold:              config.renewThreshold,
-		skewMargin:                  DefaultSignerSkewMargin,
+		PK:               pk,
+		activeAddr:       crypto.PubkeyToAddress(pk.PublicKey),
+		usable:           true,
+		staticMode:       true,                          // no reconcile/rotation/confirmation gate
+		cachedExpiration: time.Now().AddDate(100, 0, 0), // static key: effectively never expires
+		lastConfirmedAt:  time.Now().AddDate(100, 0, 0),
+		renewThreshold:   config.renewThreshold,
+		skewMargin:       DefaultSignerSkewMargin,
 	}, nil
 }
 
@@ -300,7 +296,7 @@ func (s *Signer) reconcileLocked(ctx context.Context, allowRotate bool) error {
 	anyUnknown := false
 	var whitelisted []*signerCandidate
 	for _, c := range cands {
-		exp, rErr := s.readExpiration(ctx, c.addr)
+		exp, rErr := s.chain.ReadExpiration(ctx, c.addr)
 		if rErr != nil {
 			c.status = wlUnknown
 			anyUnknown = true
@@ -369,7 +365,7 @@ func (s *Signer) reconcileLocked(ctx context.Context, allowRotate bool) error {
 // loadCandidates returns all held keys: the signer_key keyring plus the legacy `signer` row (so
 // the new binary can discover and adopt a key an old binary rotated in). Backfills NULL addresses.
 func (s *Signer) loadCandidates(ctx context.Context) ([]*signerCandidate, error) {
-	keys, err := utils.LoadSignerKeys(ctx)
+	keys, err := s.store.LoadKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +384,7 @@ func (s *Signer) loadCandidates(ctx context.Context) ([]*signerCandidate, error)
 				continue
 			}
 			addr = common.HexToAddress(ah)
-			if bErr := utils.BackfillKeyAddress(ctx, k.ID, addr.Hex()); bErr != nil {
+			if bErr := s.store.BackfillAddress(ctx, k.ID, addr.Hex()); bErr != nil {
 				log.Warn().Str("Player", "Signer").Err(bErr).Msg("failed to backfill signer_key address")
 			}
 		}
@@ -400,7 +396,7 @@ func (s *Signer) loadCandidates(ctx context.Context) ([]*signerCandidate, error)
 		cands = append(cands, &signerCandidate{id: &id, addr: addr, pkHex: k.PK, state: k.State})
 	}
 
-	if legacyPk, lErr := utils.LoadSignerPk(ctx); lErr == nil && legacyPk != "" {
+	if legacyPk, lErr := s.store.LoadLegacyPk(ctx); lErr == nil && legacyPk != "" {
 		if ah, e := utils.StringPkToAddressHex(legacyPk); e == nil {
 			addr := common.HexToAddress(ah)
 			if !seen[addr] {
@@ -451,17 +447,17 @@ func (s *Signer) ensureActive(ctx context.Context, chosen *signerCandidate) erro
 	// Persist the chosen key as the single active row (copying a legacy-only key into the keyring first).
 	id := chosen.id
 	if id == nil {
-		newID, err := utils.InsertPendingKey(ctx, chosen.addr.Hex(), chosen.pkHex)
+		newID, err := s.store.InsertPending(ctx, chosen.addr.Hex(), chosen.pkHex)
 		if err != nil {
 			return err
 		}
 		id = &newID
 	}
-	if err := utils.PromotePendingToActive(ctx, *id, chosen.pkHex); err != nil {
+	if err := s.store.Promote(ctx, *id, chosen.pkHex); err != nil {
 		log.Warn().Str("Player", "Signer").Err(err).Msg("failed to promote chosen key in DB")
 	}
 
-	if err := s.adopt(ctx, chosen.pkHex, chosen.addr, chosen.exp); err != nil {
+	if err := s.adopt(chosen.pkHex, chosen.addr, chosen.exp); err != nil {
 		return err
 	}
 	log.Info().Str("Player", "Signer").Str("activeSigner", chosen.addr.Hex()).
@@ -469,32 +465,24 @@ func (s *Signer) ensureActive(ctx context.Context, chosen *signerCandidate) erro
 	return nil
 }
 
-// adopt swaps the in-memory signing key and its tx chainHelper to the given key and marks the
-// signer usable. Caller must hold rotateMu.
-func (s *Signer) adopt(ctx context.Context, pkHex string, addr common.Address, exp time.Time) error {
+// adopt swaps the in-memory signing key to the given (confirmed-whitelisted) key and marks the
+// signer usable. On-chain writes go through s.chain (which signs with the key passed per call),
+// so adopt does no chain I/O. Caller must hold rotateMu.
+func (s *Signer) adopt(pkHex string, addr common.Address, exp time.Time) error {
 	pk, err := utils.StringToPk(pkHex)
-	if err != nil {
-		return err
-	}
-	newCH, err := NewChainHelper(ctx, WithReporterPk(pkHex))
 	if err != nil {
 		return err
 	}
 
 	s.mu.Lock()
-	old := s.chainHelper
 	s.PK = pk
 	s.activeAddr = addr
 	s.cachedExpiration = exp
 	s.lastConfirmedAt = time.Now() // adopting a key we just confirmed whitelisted on-chain
 	s.usable = true
 	s.rotating = false
-	s.chainHelper = newCH
 	s.mu.Unlock()
 
-	if old != nil && old != newCH {
-		old.Close()
-	}
 	return nil
 }
 
@@ -533,7 +521,7 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 		newHex = strings.TrimPrefix(freshHex, "0x")
 		newAddr = common.HexToAddress(addrHex)
 		// PERSIST-FIRST: the new key is durable before any chain call, so it can never be lost.
-		newID, err := utils.InsertPendingKey(ctx, newAddr.Hex(), newHex)
+		newID, err := s.store.InsertPending(ctx, newAddr.Hex(), newHex)
 		if err != nil {
 			return err
 		}
@@ -548,15 +536,15 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 
 	// updateOracle(newAddr) is submitted with `from`'s (whitelisted) key. The RPC ack is UNTRUSTED
 	// (WaitMined routinely errors on txs that actually mined — the original incident).
-	if err := s.signerUpdate(ctx, newAddr); err != nil {
+	if err := s.chain.UpdateOracle(ctx, from.pkHex, newAddr); err != nil {
 		log.Warn().Str("Player", "Signer").Err(err).Msg("updateOracle ack error (ignored; verifying by chain state)")
 	}
 
 	// Confirm by reading chain state, not by trusting the ack.
 	var newExp time.Time
 	landed := false
-	for i := 0; i < signerVerifyPollMax; i++ {
-		exp, rErr := s.readExpiration(ctx, newAddr)
+	for i := 0; i < s.verifyPollMax; i++ {
+		exp, rErr := s.chain.ReadExpiration(ctx, newAddr)
 		if rErr == nil && exp.After(time.Now()) {
 			newExp = exp
 			landed = true
@@ -565,13 +553,13 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(signerVerifyPollInterval):
+		case <-time.After(s.verifyPollInterval):
 		}
 	}
 
 	if landed {
 		// Adopt the new key in memory FIRST (source of on-chain truth), then persist to DB.
-		if err := s.adopt(ctx, newHex, newAddr, newExp); err != nil {
+		if err := s.adopt(newHex, newAddr, newExp); err != nil {
 			// Clear rotating so the node isn't stuck refusing forever; the next liveness reconcile
 			// re-adopts the now-whitelisted new key (adopt is the only place rotating is cleared).
 			s.mu.Lock()
@@ -579,17 +567,17 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 			s.mu.Unlock()
 			return err
 		}
-		if err := utils.PromotePendingToActive(ctx, id, newHex); err != nil {
+		if err := s.store.Promote(ctx, id, newHex); err != nil {
 			log.Warn().Str("Player", "Signer").Err(err).Msg("failed to promote rotated key in DB; will reconcile")
 		}
-		_ = utils.GCRetiredKeys(ctx)
+		_ = s.store.GCRetired(ctx)
 		log.Info().Str("Player", "Signer").Str("newSigner", newAddr.Hex()).Msg("signer key rotated")
 		return nil
 	}
 
 	// Not observed on-chain within budget: NEVER delete the pending key (it may still mine). Resume
 	// signing with the old key if it is still whitelisted, else refuse until the next reconcile.
-	fromExp, rErr := s.readExpiration(ctx, from.addr)
+	fromExp, rErr := s.chain.ReadExpiration(ctx, from.addr)
 	s.mu.Lock()
 	s.rotating = false
 	if rErr == nil && fromExp.After(time.Now()) {
@@ -600,26 +588,6 @@ func (s *Signer) rotateLocked(ctx context.Context, from *signerCandidate, reuse 
 	}
 	s.mu.Unlock()
 	return errorSentinel.ErrChainTransactionFail
-}
-
-func (s *Signer) readExpiration(ctx context.Context, addr common.Address) (time.Time, error) {
-	s.mu.RLock()
-	ch := s.chainHelper
-	s.mu.RUnlock()
-
-	readResult, err := ch.ReadContract(ctx, s.submissionProxyContractAddr, SignerDetailFuncSignature, addr)
-	if err != nil {
-		return time.Time{}, err
-	}
-	values, ok := readResult.([]interface{})
-	if !ok || len(values) < 2 {
-		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
-	}
-	rawTimestamp, ok := values[1].(*big.Int)
-	if !ok {
-		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
-	}
-	return time.Unix(rawTimestamp.Int64(), 0), nil
 }
 
 // SignerStatus is the in-memory truth reported by the admin endpoint (not a DB read), so the
@@ -640,8 +608,4 @@ func (s *Signer) Status() SignerStatus {
 		Rotating:     s.rotating,
 		ExpiresAt:    s.cachedExpiration.Unix(),
 	}
-}
-
-func (s *Signer) signerUpdate(ctx context.Context, newAddr common.Address) error {
-	return s.chainHelper.SubmitDelegatedFallbackDirect(ctx, s.submissionProxyContractAddr, UpdateSignerFuncSignature, newAddr)
 }

--- a/node/pkg/chain/helper/signer_deps.go
+++ b/node/pkg/chain/helper/signer_deps.go
@@ -1,0 +1,94 @@
+package helper
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"bisonai.com/miko/node/pkg/chain/utils"
+	errorSentinel "bisonai.com/miko/node/pkg/error"
+	"github.com/kaiachain/kaia/common"
+)
+
+// oracleChain and signerStore are the two external dependencies of the reconcile/rotate logic.
+// They are injected into Signer so the crash-safety scenarios (issue #2516) can be exercised
+// deterministically in unit tests with in-memory fakes, while production uses the real impls.
+
+type oracleChain interface {
+	// ReadExpiration returns the on-chain whitelist expirationTime for addr (zero time if never
+	// whitelisted). Errors are treated as "unknown" by the caller — never as "not whitelisted".
+	ReadExpiration(ctx context.Context, addr common.Address) (time.Time, error)
+	// UpdateOracle submits updateOracle(newAddr) signed by signWithPkHex (the current oracle key).
+	UpdateOracle(ctx context.Context, signWithPkHex string, newAddr common.Address) error
+}
+
+type signerStore interface {
+	LoadKeys(ctx context.Context) ([]utils.SignerKey, error)
+	LoadLegacyPk(ctx context.Context) (string, error)
+	InsertPending(ctx context.Context, address, pkHex string) (int64, error)
+	BackfillAddress(ctx context.Context, id int64, address string) error
+	Promote(ctx context.Context, id int64, pkHex string) error
+	GCRetired(ctx context.Context) error
+}
+
+// realOracleChain talks to the on-chain SubmissionProxy. Reads reuse one keyless-enough helper;
+// writes build a fresh helper signed by the caller-supplied key (rare, so per-call is fine).
+type realOracleChain struct {
+	contractAddr string
+	readHelper   *ChainHelper
+}
+
+func newRealOracleChain(ctx context.Context, contractAddr, readPkHex string) (*realOracleChain, error) {
+	readHelper, err := NewChainHelper(ctx, WithReporterPk(readPkHex))
+	if err != nil {
+		return nil, err
+	}
+	return &realOracleChain{contractAddr: contractAddr, readHelper: readHelper}, nil
+}
+
+func (c *realOracleChain) ReadExpiration(ctx context.Context, addr common.Address) (time.Time, error) {
+	readResult, err := c.readHelper.ReadContract(ctx, c.contractAddr, SignerDetailFuncSignature, addr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	values, ok := readResult.([]interface{})
+	if !ok || len(values) < 2 {
+		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
+	}
+	rawTimestamp, ok := values[1].(*big.Int)
+	if !ok {
+		return time.Time{}, errorSentinel.ErrChainFailedToParseContractResult
+	}
+	return time.Unix(rawTimestamp.Int64(), 0), nil
+}
+
+func (c *realOracleChain) UpdateOracle(ctx context.Context, signWithPkHex string, newAddr common.Address) error {
+	ch, err := NewChainHelper(ctx, WithReporterPk(signWithPkHex))
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+	return ch.SubmitDelegatedFallbackDirect(ctx, c.contractAddr, UpdateSignerFuncSignature, newAddr)
+}
+
+// realSignerStore wraps the package-level DB helpers.
+type realSignerStore struct{}
+
+func (realSignerStore) LoadKeys(ctx context.Context) ([]utils.SignerKey, error) {
+	return utils.LoadSignerKeys(ctx)
+}
+func (realSignerStore) LoadLegacyPk(ctx context.Context) (string, error) {
+	return utils.LoadSignerPk(ctx)
+}
+func (realSignerStore) InsertPending(ctx context.Context, address, pkHex string) (int64, error) {
+	return utils.InsertPendingKey(ctx, address, pkHex)
+}
+func (realSignerStore) BackfillAddress(ctx context.Context, id int64, address string) error {
+	return utils.BackfillKeyAddress(ctx, id, address)
+}
+func (realSignerStore) Promote(ctx context.Context, id int64, pkHex string) error {
+	return utils.PromotePendingToActive(ctx, id, pkHex)
+}
+func (realSignerStore) GCRetired(ctx context.Context) error {
+	return utils.GCRetiredKeys(ctx)
+}

--- a/node/pkg/chain/helper/signer_scenario_test.go
+++ b/node/pkg/chain/helper/signer_scenario_test.go
@@ -1,0 +1,516 @@
+package helper
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"bisonai.com/miko/node/pkg/chain/utils"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+)
+
+// These tests exercise the reconcile/rotate crash-safety scenarios (issue #2516) deterministically
+// with in-memory fakes for the on-chain oracle and the key store, so every failure interleaving
+// (mined-but-RPC-errored, not-landed, DB-promote-failed, out-of-band removal, ...) is covered
+// without a live chain or Postgres.
+
+// ---- fakes -----------------------------------------------------------------
+
+type fakeChain struct {
+	mu           sync.Mutex
+	exp          map[common.Address]time.Time
+	readErr      error
+	updateOracle func(f *fakeChain, from string, newAddr common.Address) error
+	updateCalls  int
+}
+
+func newFakeChain() *fakeChain { return &fakeChain{exp: map[common.Address]time.Time{}} }
+
+func (f *fakeChain) ReadExpiration(_ context.Context, addr common.Address) (time.Time, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.readErr != nil {
+		return time.Time{}, f.readErr
+	}
+	if v, ok := f.exp[addr]; ok {
+		return v, nil
+	}
+	return time.Unix(0, 0), nil // never whitelisted == on-chain expirationTime 0 (matches the real contract)
+}
+
+func (f *fakeChain) UpdateOracle(_ context.Context, from string, newAddr common.Address) error {
+	f.mu.Lock()
+	f.updateCalls++
+	fn := f.updateOracle
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(f, from, newAddr)
+	}
+	f.setWhitelisted(newAddr) // default: mines successfully
+	return nil
+}
+
+func (f *fakeChain) setWhitelisted(addr common.Address) {
+	f.mu.Lock()
+	f.exp[addr] = time.Now().Add(100 * 24 * time.Hour)
+	f.mu.Unlock()
+}
+func (f *fakeChain) setExp(addr common.Address, d time.Duration) {
+	f.mu.Lock()
+	f.exp[addr] = time.Now().Add(d)
+	f.mu.Unlock()
+}
+func (f *fakeChain) setDeactivated(addr common.Address) {
+	f.mu.Lock()
+	f.exp[addr] = time.Now().Add(-time.Hour)
+	f.mu.Unlock()
+}
+
+type fakeStore struct {
+	mu         sync.Mutex
+	keys       []utils.SignerKey
+	legacy     string
+	nextID     int64
+	promoteErr error
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{} }
+
+func (s *fakeStore) addKey(pkHex string, addr common.Address, state string) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	a := strings.ToLower(addr.Hex())
+	s.keys = append(s.keys, utils.SignerKey{ID: s.nextID, Address: &a, PK: strings.TrimPrefix(pkHex, "0x"), State: state})
+	return s.nextID
+}
+
+func (s *fakeStore) LoadKeys(_ context.Context) ([]utils.SignerKey, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]utils.SignerKey, len(s.keys))
+	copy(out, s.keys)
+	return out, nil
+}
+func (s *fakeStore) LoadLegacyPk(_ context.Context) (string, error) { return s.legacy, nil }
+func (s *fakeStore) InsertPending(_ context.Context, address, pkHex string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	a := strings.ToLower(address)
+	s.keys = append(s.keys, utils.SignerKey{ID: s.nextID, Address: &a, PK: strings.TrimPrefix(pkHex, "0x"), State: "pending"})
+	return s.nextID, nil
+}
+func (s *fakeStore) BackfillAddress(_ context.Context, id int64, address string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.keys {
+		if s.keys[i].ID == id {
+			a := strings.ToLower(address)
+			s.keys[i].Address = &a
+		}
+	}
+	return nil
+}
+func (s *fakeStore) Promote(_ context.Context, id int64, pkHex string) error {
+	if s.promoteErr != nil {
+		return s.promoteErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.keys {
+		if s.keys[i].State == "active" && s.keys[i].ID != id {
+			s.keys[i].State = "retired"
+		}
+	}
+	for i := range s.keys {
+		if s.keys[i].ID == id {
+			s.keys[i].State = "active"
+		}
+	}
+	s.legacy = strings.TrimPrefix(pkHex, "0x")
+	return nil
+}
+func (s *fakeStore) GCRetired(_ context.Context) error { return nil }
+
+func (s *fakeStore) count() int { s.mu.Lock(); defer s.mu.Unlock(); return len(s.keys) }
+func (s *fakeStore) findState(state string) *utils.SignerKey {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.keys {
+		if s.keys[i].State == state {
+			k := s.keys[i]
+			return &k
+		}
+	}
+	return nil
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+func genKey(t *testing.T) (string, common.Address, *ecdsa.PrivateKey) {
+	t.Helper()
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("genKey: %v", err)
+	}
+	return hex.EncodeToString(crypto.FromECDSA(pk)), crypto.PubkeyToAddress(pk.PublicKey), pk
+}
+
+func newScenarioSigner(chain oracleChain, store signerStore) *Signer {
+	return &Signer{
+		chain:              chain,
+		store:              store,
+		renewThreshold:     7 * 24 * time.Hour,
+		livenessInterval:   30 * time.Second,
+		skewMargin:         90 * time.Second,
+		confirmationTTL:    90 * time.Second,
+		verifyPollInterval: time.Millisecond,
+		verifyPollMax:      3,
+	}
+}
+
+func addrOf(pk *ecdsa.PrivateKey) common.Address { return crypto.PubkeyToAddress(pk.PublicKey) }
+
+// ---- scenarios -------------------------------------------------------------
+
+// S6 — the actual incident: DB + chain moved to newKey, but the running process still holds the
+// old key. reconcile must hot-swap to the whitelisted held key with NO restart.
+func TestScenario_IncidentSelfHeal(t *testing.T) {
+	ctx := context.Background()
+	oldHex, oldAddr, oldPK := genKey(t)
+	newHex, newAddr, _ := genKey(t)
+
+	store := newFakeStore()
+	store.addKey(newHex, newAddr, "active")
+	store.addKey(oldHex, oldAddr, "retired")
+	store.legacy = newHex
+
+	chain := newFakeChain()
+	chain.setWhitelisted(newAddr)
+	chain.setDeactivated(oldAddr)
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = oldPK, oldAddr, true, time.Now().Add(time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.activeAddr != newAddr || addrOf(s.PK) != newAddr {
+		t.Fatalf("expected hot-swap to new key %s, got %s", newAddr.Hex(), s.activeAddr.Hex())
+	}
+	if !s.usable {
+		t.Fatal("expected usable after adopting whitelisted key")
+	}
+}
+
+// S10 — no held key whitelisted: refuse (fail loud), keep keys.
+func TestScenario_NoneWhitelistedRefuses(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain() // aAddr absent => not whitelisted
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.usable {
+		t.Fatal("expected usable=false (refuse) when no held key is whitelisted")
+	}
+	if store.count() != 1 {
+		t.Fatal("must not delete keys when refusing")
+	}
+}
+
+// S8 (fix) — active key positively deactivated while ANOTHER candidate's read fails: must still
+// refuse immediately (a transient read error on some other key must not mask a real removal).
+func TestScenario_ActiveDeactivatedOtherUnknownRefuses(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	bHex, bAddr, _ := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	store.addKey(bHex, bAddr, "pending")
+
+	chain := newFakeChain()
+	chain.setDeactivated(aAddr) // active positively NOT whitelisted
+	// Make ONLY b's read fail by returning a global read error after seeding a is not possible with
+	// one flag; instead model: a deactivated (present, past), b unknown via a per-addr miss is "not
+	// whitelisted", so to get UNKNOWN we use readErr only for the classification of b. Simpler: use a
+	// chain that errors for b but not a.
+	chain.readErr = nil
+	// emulate b unknown: a custom chain wrapper
+	uc := &perAddrErrChain{fakeChain: chain, errAddr: bAddr, err: errors.New("rpc timeout")}
+
+	s := newScenarioSigner(uc, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.usable {
+		t.Fatal("expected refuse: active key positively deactivated even though another read failed")
+	}
+}
+
+// perAddrErrChain returns an error only for errAddr, delegating everything else to fakeChain.
+type perAddrErrChain struct {
+	*fakeChain
+	errAddr common.Address
+	err     error
+}
+
+func (c *perAddrErrChain) ReadExpiration(ctx context.Context, addr common.Address) (time.Time, error) {
+	if addr == c.errAddr {
+		return time.Time{}, c.err
+	}
+	return c.fakeChain.ReadExpiration(ctx, addr)
+}
+
+// S8 (transient) — the active key's own read fails (RPC blip): keep state, do not flip usable
+// (the sign gate's confirmationTTL bounds the stale window separately).
+func TestScenario_ActiveUnknownKeepsState(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain()
+	chain.readErr = errors.New("rpc down")
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !s.usable {
+		t.Fatal("expected usable to be retained on a transient read failure")
+	}
+}
+
+// S11 — multi-oracle network: node adopts ITS whitelisted key and ignores peers' oracle entries.
+func TestScenario_MultiOracleAdoptsOwnKey(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	_, peerAddr, _ := genKey(t) // a peer oracle we do not hold
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain()
+	chain.setWhitelisted(aAddr)
+	chain.setWhitelisted(peerAddr) // peer also whitelisted; must be irrelevant
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(100*24*time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !s.usable || s.activeAddr != aAddr {
+		t.Fatal("expected to keep own whitelisted key in a multi-oracle set")
+	}
+}
+
+// Rotation happy path: active key near expiry -> rotate to a fresh key, confirmed on-chain.
+func TestScenario_RotateHappyPath(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	store.legacy = aHex
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour) // whitelisted but within the 7d renew threshold
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.activeAddr == aAddr {
+		t.Fatal("expected rotation to a new key")
+	}
+	if !s.usable {
+		t.Fatal("expected usable after rotation")
+	}
+	if exp, _ := chain.ReadExpiration(ctx, s.activeAddr); !exp.After(time.Now()) {
+		t.Fatal("new active key must be whitelisted on-chain")
+	}
+}
+
+// S2 — updateOracle mines but the RPC returns an error: rotation must still succeed by reading
+// chain state (the exact root cause of the incident).
+func TestScenario_RotateMinedButAckError(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour)
+	chain.updateOracle = func(f *fakeChain, _ string, newAddr common.Address) error {
+		f.setWhitelisted(newAddr)              // it MINED
+		return errors.New("http2 GOAWAY")      // but the ack errored
+	}
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.activeAddr == aAddr || !s.usable {
+		t.Fatal("expected rotation to succeed via chain-state confirmation despite ack error")
+	}
+}
+
+// Not-landed: updateOracle never mines and the old key is still valid -> resume signing with the
+// old key, and NEVER delete the persisted pending key (S1 key-loss guard).
+func TestScenario_RotateNotLandedResumesOldAndKeepsPending(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour)
+	chain.updateOracle = func(_ *fakeChain, _ string, _ common.Address) error {
+		return errors.New("not mined") // does NOT set exp
+	}
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+
+	_ = s.reconcile(ctx, true)
+	if s.activeAddr != aAddr || !s.usable {
+		t.Fatal("expected to resume signing with the still-whitelisted old key")
+	}
+	if store.findState("pending") == nil {
+		t.Fatal("persist-first: the new pending key must be retained, never deleted")
+	}
+}
+
+// S1 — broadcast then the tx is not observed (crash / RPC blackout), then it mines late: the
+// persisted pending key must be adopted on a later reconcile; the key is never lost.
+func TestScenario_PersistFirstAdoptsLateMinedKey(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour)
+	chain.updateOracle = func(_ *fakeChain, _ string, _ common.Address) error { return errors.New("blackout") }
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+	_ = s.reconcile(ctx, true)
+
+	pending := store.findState("pending")
+	if pending == nil {
+		t.Fatal("pending key lost")
+	}
+	pendingAddr := common.HexToAddress(*pending.Address)
+
+	// The broadcast tx mines late; the old key is now deactivated on-chain.
+	chain.setWhitelisted(pendingAddr)
+	chain.setDeactivated(aAddr)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if s.activeAddr != pendingAddr || !s.usable {
+		t.Fatal("expected to adopt the late-mined key that was persisted before broadcast")
+	}
+}
+
+// S3/S9 — the rotation lands on-chain but the DB promote fails: the node must adopt the confirmed
+// new key in memory anyway (adopt-before-promote) and keep signing.
+func TestScenario_RotateAdoptsEvenIfPromoteFails(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	store.promoteErr = errors.New("db blip")
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour) // near expiry -> triggers rotation
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+
+	_ = s.reconcile(ctx, true)
+	if s.activeAddr == aAddr || !s.usable {
+		t.Fatal("expected in-memory adoption of the confirmed new key even when DB promote fails")
+	}
+}
+
+// Concurrency: many concurrent signs racing repeated reconciles must be data-race-free (run with
+// -race). Exercises the mu (sign-path fields) vs rotateMu (reconcile) locking discipline.
+func TestScenario_ConcurrentSignAndReconcile(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	store.legacy = aHex
+	chain := newFakeChain()
+	chain.setWhitelisted(aAddr) // far-future; no rotation
+
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(100*24*time.Hour)
+	s.lastConfirmedAt = time.Now()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_, _ = s.MakeGlobalAggregateProof(1, time.Now(), "BTC-USDT")
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = s.reconcile(ctx, true)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// S12 — an interrupted rotation left a never-mined pending key: the next rotation must RESUME it
+// (reuse), not mint yet another key (no unbounded pending growth / wedge).
+func TestScenario_RotateResumesExistingPending(t *testing.T) {
+	ctx := context.Background()
+	aHex, aAddr, aPK := genKey(t)
+	bHex, bAddr, _ := genKey(t)
+	store := newFakeStore()
+	store.addKey(aHex, aAddr, "active")
+	store.addKey(bHex, bAddr, "pending") // leftover pending from an interrupted rotation
+	chain := newFakeChain()
+	chain.setExp(aAddr, 3*24*time.Hour) // near expiry -> rotate
+	// bAddr absent from chain.exp => not whitelisted, exp==0 => reusable
+
+	before := store.count()
+	s := newScenarioSigner(chain, store)
+	s.PK, s.activeAddr, s.usable, s.cachedExpiration = aPK, aAddr, true, time.Now().Add(3*24*time.Hour)
+
+	if err := s.reconcile(ctx, true); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if store.count() != before {
+		t.Fatalf("expected to reuse the existing pending key, but a new one was minted (%d -> %d)", before, store.count())
+	}
+	if s.activeAddr != bAddr || !s.usable {
+		t.Fatal("expected to adopt the resumed pending key after it mined")
+	}
+}

--- a/node/pkg/chain/helper/signer_test.go
+++ b/node/pkg/chain/helper/signer_test.go
@@ -1,0 +1,139 @@
+package helper
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	errorSentinel "bisonai.com/miko/node/pkg/error"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+)
+
+// The sign gate is the linchpin safety property (issue #2516): the node must refuse to sign
+// (branch b) whenever it is not certain it holds a currently-whitelisted key, and must never
+// silently sign with a stale/deactivated key.
+
+func newGateSigner(t *testing.T) *Signer {
+	t.Helper()
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	return &Signer{PK: pk, skewMargin: DefaultSignerSkewMargin}
+}
+
+func TestSignGateRefusals(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name             string
+		usable           bool
+		rotating         bool
+		cachedExpiration time.Time
+		nilPK            bool
+	}{
+		{"not usable", false, false, now.Add(time.Hour), false},
+		{"rotating", true, true, now.Add(time.Hour), false},
+		{"expired", true, false, now.Add(-time.Second), false},
+		{"within skew margin", true, false, now.Add(10 * time.Second), false},
+		{"nil pk", true, false, now.Add(time.Hour), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newGateSigner(t)
+			s.usable = tc.usable
+			s.rotating = tc.rotating
+			s.cachedExpiration = tc.cachedExpiration
+			if tc.nilPK {
+				s.PK = nil
+			}
+			proof, err := s.MakeGlobalAggregateProof(1, now, "BTC-USDT")
+			if err == nil {
+				t.Fatalf("expected refusal, got proof %x", proof)
+			}
+			if !errors.Is(err, errorSentinel.ErrChainSignerNoWhitelistedKey) {
+				t.Fatalf("expected ErrChainSignerNoWhitelistedKey, got %v", err)
+			}
+			if proof != nil {
+				t.Fatalf("expected no proof on refusal, got %x", proof)
+			}
+		})
+	}
+}
+
+func TestSignGateSignsWhenUsableAndValid(t *testing.T) {
+	s := newGateSigner(t)
+	s.usable = true
+	s.cachedExpiration = time.Now().Add(24 * time.Hour)
+
+	proof, err := s.MakeGlobalAggregateProof(200000000, time.Now(), "test-aggregate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(proof) != 65 {
+		t.Fatalf("expected a 65-byte ECDSA proof, got %d bytes", len(proof))
+	}
+}
+
+func TestPickChosenPrefersActive(t *testing.T) {
+	pending := &signerCandidate{addr: common.HexToAddress("0x1"), state: "pending"}
+	active := &signerCandidate{addr: common.HexToAddress("0x2"), state: "active"}
+	if got := pickChosen([]*signerCandidate{pending, active}); got != active {
+		t.Fatal("expected the active-state candidate to be preferred")
+	}
+	if got := pickChosen([]*signerCandidate{pending}); got != pending {
+		t.Fatal("expected the only candidate to be chosen when none is active")
+	}
+}
+
+func TestPickReusablePending(t *testing.T) {
+	id := int64(5)
+	exclude := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+
+	// Reusable: pending, not whitelisted, never-an-oracle (exp unix 0), different addr, has id.
+	reusable := &signerCandidate{id: &id, addr: common.HexToAddress("0x00000000000000000000000000000000000000bb"), state: "pending", status: wlNot, exp: time.Unix(0, 0)}
+	// Not reusable: expired but was previously an oracle (nonzero exp) -> updateOracle would revert.
+	wasOracle := &signerCandidate{id: &id, addr: common.HexToAddress("0x00000000000000000000000000000000000000cc"), state: "pending", status: wlNot, exp: time.Now().Add(-time.Hour)}
+	// Not reusable: it is the active address we are rotating from.
+	isActive := &signerCandidate{id: &id, addr: exclude, state: "pending", status: wlNot, exp: time.Unix(0, 0)}
+	// Not reusable: no id (legacy-only) cannot be promoted by id.
+	noID := &signerCandidate{addr: common.HexToAddress("0x00000000000000000000000000000000000000dd"), state: "pending", status: wlNot, exp: time.Unix(0, 0)}
+
+	if got := pickReusablePending([]*signerCandidate{wasOracle, reusable}, exclude); got != reusable {
+		t.Fatal("expected the never-mined pending key to be reusable")
+	}
+	if got := pickReusablePending([]*signerCandidate{wasOracle, isActive, noID}, exclude); got != nil {
+		t.Fatal("expected no reusable pending among ineligible candidates")
+	}
+}
+
+func TestRenewalRequired(t *testing.T) {
+	s := &Signer{renewThreshold: 7 * 24 * time.Hour}
+	if !s.renewalRequired(time.Now().Add(time.Hour)) {
+		t.Fatal("expected renewal required when expiry is within the threshold")
+	}
+	if s.renewalRequired(time.Now().Add(30 * 24 * time.Hour)) {
+		t.Fatal("expected no renewal when expiry is far beyond the threshold")
+	}
+}
+
+func TestStatusReportsInMemoryState(t *testing.T) {
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(pk.PublicKey)
+	exp := time.Now().Add(time.Hour)
+	s := &Signer{PK: pk, activeAddr: addr, usable: true, cachedExpiration: exp}
+
+	st := s.Status()
+	if st.ActiveSigner != addr.Hex() {
+		t.Fatalf("expected active signer %s, got %s", addr.Hex(), st.ActiveSigner)
+	}
+	if !st.Usable {
+		t.Fatal("expected usable=true")
+	}
+	if st.ExpiresAt != exp.Unix() {
+		t.Fatalf("expected expiresAt %d, got %d", exp.Unix(), st.ExpiresAt)
+	}
+}

--- a/node/pkg/chain/helper/types.go
+++ b/node/pkg/chain/helper/types.go
@@ -52,9 +52,9 @@ func WithBlockchainType(t BlockchainType) ChainHelperOption {
 // on-chain SubmissionProxy oracle whitelist. The on-chain whitelist — never local state — is
 // the authority on which key may sign; see reconcile/rotate in signer.go (issue #2516).
 type Signer struct {
-	PK                          *ecdsa.PrivateKey
-	chainHelper                 *ChainHelper
-	submissionProxyContractAddr string
+	PK    *ecdsa.PrivateKey
+	chain oracleChain // on-chain oracle reads/writes (injectable for tests)
+	store signerStore // durable keyring (injectable for tests)
 
 	// mu guards the fast sign-path fields below.
 	mu               sync.RWMutex
@@ -66,12 +66,14 @@ type Signer struct {
 
 	rotateMu sync.Mutex // serializes reconcile+rotate within this process (TryLock)
 
-	staticMode       bool // WithSignerPk: fixed key, no reconcile/rotation/confirmation gate
-	bootstrapPk      string
-	renewThreshold   time.Duration
-	livenessInterval time.Duration
-	skewMargin       time.Duration
-	confirmationTTL  time.Duration // refuse to sign if activeAddr has not been confirmed whitelisted within this window
+	staticMode         bool // WithSignerPk: fixed key, no reconcile/rotation/confirmation gate
+	bootstrapPk        string
+	renewThreshold     time.Duration
+	livenessInterval   time.Duration
+	skewMargin         time.Duration
+	confirmationTTL    time.Duration // refuse to sign if activeAddr has not been confirmed whitelisted within this window
+	verifyPollInterval time.Duration // rotation on-chain confirmation poll cadence
+	verifyPollMax      int           // rotation on-chain confirmation poll attempts
 }
 
 type signedTx struct {

--- a/node/pkg/chain/helper/types.go
+++ b/node/pkg/chain/helper/types.go
@@ -10,6 +10,7 @@ import (
 	"bisonai.com/miko/node/pkg/chain/noncemanagerv2"
 	"bisonai.com/miko/node/pkg/chain/utils"
 	"github.com/kaiachain/kaia/client"
+	"github.com/kaiachain/kaia/common"
 )
 
 type ChainHelper struct {
@@ -47,14 +48,30 @@ func WithBlockchainType(t BlockchainType) ChainHelperOption {
 	}
 }
 
+// Signer owns the node's global-aggregate signing key and keeps it reconciled with the
+// on-chain SubmissionProxy oracle whitelist. The on-chain whitelist — never local state — is
+// the authority on which key may sign; see reconcile/rotate in signer.go (issue #2516).
 type Signer struct {
 	PK                          *ecdsa.PrivateKey
 	chainHelper                 *ChainHelper
 	submissionProxyContractAddr string
-	expirationDate              *time.Time
-	renewInterval               time.Duration
-	renewThreshold              time.Duration
-	mu                          sync.RWMutex
+
+	// mu guards the fast sign-path fields below.
+	mu               sync.RWMutex
+	activeAddr       common.Address // address of PK
+	cachedExpiration time.Time      // on-chain expirationTime of activeAddr (authoritative sign-gate input)
+	lastConfirmedAt  time.Time      // last time activeAddr was positively confirmed whitelisted on-chain
+	usable           bool           // false => refuse to sign (fail loud) instead of signing with a stale key
+	rotating         bool           // true while a rotation is in flight => refuse to sign
+
+	rotateMu sync.Mutex // serializes reconcile+rotate within this process (TryLock)
+
+	staticMode       bool // WithSignerPk: fixed key, no reconcile/rotation/confirmation gate
+	bootstrapPk      string
+	renewThreshold   time.Duration
+	livenessInterval time.Duration
+	skewMargin       time.Duration
+	confirmationTTL  time.Duration // refuse to sign if activeAddr has not been confirmed whitelisted within this window
 }
 
 type signedTx struct {
@@ -92,4 +109,11 @@ const (
 	DefaultSignerRenewThreshold = 7 * 24 * time.Hour
 	SignerDetailFuncSignature   = "whitelist(address) returns ((uint256, uint256))"
 	UpdateSignerFuncSignature   = "updateOracle(address) returns (uint256)"
+	GetAllOraclesFuncSignature  = "getAllOracles() public view returns (address[] memory)"
+
+	// Crash-safe rotation / reconciliation tunables (issue #2516).
+	DefaultSignerLivenessInterval = 30 * time.Second // how often the active key's on-chain status is re-checked
+	DefaultSignerSkewMargin       = 90 * time.Second // refuse to sign this long before the cached expiration
+	signerVerifyPollInterval      = 3 * time.Second  // poll cadence when confirming a rotation on-chain
+	signerVerifyPollMax           = 20               // ~60s budget to observe the updateOracle result
 )

--- a/node/pkg/chain/tests/chain_test.go
+++ b/node/pkg/chain/tests/chain_test.go
@@ -3,8 +3,6 @@ package tests
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
-	"fmt"
 	"math/big"
 	"os"
 	"strings"
@@ -481,7 +479,9 @@ func TestMakeAbiFuncAttribute(t *testing.T) {
 
 func TestMakeGlobalAggregateProof(t *testing.T) {
 	ctx := context.Background()
-	s, err := helper.NewSigner(ctx)
+	// Static mode (WithSignerPk): this test verifies proof FORMAT, independent of on-chain
+	// whitelist state, so use the fixed SIGNER_PK directly (the managed gate is covered elsewhere).
+	s, err := helper.NewSigner(ctx, helper.WithSignerPk(os.Getenv("SIGNER_PK")))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -563,7 +563,8 @@ func TestMakeMultiGlobalAggregateProof(t *testing.T) {
 
 func TestGlobalAggregateProofMergeAndSplit(t *testing.T) {
 	ctx := context.Background()
-	s, err := helper.NewSigner(ctx)
+	// Static mode: verifies proof merge/split format independent of on-chain whitelist state.
+	s, err := helper.NewSigner(ctx, helper.WithSignerPk(os.Getenv("SIGNER_PK")))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -685,81 +686,30 @@ func TestSignerTableSingleEntry(t *testing.T) {
 	}
 }
 
+// TestSignerRenew exercises the managed (reconcile-driven) signer. Rotation is now internal and
+// crash-safe (issue #2516): the node reconciles against the on-chain whitelist and adopts the
+// currently-whitelisted key. This integration test only runs against a real SubmissionProxy on
+// which the seeded/configured signer key is whitelisted.
 func TestSignerRenew(t *testing.T) {
 	ctx := context.Background()
 
-	contractAddr := os.Getenv("SUBMISSION_PROXY_CONTRACT")
-	if contractAddr == "" {
+	if os.Getenv("SUBMISSION_PROXY_CONTRACT") == "" {
 		t.Skip("Skipping test because SUBMISSION_PROXY_CONTRACT is not set")
 	}
 
 	s, err := helper.NewSigner(ctx)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expiration, err := s.LoadExpiration(ctx)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	// After reconcile the node must have adopted an on-chain-whitelisted key and be usable.
+	status := s.Status()
+	assert.NotEmpty(t, status.ActiveSigner)
+	assert.True(t, status.Usable, "expected the seeded signer key to be whitelisted on-chain")
+	assert.Greater(t, status.ExpiresAt, time.Now().Unix())
 
-	assert.False(t, expiration.IsZero())
-	fmt.Println(expiration)
-
-	renewalRequired := s.IsRenewalRequired()
-	assert.False(t, renewalRequired)
-
-	oldPK := s.PK
-	oldPKBytes := crypto.FromECDSA(oldPK)
-	oldPKHex := hex.EncodeToString(oldPKBytes)
-	oldSignerAddr, err := utils.StringPkToAddressHex(oldPKHex)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	newPK, newPKHex, err := utils.NewPk(ctx)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	newSignerAddr, err := utils.StringPkToAddressHex(newPKHex)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	err = s.Renew(ctx, newPK, newPKHex)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	newExpiration, err := s.LoadExpiration(ctx)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	assert.False(t, newExpiration.IsZero())
-	assert.Greater(t, newExpiration.Unix(), expiration.Unix())
-
-	//cleanup
-	chainHelperForCleanup, err := helper.NewChainHelper(ctx, helper.WithReporterPk(oldPKHex))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	addOracleFunctionSignature := "addOracle(address _oracle) external returns (uint256)"
-	removeOracleFunctionSignature := "function removeOracle(address _oracle) external"
-
-	err = chainHelperForCleanup.SubmitDelegatedFallbackDirect(ctx, contractAddr, addOracleFunctionSignature, common.HexToAddress(oldSignerAddr))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	err = chainHelperForCleanup.SubmitDelegatedFallbackDirect(ctx, contractAddr, removeOracleFunctionSignature, common.HexToAddress(newSignerAddr))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	err = db.QueryWithoutResult(ctx, "DELETE FROM signer;", nil)
-	if err != nil {
+	// CheckAndUpdateSignerPK drives reconcile+rotate; it must be safe and idempotent to call.
+	if err := s.CheckAndUpdateSignerPK(ctx); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/node/pkg/chain/tests/chain_test.go
+++ b/node/pkg/chain/tests/chain_test.go
@@ -483,7 +483,7 @@ func TestMakeGlobalAggregateProof(t *testing.T) {
 	// whitelist state, so use the fixed SIGNER_PK directly (the managed gate is covered elsewhere).
 	s, err := helper.NewSigner(ctx, helper.WithSignerPk(os.Getenv("SIGNER_PK")))
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	timestamp := time.Now()
@@ -566,7 +566,7 @@ func TestGlobalAggregateProofMergeAndSplit(t *testing.T) {
 	// Static mode: verifies proof merge/split format independent of on-chain whitelist state.
 	s, err := helper.NewSigner(ctx, helper.WithSignerPk(os.Getenv("SIGNER_PK")))
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	timestamp := time.Now()

--- a/node/pkg/chain/utils/types.go
+++ b/node/pkg/chain/utils/types.go
@@ -16,11 +16,34 @@ const (
 	SELECT_PROVIDER_URLS_QUERY = "SELECT * FROM provider_urls WHERE chain_id = @chain_id ORDER BY priority;"
 	LOAD_SIGNER                = "SELECT id, pk FROM signer LIMIT 1;"
 	STORE_SIGNER               = "INSERT INTO signer (pk, unique_dummy) VALUES (@pk, TRUE) ON CONFLICT (unique_dummy) DO UPDATE SET pk = EXCLUDED.pk;"
+
+	// signer_key keyring (issue #2516). The keyring durably holds every private key the
+	// node may still need (the confirmed active key + any in-flight pending + retired
+	// history) so a key that is / becomes the on-chain oracle is never lost across a crash.
+	LOAD_SIGNER_KEYS   = "SELECT id, address, pk, state, tx_hash, created_at, updated_at FROM signer_key ORDER BY created_at;"
+	INSERT_PENDING_KEY = "INSERT INTO signer_key (address, pk, state) VALUES (@address, @pk, 'pending') RETURNING id;"
+	BACKFILL_ADDRESS   = "UPDATE signer_key SET address = @address, updated_at = now() WHERE id = @id AND address IS NULL;"
+	SET_KEY_TXHASH     = "UPDATE signer_key SET tx_hash = @tx_hash, updated_at = now() WHERE id = @id;"
+	// PromotePendingToActive runs RETIRE_ACTIVE then ACTIVATE_KEY in one transaction, so the
+	// signer_key_one_active partial unique index is never transiently violated.
+	RETIRE_ACTIVE = "UPDATE signer_key SET state = 'retired', updated_at = now() WHERE state = 'active' AND id <> @id;"
+	ACTIVATE_KEY  = "UPDATE signer_key SET state = 'active', updated_at = now() WHERE id = @id;"
+	GC_RETIRED    = "DELETE FROM signer_key WHERE state = 'retired' AND updated_at < now() - interval '90 days';"
 )
 
 type Wallet struct {
 	ID int64  `db:"id"`
 	PK string `db:"pk"`
+}
+
+type SignerKey struct {
+	ID        int64      `db:"id"`
+	Address   *string    `db:"address"`
+	PK        string     `db:"pk"` // encrypted at rest
+	State     string     `db:"state"`
+	TxHash    *string    `db:"tx_hash"`
+	CreatedAt time.Time  `db:"created_at"`
+	UpdatedAt time.Time  `db:"updated_at"`
 }
 
 type ProviderUrl struct {

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -14,6 +14,7 @@ import (
 	"bisonai.com/miko/node/pkg/db"
 	errorSentinel "bisonai.com/miko/node/pkg/error"
 	"bisonai.com/miko/node/pkg/utils/encryptor"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
@@ -665,6 +666,103 @@ func StoreSignerPk(ctx context.Context, pk string) error {
 		return err
 	}
 	return db.QueryWithoutResult(ctx, STORE_SIGNER, map[string]any{"pk": encryptedPk})
+}
+
+type idRow struct {
+	ID int64 `db:"id"`
+}
+
+// LoadSignerKeys returns every key in the signer_key keyring with its PK DECRYPTED to
+// 0x-trimmed hex (mirroring LoadSignerPk). Rows whose PK cannot be decrypted (e.g. a
+// changed ENCRYPT_PASSWORD) are skipped with a warning rather than failing the whole load,
+// so one bad row can never blind the node to a key that is still usable.
+func LoadSignerKeys(ctx context.Context) ([]SignerKey, error) {
+	rows, err := db.QueryRows[SignerKey](ctx, LOAD_SIGNER_KEYS, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SignerKey, 0, len(rows))
+	for _, r := range rows {
+		if r.PK == "" {
+			continue
+		}
+		decrypted, decErr := encryptor.DecryptText(r.PK)
+		if decErr != nil {
+			log.Warn().Err(decErr).Int64("id", r.ID).Msg("failed to decrypt signer_key row; skipping")
+			continue
+		}
+		r.PK = strings.TrimPrefix(decrypted, "0x")
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+// InsertPendingKey durably persists a new key as 'pending' BEFORE any on-chain call, so a
+// key that a rotation is about to register on-chain can never be lost to a crash.
+func InsertPendingKey(ctx context.Context, address, pkHex string) (int64, error) {
+	encryptedPk, err := encryptor.EncryptText(strings.TrimPrefix(pkHex, "0x"))
+	if err != nil {
+		return 0, err
+	}
+	row, err := db.QueryRow[idRow](ctx, INSERT_PENDING_KEY, map[string]any{
+		"address": strings.ToLower(address),
+		"pk":      encryptedPk,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return row.ID, nil
+}
+
+func BackfillKeyAddress(ctx context.Context, id int64, address string) error {
+	return db.QueryWithoutResult(ctx, BACKFILL_ADDRESS, map[string]any{
+		"id":      id,
+		"address": strings.ToLower(address),
+	})
+}
+
+func SetKeyTxHash(ctx context.Context, id int64, txHash string) error {
+	return db.QueryWithoutResult(ctx, SET_KEY_TXHASH, map[string]any{"id": id, "tx_hash": txHash})
+}
+
+// PromotePendingToActive marks the given key as the single active key (retiring any other active
+// row first) and mirrors it into the legacy `signer` row so a rolled-back old binary still finds
+// the live key. All three writes run in ONE transaction, so the signer_key_one_active partial
+// unique index can never be transiently violated even under concurrent promotes (rolling deploy),
+// and the legacy mirror stays consistent with the keyring. It is idempotent: re-promoting the
+// already-active key is a no-op. The `state` column is bookkeeping only — the on-chain whitelist,
+// not this column, decides which key actually signs — so a crash mid-promote is self-healed by
+// reconcile (the key itself was already persisted via InsertPendingKey, so nothing is lost).
+func PromotePendingToActive(ctx context.Context, id int64, promotedPkHex string) error {
+	encryptedPk, err := encryptor.EncryptText(strings.TrimPrefix(promotedPkHex, "0x"))
+	if err != nil {
+		return err
+	}
+	pool, err := db.GetPool(ctx)
+	if err != nil {
+		return err
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) // no-op after a successful Commit
+
+	if _, err := tx.Exec(ctx, RETIRE_ACTIVE, pgx.NamedArgs{"id": id}); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, ACTIVATE_KEY, pgx.NamedArgs{"id": id}); err != nil {
+		return err
+	}
+	// Mirror into the legacy single-row `signer` table within the same transaction.
+	if _, err := tx.Exec(ctx, STORE_SIGNER, pgx.NamedArgs{"pk": encryptedPk}); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func GCRetiredKeys(ctx context.Context) error {
+	return db.QueryWithoutResult(ctx, GC_RETIRED, nil)
 }
 
 func NewPk(ctx context.Context) (*ecdsa.PrivateKey, string, error) {

--- a/node/pkg/error/sentinel.go
+++ b/node/pkg/error/sentinel.go
@@ -111,6 +111,7 @@ var (
 	ErrChainEmptySignedRawTx                 = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty signed raw tx"}
 	ErrChainPubKeyToECDSAFail                = &CustomError{Service: Others, Code: InternalError, Message: "failed to convert public key to ECDSA"}
 	ErrChainSignerPKNotFound                 = &CustomError{Service: Others, Code: InvalidInputError, Message: "signer public key not found"}
+	ErrChainSignerNoWhitelistedKey           = &CustomError{Service: Others, Code: InternalError, Message: "no held signer key is currently whitelisted on-chain; refusing to sign"}
 	ErrChainEmptyClientParam                 = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty client param"}
 	ErrChainEmptyAddressParam                = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty address param"}
 	ErrChainEmptyReporterParam               = &CustomError{Service: Others, Code: InvalidInputError, Message: "empty reporter param"}


### PR DESCRIPTION
Fixes #2516.

## Problem

A node's automatic signer-key rotation could leave the **running** node signing global-aggregate proofs with a key that is no longer the on-chain `SubmissionProxy` oracle. Because `Renew` committed the on-chain `updateOracle` **first** and only trusted the (unreliable) RPC ack, a crash / rolling deploy / "tx mined but RPC errored" could diverge the chain, the DB, and the in-memory key with **no reconciliation and no loud failure** — freezing every feed until a manual restart (the 2026-07-25 baobab incident).

## Approach — on-chain whitelist is the source of truth

- **Additive keyring (`signer_key`)** durably holds every key the node might still need (active + in-flight pending + retired). The legacy `signer` table/queries are left completely untouched (old-binary + rollback safe); the migration seeds the keyring from the existing row.
- **Authoritative sign gate**: `MakeGlobalAggregateProof` refuses (no proof emitted, so `HandlePriceFixMessage` returns before publishing) unless `usable && !rotating && now+skew < cachedExpiration` **and** the active key was confirmed whitelisted within `confirmationTTL`. It never silently signs with a stale/deactivated key.
- **`reconcile` (boot + every 30s)** reads `whitelist(addr)` for each held key and adopts whichever is currently whitelisted (per-address, so multi-oracle cypress works). Golden rule: *adopt a whitelisted held key before attempting any rotation, and rotate only FROM a whitelisted key.* This self-heals the exact incident (DB/chain on the new key, process on the old) **without a restart**.
- **`rotate`**: persist the new key **before** `updateOracle`, set `rotating=true` (stop signing for the in-flight window), confirm success by **reading chain state** (ignore the RPC ack — the root cause), adopt in memory **before** the DB promote, and never delete a pending key that might still mine.
- **Singleton Signer**, created in `Run` before the bus subscription — no goroutine leak, no two Signers rotating one oracle.
- **`getSigner` admin endpoint** now reports the actual in-memory signing key + `usable`/`rotating` via the bus, not the DB row (the misleading symptom from the incident).
- **`WithSignerPk` = static mode** (tests / explicit override): fixed key, no keyring/rotation/gate — preserves pre-fix behavior.

## How it was designed & hardened

The design was produced and adversarially stress-tested against a 12-scenario crash/failure matrix (crash between every step, "mined-but-RPC-errored", rolling deploy, out-of-band oracle removal, RPC read-your-writes, multi-oracle, etc.), then the **implementation** was adversarially reviewed against the same matrix + Go concurrency + DB/migration + regression lenses. All **11 confirmed findings** were fixed, including:

- **critical** — migration version collision (`000027` already exists; renumbered to `000041`, verified next-free vs the version-40 fleet);
- **high** — unsynchronized singleton creation could spawn two Signers → fixed by creating it before `subscribe`;
- **medium** — out-of-band oracle removal during RPC degradation could sign silently → bounded by `confirmationTTL` + active-key-specific status check;
- **medium** — managed-mode signing tests → converted to static mode;
- **low** — `PromotePendingToActive` now runs in one real transaction; `RENEW_SIGNER` nil-guarded; `rotating` cleared if adopt fails; initial reconcile no longer blocks startup on a rotation.

## Tests

- Unit tests for the safety-critical sign gate (refuses on every unsafe state; signs only when usable+valid) and the selection logic (`pickChosen`, `pickReusablePending`, `renewalRequired`, `Status`).
- `go build ./...`, `go vet`, and the new unit tests pass.
- A full crash-injection scenario harness (S1–S12) needs a testcontainers-Postgres + a mock/forked `SubmissionProxy` and is proposed as a follow-up; the design and implementation were adversarially vetted against those scenarios in the meantime.

## Must NOT change (regression guards honored)

Legacy `signer` table/`unique_dummy`/`LOAD_SIGNER`/`STORE_SIGNER`; `MakeValueSignature` wire format; the `whitelist(address)` / `updateOracle(address)` ABI strings; the Vault `SIGNER_PK` bootstrap; no unique index on `state='pending'`; never delete a pending key prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
