### PR TITLE
fix(delegator): stop the fee payer retry goroutine from crashing or leaking

### DIFF
--- a/node/pkg/delegator/secrets/secrets.go
+++ b/node/pkg/delegator/secrets/secrets.go
@@ -48,9 +48,17 @@ func (s *SecretEnv) GetSecretFromVaultWithKubernetesAuth() (*Secrets, error) {
 		return nil, fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	secretDataSet := &Secrets{
-		FeePayer: secrets.Data["FEE_PAYER"].(string),
+	// comma-ok: an unchecked assertion here panicked when the secret came back
+	// without FEE_PAYER. this runs on the fee payer retry goroutine, where a
+	// panic is unrecoverable and would kill the process.
+	raw, ok := secrets.Data["FEE_PAYER"]
+	if !ok {
+		return nil, fmt.Errorf("FEE_PAYER missing from vault secret %s/%s", s.VaultSecretPath, s.VaultKeyName)
+	}
+	feePayer, ok := raw.(string)
+	if !ok {
+		return nil, fmt.Errorf("FEE_PAYER in vault secret %s/%s is %T, want string", s.VaultSecretPath, s.VaultKeyName, raw)
 	}
 
-	return secretDataSet, nil
+	return &Secrets{FeePayer: feePayer}, nil
 }

--- a/node/pkg/delegator/utils/retry_test.go
+++ b/node/pkg/delegator/utils/retry_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// reloadFeePayer must convert a panic in a secret-store client into an error.
+// Without this the retry goroutine has no recover above it and a panicking
+// loader would kill the process once per interval.
+func TestReloadFeePayerRecoversPanic(t *testing.T) {
+	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
+	t.Setenv("USE_VAULT", "false")
+	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+
+	// no source configured -> InitFeePayerPK returns an error rather than
+	// panicking, and reloadFeePayer passes it through untouched
+	err := reloadFeePayer(context.Background(), nil)
+	if err == nil {
+		t.Fatal("reloadFeePayer() = nil, want error when no source is configured")
+	}
+	if strings.Contains(err.Error(), "panic") {
+		t.Fatalf("unexpected panic path: %v", err)
+	}
+}
+
+// A configured env key must still load through the retry path, so recovery
+// does not mask the success case.
+func TestReloadFeePayerSucceedsFromEnv(t *testing.T) {
+	t.Cleanup(func() { UpdateFeePayer("") })
+	t.Setenv("DELEGATOR_FEEPAYER_PK", validKey)
+
+	if err := reloadFeePayer(context.Background(), nil); err != nil {
+		t.Fatalf("reloadFeePayer() = %v, want nil", err)
+	}
+	if got := CurrentFeePayer(); got != validKey {
+		t.Fatalf("CurrentFeePayer() = %q, want %q", got, validKey)
+	}
+}
+
+// A cancelled context must stop the loop instead of retrying forever.
+func TestRetryFeePayerInitStopsOnContextCancel(t *testing.T) {
+	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
+	t.Setenv("USE_VAULT", "false")
+	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		retryFeePayerInit(ctx, nil, FeePayerRetryInterval)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("retryFeePayerInit did not return after context cancel")
+	}
+}

--- a/node/pkg/delegator/utils/retry_test.go
+++ b/node/pkg/delegator/utils/retry_test.go
@@ -2,32 +2,67 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
 )
 
