### PR TITLE
[DO NOT MERGE] probe: isolate DAL test flakiness on pristine master

### DIFF
--- a/node/pkg/dal/collector/collector.go
+++ b/node/pkg/dal/collector/collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// probe: no-op comment to trigger the node path filter on pristine master (isolate DAL flakiness).
 const (
 	WhitelistRefreshInterval = 10 * time.Second
 	DefaultDecimals          = "8"


### PR DESCRIPTION
Throwaway draft to run `miko dal test` on unmodified master and isolate whether the DAL API test failures on #2518 are environmental (real Kairos RPC + 10ms subscription-readiness race) or caused by that PR's collector change. Will be closed once the run reports.