### PR TITLE
feat(delegator): validate fee payer key on load, retry every 60s

### DIFF
--- a/node/pkg/delegator/sign/controller.go
+++ b/node/pkg/delegator/sign/controller.go
@@ -109,6 +109,11 @@ func initialize(c *fiber.Ctx) error {
 
 	pk = strings.TrimPrefix(pk, "0x")
 
+	// reject before storing: an unusable key here breaks every subsequent sign
+	if err := utils.ValidateFeePayerPK(pk); err != nil {
+		return err
+	}
+
 	utils.UpdateFeePayer(pk)
 
 	return c.SendString("Initialized")

--- a/node/pkg/delegator/sign/controller.go
+++ b/node/pkg/delegator/sign/controller.go
@@ -94,7 +94,9 @@ type ContractModel struct {
 }
 
 func initialize(c *fiber.Ctx) error {
-	pk := c.Query("feePayerPrivateKey", "")
+	// cloned: c.Query aliases fasthttp's request buffer, which is reused by the
+	// next request. storing it directly let a later request rewrite the key.
+	pk := strings.Clone(c.Query("feePayerPrivateKey", ""))
 	if pk == "" {
 		pgx, err := utils.GetPgx(c)
 		if err != nil {

--- a/node/pkg/delegator/tests/sign_test.go
+++ b/node/pkg/delegator/tests/sign_test.go
@@ -53,8 +53,12 @@ func TestInitialize(t *testing.T) {
 	defer t.Cleanup(cleanup)
 	defer appConfig.App.Shutdown()
 
+	// must be a real secp256k1 key: the delegator now rejects unusable ones
+	// instead of storing them and failing every later signing request
+	const overrideKey = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
+
 	params := url.Values{}
-	params.Add("feePayerPrivateKey", "0x12345")
+	params.Add("feePayerPrivateKey", "0x"+overrideKey)
 
 	appConfig.App.Get("/readpk", func(c *fiber.Ctx) error {
 		fp, error := utils.GetFeePayer(c)
@@ -64,21 +68,29 @@ func TestInitialize(t *testing.T) {
 		return c.JSON(utils.FeePayer{PrivateKey: fp})
 	})
 
-	//_, err = utils.GetRequest[interface{}](appConfig.App, "/api/v1/sign/initialize?feePayerPrivateKey=0x12345", nil)
-
-	err = utils.RawReq(appConfig.App, "GET", "/api/v1/sign/initialize?feePayerPrivateKey=0x12345", nil)
+	err = utils.RawReq(appConfig.App, "GET", "/api/v1/sign/initialize?feePayerPrivateKey=0x"+overrideKey, nil)
 	assert.Nil(t, err)
 
 	readResult, err := utils.GetRequest[utils.FeePayer](appConfig.App, "/readpk", nil)
 	assert.Nil(t, err)
-	assert.Equal(t, readResult.PrivateKey, "12345")
+	assert.Equal(t, overrideKey, readResult.PrivateKey)
+
+	// an unusable key must be refused, leaving the working one in place.
+	// RawReq only surfaces transport errors, so the 500 shows up as the stored
+	// key being unchanged rather than as a returned error.
+	err = utils.RawReq(appConfig.App, "GET", "/api/v1/sign/initialize?feePayerPrivateKey=0x12345", nil)
+	assert.Nil(t, err)
+
+	readResultAfterReject, err := utils.GetRequest[utils.FeePayer](appConfig.App, "/readpk", nil)
+	assert.Nil(t, err)
+	assert.Equal(t, overrideKey, readResultAfterReject.PrivateKey)
 
 	err = utils.RawReq(appConfig.App, "GET", "/api/v1/sign/initialize", nil)
 	assert.Nil(t, err)
 
 	readResultRefreshed, err := utils.GetRequest[utils.FeePayer](appConfig.App, "/readpk", nil)
 	assert.Nil(t, err)
-	assert.NotEqual(t, readResultRefreshed.PrivateKey, "12345")
+	assert.NotEqual(t, overrideKey, readResultRefreshed.PrivateKey)
 }
 
 func TestGetFeePayerAddress(t *testing.T) {

--- a/node/pkg/delegator/utils/feepayer_test.go
+++ b/node/pkg/delegator/utils/feepayer_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// validKey is a throwaway secp256k1 key used only to exercise validation.
+const validKey = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
+
+func TestValidateFeePayerPK(t *testing.T) {
+	tests := []struct {
+		name    string
+		pk      string
+		wantErr bool
+	}{
+		{name: "valid key", pk: validKey, wantErr: false},
+		{name: "valid key with 0x prefix", pk: "0x" + validKey, wantErr: false},
+		// the exact shape that took both networks down: the vault lookup
+		// returned nothing and the empty string was accepted as a key
+		{name: "empty", pk: "", wantErr: true},
+		{name: "truncated", pk: validKey[:32], wantErr: true},
+		{name: "too long", pk: validKey + "ab", wantErr: true},
+		{name: "not hex", pk: strings.Repeat("z", 64), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFeePayerPK(tt.pk)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidateFeePayerPK(%q) = nil, want error", tt.pk)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ValidateFeePayerPK(%q) = %v, want nil", tt.pk, err)
+			}
+		})
+	}
+}
+
+// setFeePayer must leave the stored key untouched when handed a bad one, so a
+// failed reload cannot destroy a working key.
+func TestSetFeePayerRejectsBadKeyAndKeepsPrevious(t *testing.T) {
+	t.Cleanup(func() { UpdateFeePayer("") })
+
+	if err := setFeePayer(validKey); err != nil {
+		t.Fatalf("setFeePayer(valid) = %v, want nil", err)
+	}
+	if got := CurrentFeePayer(); got != validKey {
+		t.Fatalf("CurrentFeePayer() = %q, want %q", got, validKey)
+	}
+
+	if err := setFeePayer(""); err == nil {
+		t.Fatal("setFeePayer(\"\") = nil, want error")
+	}
+	if got := CurrentFeePayer(); got != validKey {
+		t.Fatalf("CurrentFeePayer() = %q after failed reload, want previous key retained", got)
+	}
+}
+
+func TestSetFeePayerStripsPrefix(t *testing.T) {
+	t.Cleanup(func() { UpdateFeePayer("") })
+
+	if err := setFeePayer("0x" + validKey); err != nil {
+		t.Fatalf("setFeePayer(prefixed) = %v, want nil", err)
+	}
+	if got := CurrentFeePayer(); got != validKey {
+		t.Fatalf("CurrentFeePayer() = %q, want prefix stripped", got)
+	}
+}

--- a/node/pkg/delegator/utils/utils.go
+++ b/node/pkg/delegator/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"bisonai.com/miko/node/pkg/delegator/secrets"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -33,7 +34,16 @@ type AppConfig struct {
 	App      *fiber.App
 }
 
-var feePayer string
+// FeePayerRetryInterval is how long to wait before re-reading the fee payer key
+// after a load produced an unusable one.
+const FeePayerRetryInterval = 60 * time.Second
+
+// guards feePayer: the retry loop writes it from its own goroutine while every
+// request reads it through the middleware.
+var (
+	feePayerMu sync.RWMutex
+	feePayer   string
+)
 
 func Setup(options ...string) (AppConfig, error) {
 	var version string
@@ -50,9 +60,12 @@ func Setup(options ...string) (AppConfig, error) {
 		return appConfig, pgxError
 	}
 
-	err := InitFeePayerPK(context.Background(), pgxPool)
-	if err != nil {
-		fmt.Println("fee payer not initialized due to error:" + err.Error() + "\nplease refresh the application after fee payer insertion through following endpoint: /api/v1/sign/initialize")
+	if err := InitFeePayerPK(context.Background(), pgxPool); err != nil {
+		// serving continues so the non-signing routes stay up, but every signing
+		// request will fail until the retry loop lands a usable key
+		log.Error().Err(err).Dur("retry_in", FeePayerRetryInterval).
+			Msg("fee payer not initialized, signing is broken; retrying in background. To load one immediately: /api/v1/sign/initialize")
+		go retryFeePayerInit(context.Background(), pgxPool, FeePayerRetryInterval)
 	}
 
 	app := fiber.New(fiber.Config{
@@ -72,7 +85,7 @@ func Setup(options ...string) (AppConfig, error) {
 	// request and every sign hits the db for contract validation
 	validContracts := new(sync.Map)
 	app.Use(func(c *fiber.Ctx) error {
-		c.Locals("feePayer", feePayer)
+		c.Locals("feePayer", CurrentFeePayer())
 		c.Locals("pgxConn", pgxPool)
 		c.Locals("validContracts", validContracts)
 		return c.Next()
@@ -86,25 +99,76 @@ func Setup(options ...string) (AppConfig, error) {
 }
 
 func InitFeePayerPK(ctx context.Context, pgxPool *pgxpool.Pool) error {
-	var err error
-	if feePayer = os.Getenv("DELEGATOR_FEEPAYER_PK"); feePayer != "" {
-		return nil
+	// resolved into a local first: assigning the package var up front wiped a
+	// usable key whenever a later reload failed
+	if pk := os.Getenv("DELEGATOR_FEEPAYER_PK"); pk != "" {
+		return setFeePayer(pk)
 	}
 
 	useGoogleSecretManager, _ := strconv.ParseBool(os.Getenv("USE_GOOGLE_SECRET_MANAGER"))
 	useVault, _ := strconv.ParseBool(os.Getenv("USE_VAULT"))
-	if useVault {
-		feePayer, err = LoadFeePayerFromVault(ctx)
-		if err != nil {
-			return err
-		}
-	} else if useGoogleSecretManager {
-		feePayer, err = LoadFeePayerFromGSM(ctx)
-		if err != nil {
-			return err
-		}
+
+	var (
+		pk  string
+		err error
+	)
+	switch {
+	case useVault:
+		pk, err = LoadFeePayerFromVault(ctx)
+	case useGoogleSecretManager:
+		pk, err = LoadFeePayerFromGSM(ctx)
+	default:
+		return errors.New("no fee payer source configured")
+	}
+	if err != nil {
+		return err
+	}
+
+	return setFeePayer(pk)
+}
+
+// ValidateFeePayerPK reports whether pk is a usable secp256k1 private key.
+// Without this the delegator accepts an empty or truncated key and fails every
+// signing request until it is restarted.
+func ValidateFeePayerPK(pk string) error {
+	if pk == "" {
+		return errors.New("fee payer private key is empty")
+	}
+	if _, err := crypto.HexToECDSA(strings.TrimPrefix(pk, "0x")); err != nil {
+		return fmt.Errorf("unusable fee payer private key: %w", err)
 	}
 	return nil
+}
+
+func setFeePayer(pk string) error {
+	if err := ValidateFeePayerPK(pk); err != nil {
+		return err
+	}
+	UpdateFeePayer(strings.TrimPrefix(pk, "0x"))
+	return nil
+}
+
+// retryFeePayerInit reloads the key until one validates. Started only when the
+// initial load failed, so the process recovers from a transient secret-store
+// outage on its own instead of serving 500s until someone notices.
+func retryFeePayerInit(ctx context.Context, pgxPool *pgxpool.Pool, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Error().Err(ctx.Err()).Msg("fee payer retry stopped before a usable key was loaded")
+			return
+		case <-ticker.C:
+			if err := InitFeePayerPK(ctx, pgxPool); err != nil {
+				log.Error().Err(err).Dur("retry_in", interval).Msg("fee payer reload failed, retrying")
+				continue
+			}
+			log.Info().Msg("fee payer key reloaded successfully, signing restored")
+			return
+		}
+	}
 }
 
 func CustomErrorHandler(c *fiber.Ctx, err error) error {
@@ -153,7 +217,16 @@ func GetFeePayer(c *fiber.Ctx) (string, error) {
 }
 
 func UpdateFeePayer(newFeePayer string) {
+	feePayerMu.Lock()
+	defer feePayerMu.Unlock()
 	feePayer = newFeePayer
+}
+
+// CurrentFeePayer returns the key the process is signing with.
+func CurrentFeePayer() string {
+	feePayerMu.RLock()
+	defer feePayerMu.RUnlock()
+	return feePayer
 }
 
 func GetPgx(c *fiber.Ctx) (*pgxpool.Pool, error) {
@@ -299,14 +372,15 @@ func GetPublicKey(pk string) (string, error) {
 
 	privateKeyECDSA, err := crypto.HexToECDSA(pk)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert private key to ECDSA: " + err.Error())
+		return "", fmt.Errorf("failed to convert private key to ECDSA: %w", err)
 	}
 
 	publicKey := privateKeyECDSA.Public()
 
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return "", fmt.Errorf("failed to convert public key to ECDSA format: " + err.Error())
+		// err is nil on this branch; calling err.Error() here panicked
+		return "", errors.New("failed to convert public key to ECDSA format")
 	}
 
 	address := crypto.PubkeyToAddress(*publicKeyECDSA)


### PR DESCRIPTION
# Description

On 2026-07-29 both baobab and cypress stopped signing delegated transactions for ~4.5 hours. The delegator loaded an unusable fee-payer private key at startup, stored it without any validation, and then failed **every** signing request until the process was restarted.

The error was on the wire the whole time — a packet capture on the cypress delegator showed:

```
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Content-Length: 29

invalid length, need 256 bits
```

That is `crypto.HexToECDSA` rejecting the key. The key is fetched once at startup and held for the life of the process, so a single bad read is permanent.

## What made a transient read fatal

1. `LoadFeePayerFromVault` can return `("", nil)` — an empty key with **no error**.
2. `Setup` treated the failure as non-fatal: `fmt.Println` and serve anyway.
3. Nothing validated the key. `HexToECDSA` isn't reached until the first signing request.
4. No recovery path. The key is never re-read, so it stayed broken until a restart.

Net effect: a process that looks perfectly healthy — readiness probe green, `GET /` 200, ArgoCD Synced/Healthy — while every signature fails.

## Changes

- **`ValidateFeePayerPK`** — rejects empty, truncated, over-long and non-hex keys.
- **`InitFeePayerPK` resolves into a local** before storing. Previously `if feePayer = os.Getenv(...)` assigned the package var up front, so a failed reload *wiped a working key*. It now also returns an error when no source is configured, rather than silently succeeding with an empty key.
- **Retry loop** — on a failed initial load, reloads every 60s until a key validates, then logs and stops. This alone would have self-healed the outage, since the underlying condition cleared within minutes.
- **`feePayer` guarded by a `sync.RWMutex`** — required, not incidental: the retry goroutine writes the key while every request reads it through the middleware. Without this the retry introduces a data race.
- **`/api/v1/sign/initialize`** validates a supplied key before storing it.

Behaviour on an unusable key changes from *silently serve and fail every sign* to *log loudly at Error and self-heal*.

## Included prerequisite

`GetPublicKey` had `fmt.Errorf("...: " + err.Error())` on a branch where `err` is guaranteed nil — a nil-pointer panic, not just a lint warning. It also tripped `go vet` with a non-constant format string, and **because `go test` runs `vet`, this package's tests could not build at all**. Fixing it is what allows the new tests to run. It is confined to two lines in `GetPublicKey` and can be reverted independently if you would rather it landed separately.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

### Testing

- `go build ./...` clean; `go vet ./pkg/delegator/...` clean (was 2 warnings before).
- New `pkg/delegator/utils/feepayer_test.go` — 8 cases covering valid/prefixed/empty/truncated/over-long/non-hex keys, that a failed reload retains the previous key, and prefix stripping. All pass, including under `-race`.
- `pkg/delegator/utils` now reports **ok** — on master it reports `[build failed]`.
- **Known failure, pre-existing:** `pkg/delegator/tests` panics in `TestMain` (needs a valid fee-payer key in env). Reproduced identically on a clean tree with these changes stashed — unchanged by this PR.
- Not covered by tests: the 60s retry loop itself and the Vault read path, both of which need a live secret store.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image

## Note

This does not address what caused the bad read. Vault runs on standalone VMs outside both clusters and its audit log for 20:24–21:03 UTC was not examined; 20:24 UTC is 05:24 KST, so a host-level scheduled job on those VMs is worth ruling out. This PR makes the delegator survive such an event rather than prevent it.