-// reloadFeePayer must convert a panic in a secret-store client into an error.
-// Without this the retry goroutine has no recover above it and a panicking
-// loader would kill the process once per interval.
-func TestReloadFeePayerRecoversPanic(t *testing.T) {
+// noFeePayerSource points InitFeePayerPK at nothing, so it fails without
+// touching a real secret store.
+func noFeePayerSource(t *testing.T) {
+	t.Helper()
 	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
 	t.Setenv("USE_VAULT", "false")
 	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+}
 
-	// no source configured -> InitFeePayerPK returns an error rather than
-	// panicking, and reloadFeePayer passes it through untouched
+// The retry goroutine has no fiber recover middleware above it, so a panicking
+// secret-store client would kill the process once per interval.
+func TestReloadFeePayerRecoversPanic(t *testing.T) {
+	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
+	t.Setenv("USE_VAULT", "true")
+	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+
+	orig := loadFeePayerFromVault
+	t.Cleanup(func() { loadFeePayerFromVault = orig; UpdateFeePayer("") })
+	loadFeePayerFromVault = func(context.Context) (string, error) {
+		panic("vault client blew up")
+	}
+
 	err := reloadFeePayer(context.Background(), nil)
 	if err == nil {
-		t.Fatal("reloadFeePayer() = nil, want error when no source is configured")
+		t.Fatal("reloadFeePayer() = nil, want error when the loader panics")
 	}
-	if strings.Contains(err.Error(), "panic") {
-		t.Fatalf("unexpected panic path: %v", err)
+	if !strings.Contains(err.Error(), "panic while loading fee payer") {
+		t.Fatalf("reloadFeePayer() = %v, want the panic surfaced as an error", err)
+	}
+	if !strings.Contains(err.Error(), "vault client blew up") {
+		t.Fatalf("reloadFeePayer() = %v, want the panic value preserved", err)
 	}
 }
 
-// A configured env key must still load through the retry path, so recovery
-// does not mask the success case.
+// A loader returning an ordinary error must pass through untouched, not be
+// dressed up as a panic.
+func TestReloadFeePayerPassesThroughError(t *testing.T) {
+	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
+	t.Setenv("USE_VAULT", "true")
+	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+
+	orig := loadFeePayerFromVault
+	sentinel := errors.New("vault unreachable")
+	t.Cleanup(func() { loadFeePayerFromVault = orig; UpdateFeePayer("") })
+	loadFeePayerFromVault = func(context.Context) (string, error) { return "", sentinel }
+
+	err := reloadFeePayer(context.Background(), nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("reloadFeePayer() = %v, want %v", err, sentinel)
+	}
+}
+
+// Recovery must not mask the success path.
 func TestReloadFeePayerSucceedsFromEnv(t *testing.T) {
 	t.Cleanup(func() { UpdateFeePayer("") })
 	t.Setenv("DELEGATOR_FEEPAYER_PK", validKey)
@@ -40,11 +75,35 @@ func TestReloadFeePayerSucceedsFromEnv(t *testing.T) {
 	}
 }
 
-// A cancelled context must stop the loop instead of retrying forever.
+// Shutting the app down must cancel the retry loop. Without this each Setup
+// leaks a goroutine that nothing can stop.
+func TestFeePayerRetryStopsOnAppShutdown(t *testing.T) {
+	noFeePayerSource(t)
+	t.Cleanup(func() { UpdateFeePayer("") })
+
+	app := fiber.New()
+	ctx := startFeePayerRetry(app, nil, FeePayerRetryInterval)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("retry context cancelled before shutdown")
+	default:
+	}
+
+	if err := app.Shutdown(); err != nil {
+		t.Fatalf("app.Shutdown() = %v, want nil", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("app shutdown did not cancel the retry context")
+	}
+}
+
+// A cancelled context must stop the loop rather than retrying forever.
 func TestRetryFeePayerInitStopsOnContextCancel(t *testing.T) {
-	t.Setenv("DELEGATOR_FEEPAYER_PK", "")
-	t.Setenv("USE_VAULT", "false")
-	t.Setenv("USE_GOOGLE_SECRET_MANAGER", "false")
+	noFeePayerSource(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/node/pkg/delegator/utils/utils.go
+++ b/node/pkg/delegator/utils/utils.go
@@ -47,6 +47,13 @@ var (
 	feePayer   string
 )
 
+// indirected so tests can substitute a loader that panics, which is the only
+// way to exercise the recover in reloadFeePayer.
+var (
+	loadFeePayerFromVault = LoadFeePayerFromVault
+	loadFeePayerFromGSM   = LoadFeePayerFromGSM
+)
+
 func Setup(options ...string) (AppConfig, error) {
 	var version string
 	var appConfig AppConfig
@@ -89,18 +96,10 @@ func Setup(options ...string) (AppConfig, error) {
 
 	if feePayerErr != nil {
 		// serving continues so the non-signing routes stay up, but every signing
-		// request will fail until the retry loop lands a usable key.
-		// tied to app shutdown: Setup is called once per test, so an uncancellable
-		// goroutine here would accumulate one leaked retry loop per invocation.
-		retryCtx, cancelRetry := context.WithCancel(context.Background())
-		app.Hooks().OnShutdown(func() error {
-			cancelRetry()
-			return nil
-		})
-
+		// request will fail until the retry loop lands a usable key
 		log.Error().Err(feePayerErr).Dur("retry_in", FeePayerRetryInterval).
 			Msg("fee payer not initialized, signing is broken; retrying in background. To load one immediately: /api/v1/sign/initialize")
-		go retryFeePayerInit(retryCtx, pgxPool, FeePayerRetryInterval)
+		startFeePayerRetry(app, pgxPool, FeePayerRetryInterval)
 	}
 
 	appConfig = AppConfig{
@@ -126,9 +125,9 @@ func InitFeePayerPK(ctx context.Context, pgxPool *pgxpool.Pool) error {
 	)
 	switch {
 	case useVault:
-		pk, err = LoadFeePayerFromVault(ctx)
+		pk, err = loadFeePayerFromVault(ctx)
 	case useGoogleSecretManager:
-		pk, err = LoadFeePayerFromGSM(ctx)
+		pk, err = loadFeePayerFromGSM(ctx)
 	default:
 		return errors.New("no fee payer source configured")
 	}
@@ -158,6 +157,21 @@ func setFeePayer(pk string) error {
 	}
 	UpdateFeePayer(strings.TrimPrefix(pk, "0x"))
 	return nil
+}
+
+// startFeePayerRetry launches the retry loop and ties its lifetime to the app.
+// Setup runs once per test (27 call sites), so an uncancellable goroutine here
+// would leak one retry loop per invocation, all racing to write feePayer.
+// Returns the context so callers can observe cancellation.
+func startFeePayerRetry(app *fiber.App, pgxPool *pgxpool.Pool, interval time.Duration) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	app.Hooks().OnShutdown(func() error {
+		cancel()
+		return nil
+	})
+
+	go retryFeePayerInit(ctx, pgxPool, interval)
+	return ctx
 }
 
 // reloadFeePayer wraps InitFeePayerPK so a panic in a secret-store client ends

--- a/node/pkg/delegator/utils/utils.go
+++ b/node/pkg/delegator/utils/utils.go
@@ -18,7 +18,9 @@ import (
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
-	"github.com/gofiber/fiber/v2/middleware/recover"
+	// aliased: the package name "recover" shadows the builtin, which
+	// reloadFeePayer needs
+	fiberrecover "github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kaiachain/kaia/crypto"
@@ -60,13 +62,7 @@ func Setup(options ...string) (AppConfig, error) {
 		return appConfig, pgxError
 	}
 
-	if err := InitFeePayerPK(context.Background(), pgxPool); err != nil {
-		// serving continues so the non-signing routes stay up, but every signing
-		// request will fail until the retry loop lands a usable key
-		log.Error().Err(err).Dur("retry_in", FeePayerRetryInterval).
-			Msg("fee payer not initialized, signing is broken; retrying in background. To load one immediately: /api/v1/sign/initialize")
-		go retryFeePayerInit(context.Background(), pgxPool, FeePayerRetryInterval)
-	}
+	feePayerErr := InitFeePayerPK(context.Background(), pgxPool)
 
 	app := fiber.New(fiber.Config{
 		AppName:           "delegator " + version,
@@ -74,8 +70,8 @@ func Setup(options ...string) (AppConfig, error) {
 		ErrorHandler:      CustomErrorHandler,
 	})
 
-	app.Use(recover.New(
-		recover.Config{
+	app.Use(fiberrecover.New(
+		fiberrecover.Config{
 			EnableStackTrace:  true,
 			StackTraceHandler: CustomStackTraceHandler,
 		},
@@ -90,6 +86,22 @@ func Setup(options ...string) (AppConfig, error) {
 		c.Locals("validContracts", validContracts)
 		return c.Next()
 	})
+
+	if feePayerErr != nil {
+		// serving continues so the non-signing routes stay up, but every signing
+		// request will fail until the retry loop lands a usable key.
+		// tied to app shutdown: Setup is called once per test, so an uncancellable
+		// goroutine here would accumulate one leaked retry loop per invocation.
+		retryCtx, cancelRetry := context.WithCancel(context.Background())
+		app.Hooks().OnShutdown(func() error {
+			cancelRetry()
+			return nil
+		})
+
+		log.Error().Err(feePayerErr).Dur("retry_in", FeePayerRetryInterval).
+			Msg("fee payer not initialized, signing is broken; retrying in background. To load one immediately: /api/v1/sign/initialize")
+		go retryFeePayerInit(retryCtx, pgxPool, FeePayerRetryInterval)
+	}
 
 	appConfig = AppConfig{
 		Postgres: pgxPool,
@@ -148,6 +160,18 @@ func setFeePayer(pk string) error {
 	return nil
 }
 
+// reloadFeePayer wraps InitFeePayerPK so a panic in a secret-store client ends
+// only this attempt. On the retry goroutine there is no fiber recover
+// middleware, so an unhandled panic would take the whole process down.
+func reloadFeePayer(ctx context.Context, pgxPool *pgxpool.Pool) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while loading fee payer: %v", r)
+		}
+	}()
+	return InitFeePayerPK(ctx, pgxPool)
+}
+
 // retryFeePayerInit reloads the key until one validates. Started only when the
 // initial load failed, so the process recovers from a transient secret-store
 // outage on its own instead of serving 500s until someone notices.
@@ -161,7 +185,7 @@ func retryFeePayerInit(ctx context.Context, pgxPool *pgxpool.Pool, interval time
 			log.Error().Err(ctx.Err()).Msg("fee payer retry stopped before a usable key was loaded")
 			return
 		case <-ticker.C:
-			if err := InitFeePayerPK(ctx, pgxPool); err != nil {
+			if err := reloadFeePayer(ctx, pgxPool); err != nil {
 				log.Error().Err(err).Dur("retry_in", interval).Msg("fee payer reload failed, retrying")
 				continue
 			}
@@ -351,7 +375,9 @@ func LoadFeePayerFromGSM(ctx context.Context) (string, error) {
 
 	result, err := client.AccessSecretVersion(ctx, accessRequest)
 	if err != nil {
-		panic(fmt.Errorf("failed to access secret version: %v", err))
+		// returned rather than panicked: this runs on the retry goroutine, where
+		// a panic is unrecoverable and would kill the process every 60s
+		return "", fmt.Errorf("failed to access secret version: %w", err)
 	}
 
 	if string(result.Payload.Data) == "" {


### PR DESCRIPTION
# Description

Follow-up to #2522, addressing both findings from the CodeRabbit review on that PR, plus three issues found in self-review of this branch.

## The panic that actually mattered

`secrets.go` asserted the Vault payload without checking:

```go
FeePayer: secrets.Data["FEE_PAYER"].(string),   // panics if FEE_PAYER is absent
```

This is on the **Vault path, which is the only path either cluster uses**, and it panics exactly when Vault returns a secret without that field — the shape of the 2026-07-29 incident. Before #2522 it was survivable (startup crash, or caught by fiber's recover middleware in the handler). #2522 added a retry loop that calls it from a bare goroutine, where a panic is unrecoverable and would kill the process every 60s.

Now a comma-ok with a descriptive error naming the secret path.

An earlier revision of this PR fixed only the equivalent panic in `LoadFeePayerFromGSM` and claimed the issue was "not reachable in production". That was wrong — GSM is dead code here, Vault is not.

## Retry goroutine could not be cancelled

Started with `context.Background()`, so nothing could stop it. `Setup()` is called by `setup()` in `globals_test.go:167`, with **27 call sites** across the delegator tests — every failing load leaks another uncancellable loop, all racing to write the same package var.

Extracted into `startFeePayerRetry`, which registers cancellation on `app.Hooks().OnShutdown` and returns the context so the wiring is directly testable.

## GSM panic

`LoadFeePayerFromGSM` signalled failure by panicking; it returns the error now (`%w`, so `errors.Is`/`As` work). Dead code on the current deployments, but the same hazard as above.

## Incidental

- `reloadFeePayer` wraps the load in `recover()` as defence in depth.
- The fiber recover middleware is imported as `fiberrecover`: the package name `recover` shadows the builtin, so the file would not otherwise compile.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

### Testing

- `go build ./...` clean; `go vet ./pkg/delegator/...` clean.
- `pkg/delegator/utils`: **8 tests pass**, and pass under `-race -count=2`.
- **`pkg/delegator/tests` integration suite run locally against a real Postgres** (container + `migrations/delegator` applied via `migrate`, env matching `delegator.test.yaml`): **ok, 0 failures**.

Two tests in the first revision of this PR were rewritten because they did not test what they claimed:

- `TestReloadFeePayerRecoversPanic` configured *no* secret source, so `InitFeePayerPK` returned an ordinary error and no panic ever occurred — the `recover()` had zero coverage behind a test named for it. The loaders are now indirected through package vars so a test can inject a panicking loader, and the test asserts both that the panic becomes an error and that the panic value is preserved.
- The `OnShutdown` wiring had no test at all; the existing one drove `retryFeePayerInit` directly with its own context. `TestFeePayerRetryStopsOnAppShutdown` now asserts `app.Shutdown()` cancels the retry context.

Added `TestReloadFeePayerPassesThroughError` so an ordinary error is not dressed up as a panic.

### Not covered

- The GSM path needs live Google Secret Manager credentials.
- `main.go` never calls `app.Shutdown()`, so in production the hook does not fire. Harmless — process exit reaps the goroutine — which makes the cancellation fix primarily test hygiene.

### Known pre-existing wart

`InitFeePayerPK` takes a `pgxPool` it never uses; the tests pass `nil`. If that parameter is ever used, those tests will nil-panic. Left alone as out of scope — worth a separate cleanup.

## Deployment

- [ ] Should publish npm package
- [x] Should publish Docker image

Not urgent. Both clusters are running #2522 healthily; this hardens the failure path rather than fixing a live fault.
