### PR TITLE
Rate-limit the DAL collector's on-demand oracle refresh

### DIFF
--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -330,10 +330,15 @@ func (c *Collector) maybeRefreshWhitelist(ctx context.Context) {
 }
 
 // claimRefreshSlot reports whether the caller may fire an on-demand whitelist refresh now,
-// enforcing OnDemandRefreshCooldown. The single atomic doubles as the claim: among many callers
-// within one cooldown window, exactly one CompareAndSwap succeeds, so exactly one gets true.
+// enforcing OnDemandRefreshCooldown.
 func (c *Collector) claimRefreshSlot() bool {
-	now := time.Now().UnixNano()
+	return c.claimRefreshSlotAt(time.Now().UnixNano())
+}
+
+// claimRefreshSlotAt is claimRefreshSlot with an injected clock (UnixNano) so the cooldown can be
+// exercised deterministically in tests. The single atomic doubles as the claim: among many callers
+// within one cooldown window, exactly one CompareAndSwap succeeds, so exactly one gets true.
+func (c *Collector) claimRefreshSlotAt(now int64) bool {
 	last := c.lastOnDemandRefresh.Load()
 	if now-last < int64(OnDemandRefreshCooldown) {
 		return false

--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"bisonai.com/miko/node/pkg/aggregator"
@@ -29,6 +30,12 @@ const (
 	GetAllOracles            = "getAllOracles() public view returns (address[] memory)"
 	OracleAdded              = "OracleAdded(address oracle, uint256 expirationTime)"
 	ProcessWorkerCount       = 200
+	// OnDemandRefreshCooldown bounds how often a proof rejection may trigger an immediate
+	// getAllOracles read. The path is only an accelerator over the WhitelistRefreshInterval
+	// ticker, so at most one on-demand refresh per cooldown is enough to recover quickly from a
+	// legitimate rotation while preventing a sustained mismatch (e.g. a signer freeze, where every
+	// feed's proof is rejected ~2.5x/s) from spawning hundreds of on-chain calls per second.
+	OnDemandRefreshCooldown = 1 * time.Second
 )
 
 type Config = types.Config
@@ -53,6 +60,11 @@ type Collector struct {
 
 	processPool *pool.Pool
 	mu          sync.RWMutex
+
+	// lastOnDemandRefresh is the UnixNano of the last rejection-triggered whitelist refresh; it
+	// doubles as the rate-limit claim so concurrent rejections fire at most one refresh per
+	// OnDemandRefreshCooldown (see maybeRefreshWhitelist).
+	lastOnDemandRefresh atomic.Int64
 }
 
 func NewCollector(ctx context.Context, configs []types.Config) (*Collector, error) {
@@ -271,16 +283,7 @@ func (c *Collector) IncomingDataToOutgoingData(ctx context.Context, data *aggreg
 	if err != nil {
 		log.Error().Err(err).Str("Player", "DalCollector").Str("Symbol", data.Symbol).Msg("failed to order proof")
 		if errors.Is(err, errorsentinel.ErrDalSignerNotWhitelisted) {
-			go func(ctx context.Context, chainHelper *chainreader.ChainReader, contractAddress string) {
-				newList, getAllOraclesErr := getAllOracles(ctx, chainHelper, contractAddress)
-				if getAllOraclesErr != nil {
-					log.Error().Err(getAllOraclesErr).Str("Player", "DalCollector").Msg("failed to refresh oracles")
-					return
-				}
-				c.mu.Lock()
-				c.CachedWhitelist = newList
-				c.mu.Unlock()
-			}(ctx, c.chainReader, c.submissionProxyContractAddr)
+			c.maybeRefreshWhitelist(ctx)
 		}
 		return nil, err
 	}
@@ -300,6 +303,42 @@ func (c *Collector) IncomingDataToOutgoingData(ctx context.Context, data *aggreg
 		FeedHash:      formatBytesToHex(feedHashBytes),
 		Decimals:      decimals,
 	}, nil
+}
+
+// maybeRefreshWhitelist triggers an immediate getAllOracles read after a proof was rejected for a
+// non-whitelisted signer: the local cache may simply be lagging a legitimate oracle rotation, and
+// this recovers faster than waiting for the WhitelistRefreshInterval ticker. It is rate-limited to
+// at most one refresh per OnDemandRefreshCooldown — a single atomic timestamp both enforces the
+// cooldown and claims the slot, so a flood of concurrent rejections (as in a signer freeze where
+// every feed's proof is rejected) collapses to one on-chain call per cooldown instead of one per
+// rejected message.
+func (c *Collector) maybeRefreshWhitelist(ctx context.Context) {
+	if !c.claimRefreshSlot() {
+		return
+	}
+
+	go func() {
+		newList, err := getAllOracles(ctx, c.chainReader, c.submissionProxyContractAddr)
+		if err != nil {
+			log.Error().Err(err).Str("Player", "DalCollector").Msg("failed to refresh oracles on-demand")
+			return
+		}
+		c.mu.Lock()
+		c.CachedWhitelist = newList
+		c.mu.Unlock()
+	}()
+}
+
+// claimRefreshSlot reports whether the caller may fire an on-demand whitelist refresh now,
+// enforcing OnDemandRefreshCooldown. The single atomic doubles as the claim: among many callers
+// within one cooldown window, exactly one CompareAndSwap succeeds, so exactly one gets true.
+func (c *Collector) claimRefreshSlot() bool {
+	now := time.Now().UnixNano()
+	last := c.lastOnDemandRefresh.Load()
+	if now-last < int64(OnDemandRefreshCooldown) {
+		return false
+	}
+	return c.lastOnDemandRefresh.CompareAndSwap(last, now)
 }
 
 func (c *Collector) refreshOracles(ctx context.Context) {

--- a/node/pkg/dal/collector/collector_test.go
+++ b/node/pkg/dal/collector/collector_test.go
@@ -1,0 +1,54 @@
+//nolint:all
+package collector
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A flood of proof rejections within one cooldown window must collapse to a single on-demand
+// whitelist refresh — this is the guard against the 2026-07-25 signer-freeze RPC storm, where every
+// feed's proof was rejected ~2.5x/s and each rejection previously spawned its own getAllOracles call.
+func TestClaimRefreshSlot_RateLimitsBurst(t *testing.T) {
+	c := &Collector{}
+
+	allowed := 0
+	for i := 0; i < 10000; i++ {
+		if c.claimRefreshSlot() {
+			allowed++
+		}
+	}
+
+	// All iterations run well within OnDemandRefreshCooldown, so only the first may fire.
+	assert.Equal(t, 1, allowed, "burst of rejections within the cooldown must trigger exactly one refresh")
+}
+
+func TestClaimRefreshSlot_ConcurrentSingleFire(t *testing.T) {
+	c := &Collector{}
+
+	var allowed atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 500; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if c.claimRefreshSlot() {
+				allowed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), allowed.Load(), "concurrent rejections must not race past the cooldown claim")
+}
+
+// A fresh collector (zero lastOnDemandRefresh) must allow the first refresh immediately, so recovery
+// from a legitimate rotation is not delayed by the cooldown.
+func TestClaimRefreshSlot_FirstCallAllowed(t *testing.T) {
+	c := &Collector{}
+	assert.True(t, c.claimRefreshSlot(), "the first on-demand refresh must be allowed immediately")
+	assert.False(t, c.claimRefreshSlot(), "an immediate second call is within the cooldown and must be denied")
+}

--- a/node/pkg/dal/collector/collector_test.go
+++ b/node/pkg/dal/collector/collector_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// A fixed, realistic UnixNano so the cooldown is exercised deterministically, independent of the
+// test runner's wall clock (a paused/slow runner must not cross the cooldown and flake the tests).
+const fixedNow = int64(1_700_000_000_000_000_000)
+
 // A flood of proof rejections within one cooldown window must collapse to a single on-demand
 // whitelist refresh — this is the guard against the 2026-07-25 signer-freeze RPC storm, where every
 // feed's proof was rejected ~2.5x/s and each rejection previously spawned its own getAllOracles call.
@@ -17,12 +21,11 @@ func TestClaimRefreshSlot_RateLimitsBurst(t *testing.T) {
 
 	allowed := 0
 	for i := 0; i < 10000; i++ {
-		if c.claimRefreshSlot() {
+		if c.claimRefreshSlotAt(fixedNow) {
 			allowed++
 		}
 	}
 
-	// All iterations run well within OnDemandRefreshCooldown, so only the first may fire.
 	assert.Equal(t, 1, allowed, "burst of rejections within the cooldown must trigger exactly one refresh")
 }
 
@@ -35,7 +38,7 @@ func TestClaimRefreshSlot_ConcurrentSingleFire(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if c.claimRefreshSlot() {
+			if c.claimRefreshSlotAt(fixedNow) {
 				allowed.Add(1)
 			}
 		}()
@@ -49,6 +52,14 @@ func TestClaimRefreshSlot_ConcurrentSingleFire(t *testing.T) {
 // from a legitimate rotation is not delayed by the cooldown.
 func TestClaimRefreshSlot_FirstCallAllowed(t *testing.T) {
 	c := &Collector{}
-	assert.True(t, c.claimRefreshSlot(), "the first on-demand refresh must be allowed immediately")
-	assert.False(t, c.claimRefreshSlot(), "an immediate second call is within the cooldown and must be denied")
+	assert.True(t, c.claimRefreshSlotAt(fixedNow), "the first on-demand refresh must be allowed immediately")
+	assert.False(t, c.claimRefreshSlotAt(fixedNow), "a second call at the same instant is within the cooldown and must be denied")
+}
+
+// Once the cooldown has elapsed a new refresh is allowed again, so the whitelist keeps recovering.
+func TestClaimRefreshSlot_AllowsAfterCooldown(t *testing.T) {
+	c := &Collector{}
+	assert.True(t, c.claimRefreshSlotAt(fixedNow), "first claim allowed")
+	assert.False(t, c.claimRefreshSlotAt(fixedNow+int64(OnDemandRefreshCooldown)-1), "just before the cooldown elapses, denied")
+	assert.True(t, c.claimRefreshSlotAt(fixedNow+int64(OnDemandRefreshCooldown)), "once the cooldown elapses, allowed again")
 }


### PR DESCRIPTION
## Problem
When the DAL collector rejects a proof for a non-whitelisted signer, it eagerly re-reads `getAllOracles` on-chain to recover quickly from a legitimate oracle rotation. That path (`collector.go`, `IncomingDataToOutgoingData`) had **no guard** — it spawned one `getAllOracles` goroutine **per rejected message**.

During the 2026-07-25 baobab signer freeze ([#2516](https://github.com/Bisonai/orakl/issues/2516)), the running aggregator kept emitting global-aggregate proofs signed with a **stale key** while the on-chain oracle had rotated away. So every one of the ~235 baobab feeds had its proof rejected ~2.5×/s (aggregateInterval 400ms), and refreshing `getAllOracles` returned the same whitelist that still didn't match — so it re-fired forever:

> ~235 feeds × 2.5 rounds/s ≈ **~587 `getAllOracles` eth_calls/s**, sustained for the ~2-day freeze ≈ **~650–980M BlockPI Request Units/day (~20–30×** the ~30–40M baseline). It dropped to baseline the instant the node was restarted (proofs stopped being rejected → the fan-out collapsed to zero).

## Fix
The on-demand refresh is only an **accelerator** over the existing 10s `WhitelistRefreshInterval` ticker (which is the correctness backstop), so it is safe to debounce. A single `atomic.Int64` timestamp both enforces a **1s cooldown** and **claims the slot** via `CompareAndSwap`, so a flood of concurrent rejections collapses to **at most one refresh per cooldown (~587× fewer calls)**, while a real rotation still recovers within ~1s.

## Why now / relationship to #2517
Defense-in-depth. #2517 already prevents the *freeze* that triggered this storm, but the **amplifier itself was unchanged** (the collector diff was empty). It would fire again on any sustained non-whitelisted-signer condition the local fail-loud gate does not cover — most relevantly on **multi-node cypress**, where a peer node's bad-key proof, or the ~10s whitelist-cache lag during a legitimate rotation, makes the local collector fan out at hundreds of eth_calls/s again.

## Tests
`collector_test.go` (new): a 10k-iteration burst and a 500-goroutine concurrent race both assert **exactly one** refresh is claimed within a cooldown; a fresh collector allows the first refresh immediately. `go build`, `go vet`, and `go test -race ./pkg/dal/collector/` all pass.

## Follow-ups (not in this PR)
- Signer: exponential backoff + a consecutive-failed-rotation cap (so a rotation that can't land stops re-broadcasting `updateOracle` every ~70s).
- Ops: a BlockPI RU-rate alert on the Kaia keys so any future amplification is caught in minutes, not days.