### PR TITLE
fix(delegator): surface swallowed errors, share contract cache, bound tx query

### DIFF
--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -38,10 +38,9 @@ func MakePayload(tx *types.Transaction) (SignInsertPayload, error) {
 	to := strings.ToLower(tx.To().Hex())
 	input := "0x" + hex.EncodeToString(tx.Data())
 	gas := fmt.Sprintf("0x%x", tx.Gas())
-	// big.Int.String() is decimal; behind an "0x" prefix it is read back as hex
-	value := "0x" + tx.Value().Text(16)
+	value := "0x" + tx.Value().String()
 	chainId := tx.ChainId()
-	gasPrice := "0x" + tx.GasPrice().Text(16)
+	gasPrice := "0x" + tx.GasPrice().String()
 	nonce := fmt.Sprintf("0x%x", tx.Nonce())
 
 	sig := tx.RawSignatureValues()

--- a/node/pkg/chain/utils/utils.go
+++ b/node/pkg/chain/utils/utils.go
@@ -38,9 +38,10 @@ func MakePayload(tx *types.Transaction) (SignInsertPayload, error) {
 	to := strings.ToLower(tx.To().Hex())
 	input := "0x" + hex.EncodeToString(tx.Data())
 	gas := fmt.Sprintf("0x%x", tx.Gas())
-	value := "0x" + tx.Value().String()
+	// big.Int.String() is decimal; behind an "0x" prefix it is read back as hex
+	value := "0x" + tx.Value().Text(16)
 	chainId := tx.ChainId()
-	gasPrice := "0x" + tx.GasPrice().String()
+	gasPrice := "0x" + tx.GasPrice().Text(16)
 	nonce := fmt.Sprintf("0x%x", tx.Nonce())
 
 	sig := tx.RawSignatureValues()
@@ -59,9 +60,9 @@ func MakePayload(tx *types.Transaction) (SignInsertPayload, error) {
 		ChainId:  "0x" + chainId.Text(16),
 		GasPrice: gasPrice,
 		Nonce:    nonce,
-		V:        r,
-		R:        s,
-		S:        v,
+		V:        v,
+		R:        r,
+		S:        s,
 		RawTx:    rawTx,
 	}
 

--- a/node/pkg/delegator/sign/controller.go
+++ b/node/pkg/delegator/sign/controller.go
@@ -23,6 +23,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	defaultTransactionLimit = 100
+	maxTransactionLimit     = 1000
+)
+
 type FeePayer struct {
 	PrivateKey string `json:"privateKey" db:"privateKey"`
 }
@@ -241,7 +246,17 @@ func insertV2(c *fiber.Ctx) error {
 }
 
 func get(c *fiber.Ctx) error {
-	transactions, err := utils.QueryRows[SignModel](c, GetTransactions, nil)
+	// unbounded select loads the whole table into memory and can oom the process
+	limit := c.QueryInt("limit", defaultTransactionLimit)
+	if limit < 1 || limit > maxTransactionLimit {
+		limit = defaultTransactionLimit
+	}
+	offset := c.QueryInt("offset", 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	transactions, err := utils.QueryRows[SignModel](c, GetTransactions, map[string]any{"limit": limit, "offset": offset})
 	if err != nil {
 		return err
 	}
@@ -454,9 +469,12 @@ func updateFeePayer(tx *types.Transaction, feePayer common.Address) (*types.Tran
 	}
 
 	newTx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedSmartContractExecution, remap)
+	if err != nil {
+		return nil, err
+	}
 
 	newTx.SetSignature(tx.GetTxInternalData().RawSignatureValues())
-	return newTx, err
+	return newTx, nil
 }
 
 func TxToHash(tx *types.Transaction) string {

--- a/node/pkg/delegator/sign/queries.go
+++ b/node/pkg/delegator/sign/queries.go
@@ -44,7 +44,7 @@ const (
 		)
 		AND "encodedName" = @encodedName;
 	`
-	GetTransactions       = `SELECT * FROM transactions;`
+	GetTransactions       = `SELECT * FROM transactions ORDER BY transaction_id DESC LIMIT @limit OFFSET @offset;`
 	GetTransactionById    = `SELECT * FROM transactions WHERE transaction_id = @id;`
 	DeleteTransactionById = `DELETE FROM transactions WHERE transaction_id = @id RETURNING *;`
 )

--- a/node/pkg/delegator/utils/utils.go
+++ b/node/pkg/delegator/utils/utils.go
@@ -68,10 +68,13 @@ func Setup(options ...string) (AppConfig, error) {
 		},
 	))
 	app.Use(cors.New())
+	// shared across requests, otherwise the cache is rebuilt empty on every
+	// request and every sign hits the db for contract validation
+	validContracts := new(sync.Map)
 	app.Use(func(c *fiber.Ctx) error {
 		c.Locals("feePayer", feePayer)
 		c.Locals("pgxConn", pgxPool)
-		c.Locals("validContracts", new(sync.Map))
+		c.Locals("validContracts", validContracts)
 		return c.Next()
 	})
 
@@ -119,7 +122,7 @@ func CustomErrorHandler(c *fiber.Ctx, err error) error {
 
 	// Return status code with error message
 	// | ${status} | ${ip} | ${method} | ${path} | ${error}",
-	log.Error().Err(err).Str("call info", fmt.Sprintf("| %d | %s | %s | %s | %s\n", code, c.IP(), c.Method(), c.Path(), err.Error()))
+	log.Error().Err(err).Str("call info", fmt.Sprintf("| %d | %s | %s | %s | %s\n", code, c.IP(), c.Method(), c.Path(), err.Error())).Msg("request failed")
 	return c.Status(code).SendString(err.Error())
 }
 


### PR DESCRIPTION
# Description

While debugging why fee-delegated submissions were failing on baobab and cypress (`POST /api/v1/sign/v2` returning 500), the root blocker turned out to be that **the delegator cannot report errors at all**. This PR fixes that plus three adjacent bugs found along the way.

It does **not** fix the underlying 500 — that cause is still unknown. The point of this PR is to make the error visible so the real bug can be diagnosed with evidence instead of guesswork.

### 1. Every error was silently discarded (the blocker)

`node/pkg/delegator/utils/utils.go:122`

```go
log.Error().Err(err).Str("call info", fmt.Sprintf(...))   // no .Msg() / .Send()
```

A zerolog event is only written when a terminal method is called. This one never was, so **every 500 from every code path in the delegator has been invisible since this code was written**, at any `LOG_LEVEL`. Setting `LOG_LEVEL=info` in production produced no output for this reason.

The caller cannot recover it either: `pkg/utils/request/request.go:85` returns on non-200 *before* `io.ReadAll`, so the reporter discards the response body unread.

### 2. Contract cache was rebuilt empty on every request

`utils.go:74` — `c.Locals("validContracts", new(sync.Map))` sits inside the per-request middleware, so a fresh empty map is allocated per request. The cache never hits, `"contract approved through cache"` can never log, and **every sign request does a DB lookup**. Hoisted so it is shared.

### 3. `GetTransactions` was an unbounded `SELECT *`

`sign/queries.go:47` — `SELECT * FROM transactions;` with no limit, against a table appended to on every successful sign. A single `GET /api/v1/sign` loads the entire table into a 500Mi container. Both delegators were OOMKilled (exit 137) within 32 seconds of each other; this is the only unbounded allocation path in the service. Now paginated (`limit` default 100, max 1000; `offset`).

### 4. Nil deref in `updateFeePayer`

`sign/controller.go` — `newTx.SetSignature(...)` ran before `err` was checked, so a `NewTransactionWithMap` failure panics instead of returning the error.

### 5. `MakePayload` had `V`/`R`/`S` rotated

`pkg/chain/utils/utils.go` — the locals are assigned correctly (`r`, `s`, `v`), then the struct literal puts them in the wrong fields: `V: r`, `R: s`, `S: v`.

Impact by endpoint:

| Endpoint | Handler | Effect |
|---|---|---|
| `POST /sign` (v1) | `CreateUnsignedTx` reads `tx.R`/`tx.S`/`tx.V` | would rebuild the tx with the wrong signature and recover the wrong sender |
| `POST /sign/v2` | signature comes from `HashToTx(rawTx)` | fields only validated `required` + written to the audit row |
| `POST /sign/volatile` | signature comes from `HashToTx(rawTx)` | fields unused entirely |

The reporter calls v2 (`DelegatorEndpoint = "/api/v1/sign/v2"`), so this never affected production signing — it corrupted the `transactions` audit rows, and means the v1 path has been broken for as long as this code has existed.

### Deliberately left out

`MakePayload` also emits `value` and `gasPrice` as `"0x" + big.Int.String()` — decimal digits behind an `0x` prefix, which the delegator reads back as hex via `SetString(s, 0)` (`27500000000` → `0x27500000000` → parses as ~98× too large). Correcting it was **dropped from this PR on purpose**: v2 never reads those strings for signing, and changing them only alters v1 behaviour that nothing currently exercises. Not worth the risk in a diagnostic fix; it belongs in its own PR where v1 can actually be tested.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

### Testing

- `go build ./...` clean; `go vet ./pkg/chain/utils/...` clean.
- `go vet` on the delegator packages: two **pre-existing** warnings at `delegator/utils/utils.go:302,309` (non-constant format string), untouched by this PR.
- **Known failures, all pre-existing** — reproduced on a clean tree with these changes stashed:
  - `pkg/delegator/tests` — `TestMain` panics, needs a valid fee-payer key in env
  - `pkg/delegator/utils` — build fails on the two pre-existing vet warnings above
  - `pkg/chain/tests` — `TestNewKaiaHelper` needs chain env; `pkg/chain/helper` passes
  - `pkg/chain/utils` has no test files
- **CI:** `miko delegator test` passes. `miko node test` fails on `TestContextCancelDuringJobExecution` (`pkg/utils/tests/pool_test.go:89`) — unrelated to this diff (worker pool, untouched) and timing-flaky by construction: the job sleeps 200ms against a 300ms timeout while `cancel()` races the worker picking it up. Reproduced locally 3 failures in 25 runs.
- No new tests added: these are wiring/guard fixes, and the packages have no test harness that runs without live DB/chain credentials.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image

Deploying item 1 to baobab surfaces the real `/sign/v2` error in the logs immediately.
